### PR TITLE
remove strict check on stddev to exist for numeric metrics. 

### DIFF
--- a/src/xngin/apiserver/routers/common_api_types.py
+++ b/src/xngin/apiserver/routers/common_api_types.py
@@ -250,14 +250,8 @@ class DesignSpecMetric(DesignSpecMetricBase):
     ] = None
 
     @model_validator(mode="after")
-    def stddev_only_if_numeric(self):
-        """Enforce that metric_stddev is present for NUMERICs"""
-        if (
-            self.metric_type == MetricType.NUMERIC
-            and self.available_n
-            and self.metric_stddev is None
-        ):
-            raise ValueError("missing stddev")
+    def stddev_check(self):
+        """Enforce that metric_stddev is empty for non-NUMERICs. FE will handle numerics without stddev (due to all nulls)"""
         if (
             self.metric_type is not MetricType.NUMERIC
             and self.metric_stddev is not None


### PR DESCRIPTION
The FE will let users bypass with a friendlier warning, re:

[MetricPowerAnalysisMessageType.NO_BASELINE](https://github.com/agency-fund/evidential-be/blob/b97533e09dca09075fff77f61d7038b086f63bfa/src/xngin/stats/power.py#L68)
[MetricPowerAnalysisMessageType.ZERO_STDDEV](https://github.com/agency-fund/evidential-be/blob/b97533e09dca09075fff77f61d7038b086f63bfa/src/xngin/stats/power.py#L80)
