### PR TITLE
Only select necessary columns from the DWH with preassigned experiments (plus some cleanup)

### DIFF
--- a/src/xngin/apiserver/dwh/queries.py
+++ b/src/xngin/apiserver/dwh/queries.py
@@ -5,7 +5,6 @@ from datetime import datetime, timedelta
 import sqlalchemy
 from sqlalchemy import (
     ColumnElement,
-    ColumnOperators,
     DateTime,
     Float,
     Integer,
@@ -232,7 +231,7 @@ def create_query_filters(sa_table: sqlalchemy.Table, filters: list[Filter]):
     return [create_one_filter(filter_, sa_table) for filter_ in filters]
 
 
-def create_special_experiment_id_filter(col: sqlalchemy.Column, filter_: Filter) -> ColumnOperators:
+def create_special_experiment_id_filter(col: sqlalchemy.Column, filter_: Filter) -> ColumnElement:
     matching_regex = make_csv_regex(filter_.value)
     match filter_.relation:
         case Relation.INCLUDES:
@@ -276,7 +275,7 @@ def general_excludes_filter(
     )
 
 
-def create_datetime_filter(col: sqlalchemy.Column, filter_: Filter) -> ColumnOperators:
+def create_datetime_filter(col: sqlalchemy.Column, filter_: Filter) -> ColumnElement:
     """Converts a single Filter for a DateTime-typed column into a sqlalchemy filter."""
 
     def str_to_datetime(s: int | float | str | datetime | None) -> datetime | None:
@@ -333,7 +332,7 @@ def create_datetime_filter(col: sqlalchemy.Column, filter_: Filter) -> ColumnOpe
             raise RuntimeError("Bug: invalid filter.")
 
 
-def create_filter(col: sqlalchemy.Column, filter_: Filter) -> ColumnOperators:
+def create_filter(col: sqlalchemy.Column, filter_: Filter) -> ColumnElement:
     """Converts a single Filter to a sqlalchemy filter."""
     match filter_.relation:
         case Relation.BETWEEN:
@@ -358,5 +357,11 @@ def create_filter(col: sqlalchemy.Column, filter_: Filter) -> ColumnOperators:
             raise RuntimeError("Bug: invalid Filter.")
 
 
-def compose_query(sa_table: Table, chosen_n: int, filters):
-    return select(sa_table).filter(*filters).order_by(custom_functions.Random(sa_table=sa_table)).limit(chosen_n)
+def compose_query(sa_table: Table, select_columns: set[str], filters: list[ColumnElement], chosen_n: int):
+    columns = []
+    for col in sorted(select_columns):  # sort for stable generated sql
+        if col not in sa_table.c:
+            raise ValueError(f"Column {col} not found in schema.")
+        columns.append(sa_table.c[col])
+    columns = columns or sa_table.c.values()
+    return select(*columns).filter(*filters).order_by(custom_functions.Random(sa_table=sa_table)).limit(chosen_n)

--- a/src/xngin/apiserver/dwh/test_dialect_sql.py
+++ b/src/xngin/apiserver/dwh/test_dialect_sql.py
@@ -96,8 +96,8 @@ def test_datetimes(testcase: DateTimeTestCase):
     sa_table = Datetimes.get_table()
     q = compose_query(
         sa_table,
-        2,
-        create_query_filters(
+        select_columns=set(),
+        filters=create_query_filters(
             sa_table,
             [
                 Filter(
@@ -112,6 +112,7 @@ def test_datetimes(testcase: DateTimeTestCase):
                 ),
             ],
         ),
+        chosen_n=2,
     )
     ddl = str(CreateTable(sa_table).compile(dialect=testcase.dialect))
     normalized_ddl = re.sub(r"\s+", " ", ddl.replace("\n", "").strip())
@@ -592,7 +593,7 @@ def test_where(testcase: WhereTestCase):
 
     sa_table = WhereTable.get_table()
     filters = create_query_filters(sa_table, testcase.filters)
-    q = compose_query(sa_table, 3, filters)
+    q = compose_query(sa_table, select_columns=set(), filters=filters, chosen_n=3)
 
     failures = {}
     for dbtype in testcase.where:

--- a/src/xngin/apiserver/dwh/test_queries.py
+++ b/src/xngin/apiserver/dwh/test_queries.py
@@ -227,32 +227,53 @@ def fixture_queries_session():
         engine.dispose()
 
 
-def test_compile_query_without_filters_pg():
+def test_compile_query_with_missing_select_column():
+    with pytest.raises(ValueError, match=r"Column missing_column not found in schema."):
+        compose_query(SampleTable.get_table(), {"missing_column"}, [], 2)
+
+
+SELECT_COLUMNS_CASES_PG = [
+    pytest.param(
+        set(),
+        "test_table.id, test_table.int_col, test_table.float_col, test_table.bool_col, test_table.string_col, "
+        "test_table.experiment_ids",
+        id="all",
+    ),
+    pytest.param({"id", "int_col"}, "test_table.id, test_table.int_col", id="id_and_int_col"),
+]
+
+
+@pytest.mark.parametrize("select_columns, expected_columns", SELECT_COLUMNS_CASES_PG)
+def test_compile_query_without_filters_pg(select_columns, expected_columns):
     # SQLAlchemy shares a base class for both psycopg2's and psycopg's dialect so they are very similar.
     dialects = (
         sqlalchemy.dialects.postgresql.psycopg2.dialect(),
         sqlalchemy.dialects.postgresql.psycopg.dialect(),
     )
     for dialect in dialects:
-        query = compose_query(SampleTable.get_table(), 2, [])
+        query = compose_query(SampleTable.get_table(), select_columns, [], 2)
         actual = str(query.compile(dialect=dialect, compile_kwargs={"literal_binds": True})).replace("\n", "")
-        expectation = (
-            "SELECT test_table.id, test_table.int_col, test_table.float_col,"
-            " test_table.bool_col, test_table.string_col, test_table.experiment_ids "
-            "FROM test_table ORDER BY random()  LIMIT 2"
-        )  # two spaces!
+        expectation = f"SELECT {expected_columns} FROM test_table ORDER BY random()  LIMIT 2"  # two spaces!
         assert actual == expectation
 
 
-def test_compile_query_without_filters_bq():
-    query = compose_query(SampleTable.get_table(), 2, [])
+SELECT_COLUMNS_CASES_BQ = [
+    pytest.param(
+        set(),
+        "`test_table`.`id`, `test_table`.`int_col`, `test_table`.`float_col`, `test_table`.`bool_col`, "
+        "`test_table`.`string_col`, `test_table`.`experiment_ids`",
+        id="all",
+    ),
+    pytest.param({"id", "int_col"}, "`test_table`.`id`, `test_table`.`int_col`", id="id_and_int_col"),
+]
+
+
+@pytest.mark.parametrize("select_columns, expected_columns", SELECT_COLUMNS_CASES_BQ)
+def test_compile_query_without_filters_bq(select_columns, expected_columns):
+    query = compose_query(SampleTable.get_table(), select_columns, [], 2)
     dialect = sqlalchemy_bigquery.dialect()
     actual = str(query.compile(dialect=dialect, compile_kwargs={"literal_binds": True})).replace("\n", "")
-    expectation = (
-        "SELECT `test_table`.`id`, `test_table`.`int_col`, `test_table`.`float_col`, "
-        "`test_table`.`bool_col`, `test_table`.`string_col`, `test_table`.`experiment_ids` "
-        "FROM `test_table` ORDER BY rand() LIMIT 2"
-    )
+    expectation = f"SELECT {expected_columns} FROM `test_table` ORDER BY rand() LIMIT 2"
     assert actual == expectation, actual
 
 
@@ -402,7 +423,7 @@ def test_is_nullable(testcase, queries_session, use_deterministic_random):
     testcase.filters = [Filter.model_validate(filt.model_dump()) for filt in testcase.filters]
     table = SampleNullableTable.get_table()
     filters = create_query_filters(table, testcase.filters)
-    q = compose_query(table, testcase.chosen_n, filters)
+    q = compose_query(table, set(), filters, testcase.chosen_n)
     query_results = queries_session.execute(q)
     assert list(sorted([r.id for r in query_results])) == list(sorted(r.id for r in testcase.matches)), testcase
 
@@ -536,7 +557,7 @@ RELATION_CASES = [
 def test_relations(testcase, queries_session, use_deterministic_random):
     testcase.filters = [Filter.model_validate(filt.model_dump()) for filt in testcase.filters]
     filters = create_query_filters(SampleTable.get_table(), testcase.filters)
-    q = compose_query(SampleTable.get_table(), testcase.chosen_n, filters)
+    q = compose_query(SampleTable.get_table(), set(), filters, testcase.chosen_n)
     query_results = queries_session.execute(q)
     assert list(sorted([r.id for r in query_results])) == list(sorted(r.id for r in testcase.matches)), testcase
 

--- a/src/xngin/apiserver/routers/admin/admin_api.py
+++ b/src/xngin/apiserver/routers/admin/admin_api.py
@@ -1258,7 +1258,7 @@ async def create_experiment(
         session=session, organization_id=organization_id, request_webhooks=body.webhooks
     )
 
-    return await experiments_common.create_dwh_experiment_impl(
+    return await experiments_common.create_experiment_impl(
         request=body,
         datasource=datasource,
         xngin_session=session,

--- a/src/xngin/apiserver/routers/assignment_adapters.py
+++ b/src/xngin/apiserver/routers/assignment_adapters.py
@@ -80,7 +80,7 @@ def assign_treatment(
 
     # Extract Decimal column names from SQLAlchemy table and convert to float.
     # (Decimals are possible if the Table was created with SA's autoload instead of cursor).
-    if decimals := [c.name for c in sa_table.columns if c.type.python_type is decimal.Decimal]:
+    if decimals := [c.name for c in sa_table.columns if c.type.python_type is decimal.Decimal and c.name in df]:
         df[decimals] = df[decimals].astype(float)
 
     # Call the core assignment function

--- a/src/xngin/apiserver/routers/experiments/experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_api.py
@@ -12,7 +12,6 @@ from fastapi import (
     Depends,
     FastAPI,
     Query,
-    status,
 )
 from fastapi.responses import StreamingResponse
 from loguru import logger
@@ -38,8 +37,6 @@ from xngin.apiserver.routers.common_api_types import (
 )
 from xngin.apiserver.routers.experiments.dependencies import experiment_dependency
 from xngin.apiserver.routers.experiments.experiments_common import (
-    abandon_experiment_impl,
-    commit_experiment_impl,
     create_assignment_for_participant,
     get_assign_summary,
     get_existing_assignment_for_participant,
@@ -65,32 +62,6 @@ router = APIRouter(
     lifespan=lifespan,
     prefix=constants.API_PREFIX_V1,
 )
-
-
-@router.post(
-    "/experiments/{experiment_id}/commit",
-    summary="Marks any ASSIGNED experiment as COMMITTED.",
-    status_code=status.HTTP_204_NO_CONTENT,
-    include_in_schema=False,
-)
-async def commit_experiment_sl(
-    experiment: Annotated[tables.Experiment, Depends(experiment_dependency)],
-    xngin_session: Annotated[AsyncSession, Depends(xngin_db_session)],
-):
-    return await commit_experiment_impl(xngin_session, experiment)
-
-
-@router.post(
-    "/experiments/{experiment_id}/abandon",
-    summary="Marks any DESIGNING or ASSIGNED experiment as ABANDONED.",
-    status_code=status.HTTP_204_NO_CONTENT,
-    include_in_schema=False,
-)
-async def abandon_experiment_sl(
-    experiment: Annotated[tables.Experiment, Depends(experiment_dependency)],
-    xngin_session: Annotated[AsyncSession, Depends(xngin_db_session)],
-):
-    return await abandon_experiment_impl(xngin_session, experiment)
 
 
 @router.get(

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -68,7 +68,7 @@ def random_choice[T](choices: Sequence[T], seed: int | None = None) -> T:
     return secrets.choice(choices)
 
 
-async def create_dwh_experiment_impl(
+async def create_experiment_impl(
     request: CreateExperimentRequest,
     datasource: tables.Datasource,
     xngin_session: AsyncSession,

--- a/src/xngin/apiserver/routers/experiments/test_experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_common.py
@@ -32,7 +32,7 @@ from xngin.apiserver.routers.experiments.experiments_common import (
     abandon_experiment_impl,
     commit_experiment_impl,
     create_assignment_for_participant,
-    create_dwh_experiment_impl,
+    create_experiment_impl,
     create_preassigned_experiment_impl,
     experiment_assignments_to_csv_generator,
     get_assign_summary,
@@ -350,7 +350,7 @@ async def test_create_experiment_impl_for_online(
     """Test implementation of creating an online experiment."""
     request = make_create_online_experiment_request()
 
-    response = await create_dwh_experiment_impl(
+    response = await create_experiment_impl(
         request=request.model_copy(deep=True),
         datasource=testing_datasource.ds,
         random_state=42,
@@ -433,7 +433,7 @@ async def test_create_experiment_impl_overwrites_uuids(
     original_experiment_id = request.design_spec.experiment_id
     original_arm_ids = [arm.arm_id for arm in request.design_spec.arms]
 
-    response = await create_dwh_experiment_impl(
+    response = await create_experiment_impl(
         request=request,
         datasource=testing_datasource.ds,
         random_state=42,
@@ -474,7 +474,7 @@ async def test_create_experiment_impl_no_metric_stratification(
     request = make_create_preassigned_experiment_request()
 
     # Test with stratify_on_metrics=False
-    response = await create_dwh_experiment_impl(
+    response = await create_experiment_impl(
         request=request.model_copy(deep=True),
         datasource=testing_datasource.ds,
         random_state=42,


### PR DESCRIPTION
## Description

Reduce unnecessary load and data transfer from a client's data warehouse.

Also removes deprecated (and long-hidden in openapi spec) integrator endpoints, whose original functionality should only be performed through the UI:
    /experiments/with-assignment
    /experiments/{experiment_id}/commit
    /experiments/{experiment_id}/abandon
    
## How has this been tested?

- [x ] I have updated the automated tests