### PR TITLE
Rename the migration check from ruff to check-migrations

### DIFF
--- a/.github/workflows/migrations.yaml
+++ b/.github/workflows/migrations.yaml
@@ -20,7 +20,7 @@ env:
   PYTHONUNBUFFERED: "1"
 
 jobs:
-  ruff:
+  check-migrations:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
After this is merged, we should add check-migrations to the branch protection rules under "require status checks": https://github.com/agency-fund/evidential-be/settings/rules/6630679
