### PR TITLE
Invalidate inspection caches any time update_datasource is called.

### DIFF
--- a/src/xngin/apiserver/routers/admin/admin_api.py
+++ b/src/xngin/apiserver/routers/admin/admin_api.py
@@ -785,18 +785,18 @@ async def update_datasource(
         raise_unless_safe_hostname(body.dsn)
         cfg = ds.get_config()
         cfg.dwh = api_dsn_to_settings_dwh(body.dsn, cfg.dwh)
-
-        # Invalidate cached inspections.
         ds.set_config(cfg)
-        ds.clear_table_list()
-        invalidate_inspect_tables = delete(tables.DatasourceTablesInspected).where(
-            tables.DatasourceTablesInspected.datasource_id == datasource_id
-        )
-        invalidate_inspect_ptype = delete(tables.ParticipantTypesInspected).where(
-            tables.ParticipantTypesInspected.datasource_id == datasource_id
-        )
-        await session.execute(invalidate_inspect_tables)
-        await session.execute(invalidate_inspect_ptype)
+
+    ds.clear_table_list()
+    invalidate_inspect_tables = delete(tables.DatasourceTablesInspected).where(
+        tables.DatasourceTablesInspected.datasource_id == datasource_id
+    )
+    invalidate_inspect_ptype = delete(tables.ParticipantTypesInspected).where(
+        tables.ParticipantTypesInspected.datasource_id == datasource_id
+    )
+    await session.execute(invalidate_inspect_tables)
+    await session.execute(invalidate_inspect_ptype)
+
     await session.commit()
     return GENERIC_SUCCESS
 
@@ -1088,8 +1088,6 @@ async def update_participant_type(
     config = ds.get_config()
     participant = config.find_participants(participant_id)
     config.participants.remove(participant)
-    if not isinstance(participant, ParticipantsDef):
-        return Response(status_code=405, content="Only schema participants can be updated")
     if body.participant_type is not None:
         participant.participant_type = body.participant_type
     if body.table_name is not None:


### PR DESCRIPTION
We now invalidate the cached inspections any time the user updates a
datasource via the `update_datasource` API call.

