### PR TITLE
Invoke mypy directly as shell command during precommit.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,12 +46,15 @@ repos:
   #       exclude: '^(.*/)?test_.*\.py$'
   #       entry: interrogate
   #       args: [-v, --fail-under=95, --ignore-module]
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.16.1
+  - repo: local
     hooks:
-      - id: mypy
-        entry: uv run mypy
-        pass_filenames: false
+      - id: uv-run-mypy
+        'types_or': [ python, pyi ]
         args:
-          - src
           - --config-file=pyproject.toml
+          - src
+        entry: uv run mypy
+        language: system
+        name: mypy
+        pass_filenames: false
+        require_serial: true


### PR DESCRIPTION
This might speed up mypy invocations because it will avoid pre-commit initializing a second Python environment. It is also simpler to debug when there are virtualenv issues.