### PR TITLE
fix assignment bug when the participant_id column uses big integers

### DIFF
--- a/src/xngin/apiserver/routers/assignment_adapters.py
+++ b/src/xngin/apiserver/routers/assignment_adapters.py
@@ -130,7 +130,7 @@ def _make_assign_response(
     stratum_ids = [0] * len(treatment_ids) if stratum_ids is None else stratum_ids
 
     for stratum_id, treatment_assignment, row in zip(
-        stratum_ids, treatment_ids, data, strict=False
+        stratum_ids, treatment_ids, data, strict=True
     ):
         strata = None
         row_dict = row._asdict()

--- a/src/xngin/apiserver/routers/test_assignment_adapters.py
+++ b/src/xngin/apiserver/routers/test_assignment_adapters.py
@@ -211,7 +211,7 @@ def test_assign_adapter_multiple_arms(sample_table, sample_rows):
 MAX_SAFE_INTEGER = (1 << 53) - 1  # 9007199254740991
 
 
-def test_assign_adapter_with_large_integers_as_participant_ids(
+def test_assign_adapter_with_large_decimals_as_participant_ids(
     sample_table, sample_data
 ):
     """Test assignment with large integer participant IDs (underlying type is Decimal)."""
@@ -244,12 +244,41 @@ def test_assign_adapter_with_large_integers_as_participant_ids(
     # Ensure the id string is rendered properly. (index=891 since participant ids are ordered lexicogrpahically)
     json_str = result.model_dump_json()
     assert '"participant_id":"9007199254740993"' in json_str
+    ids = {a.participant_id for a in result.assignments}
+    assert ids == set(sample_data["id"].astype(str))
 
     # We should be able to support very big negatives as well
     sample_data.loc[0, "id"] = Decimal(-MAX_SAFE_INTEGER - 2)
     result = assign(sample_data)
     json = result.model_dump()
     assert json["assignments"][0]["participant_id"] == "-9007199254740993"
+    ids = {a.participant_id for a in result.assignments}
+    assert ids == set(sample_data["id"].astype(str))
+
+
+def test_assign_adapter_with_bigints_as_participant_ids(sample_table, sample_data):
+    """Test assignment with large integer participant IDs (underlying type is BigInt)."""
+    sample_data["id"] = sample_data["id"].astype("int64")
+    # if cast to float64 would round to 9007199254740992
+    sample_data.loc[1, "id"] = MAX_SAFE_INTEGER + 2
+    # If we didn't catch stochatreat's upcast of int64 to float64, this next value would be rounded
+    # to nonexistent 103241243500726320 and raise a ValueError in our response construction.
+    sample_data.loc[2, "id"] = 103241243500726324
+    rows = [Row(**row) for row in sample_data.to_dict("records")]
+    result = assign_treatment(
+        sa_table=sample_table,
+        data=rows,
+        stratum_cols=["gender", "region"],
+        id_col="id",
+        arms=make_arms(["control", "treatment"]),
+        experiment_id="b767716b-f388-4cd9-a18a-08c4916ce26f",
+        random_state=42,
+    )
+    # These raise StopIteration if they don't exist
+    next(a for a in result.assignments if a.participant_id == "9007199254740993")
+    next(a for a in result.assignments if a.participant_id == "103241243500726324")
+    ids = {a.participant_id for a in result.assignments}
+    assert ids == set(sample_data["id"].astype(str))
 
 
 def test_assign_adapter_renders_decimal_and_bool_strata_correctly(

--- a/src/xngin/stats/assignment.py
+++ b/src/xngin/stats/assignment.py
@@ -10,6 +10,7 @@ from xngin.stats.balance import (
     preprocess_for_balance_and_stratification,
     restore_original_numeric_columns,
 )
+from xngin.stats.stats_errors import StatsError
 
 STOCHATREAT_STRATUM_ID_NAME = "stratum_id"
 STOCHATREAT_TREAT_NAME = "treat"
@@ -72,6 +73,9 @@ def assign_treatment_and_check_balance(
     # didn't originally recognize when creating the dataframe. This might have arisen from nullable
     # numeric columns in the underlying database being converted to object types.
     orig_data_to_stratify = df[[id_col, *orig_stratum_cols]].infer_objects()
+    # Protect against inadvertent precision loss from stochatreat silently upcasting your index.
+    orig_data_to_stratify[id_col] = orig_data_to_stratify[id_col].astype("object")
+
     df_cleaned, exclude_cols_set, numeric_notnull_set = (
         preprocess_for_balance_and_stratification(
             data=orig_data_to_stratify,
@@ -105,9 +109,15 @@ def assign_treatment_and_check_balance(
         # internally uses legacy np.random.RandomState which can take None
         random_state=random_state,  # type: ignore[arg-type]
     )
+
     df_cleaned = df_cleaned.merge(treatment_status, on=id_col)
     stratum_ids = df_cleaned[STOCHATREAT_STRATUM_ID_NAME]
     treatment_ids = df_cleaned[STOCHATREAT_TREAT_NAME]
+
+    if len(df) != len(treatment_ids):
+        raise StatsError(
+            f"Expected {len(df)} assignments but only have {len(df_cleaned)}"
+        )
 
     # Put back non-null numeric columns for a more robust balance check.
     df_cleaned.drop(columns=[STOCHATREAT_STRATUM_ID_NAME], inplace=True)

--- a/src/xngin/stats/assignment.py
+++ b/src/xngin/stats/assignment.py
@@ -114,9 +114,10 @@ def assign_treatment_and_check_balance(
     stratum_ids = df_cleaned[STOCHATREAT_STRATUM_ID_NAME]
     treatment_ids = df_cleaned[STOCHATREAT_TREAT_NAME]
 
-    if len(df) != len(treatment_ids):
+    if len(df) != len(df_cleaned):
         raise StatsError(
-            f"Expected {len(df)} assignments but only have {len(df_cleaned)}"
+            f"Expected {len(df)} assignments but only have {len(df_cleaned)}. "
+            f"Check if your {id_col} values could be causing problems."
         )
 
     # Put back non-null numeric columns for a more robust balance check.

--- a/src/xngin/stats/test_assignment.py
+++ b/src/xngin/stats/test_assignment.py
@@ -287,3 +287,22 @@ def test_simple_random_assignment_with_different_seeds(sample_df):
     assert len(assignments1) == len(assignments3)
     assert assignments1.count(0) == assignments3.count(0)
     assert assignments1.count(1) == assignments3.count(1)
+
+
+def test_assign_treatment_with_large_integers_as_participant_ids(sample_df):
+    """Test assignment with large integer participant IDs (underlying type is int64)."""
+    sample_df["id"] = sample_df["id"].astype("int64")
+    max_safe_int = (1 << 53) - 1
+    # This value is 9007199254740993 but if cast to float64 would round to 9007199254740992
+    sample_df.loc[1, "id"] = max_safe_int + 2
+    # Next value would get rounded to 103241243500726320 if a float64
+    sample_df.loc[2, "id"] = 103241243500726324
+    result = assign_treatment_and_check_balance(
+        df=sample_df,
+        stratum_cols=["gender", "region"],
+        id_col="id",
+        n_arms=2,
+        random_state=42,
+    )
+
+    assert len(result.treatment_ids) == len(sample_df)


### PR DESCRIPTION
## Description

Stochatreat’s internals adds fake rows of data as a step, which introduces nulls to the unique id column. If it is of certain dtypes, pandas will upcast it to a float, losing precision and cause us to mismatch/drop treatment assignments.

Fix is a workaround that pre-casts the column type to object directly, avoiding the loss of precision.

## How has this been tested?

Unittests added to first verify failures before fix, then passing after.

## Checklist

Fill with `x` for completed.

- [* ] I have updated the automated tests
