### PR TITLE
fix bandit update outcome pathspec

### DIFF
--- a/src/xngin/apiserver/routers/common_api_types.py
+++ b/src/xngin/apiserver/routers/common_api_types.py
@@ -1186,7 +1186,6 @@ type GetFiltersResponseElement = GetFiltersResponseNumericOrDate | GetFiltersRes
 class UpdateBanditArmOutcomeRequest(ApiBaseModel):
     """Describes the outcome of a bandit experiment."""
 
-    participant_id: str
     outcome: float
 
 

--- a/src/xngin/apiserver/routers/experiments/experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_api.py
@@ -258,6 +258,7 @@ async def get_cmab_experiment_assignment_for_participant(
     Used only for bandit experiments.""",
 )
 async def update_bandit_arm_with_participant_outcome(
+    participant_id: str,
     body: Annotated[UpdateBanditArmOutcomeRequest, Body()],
     experiment: Annotated[tables.Experiment, Depends(experiment_dependency)],
     session: Annotated[AsyncSession, Depends(xngin_db_session)],
@@ -269,7 +270,7 @@ async def update_bandit_arm_with_participant_outcome(
     updated_arm = await update_bandit_arm_with_outcome_impl(
         xngin_session=session,
         experiment=experiment,
-        participant_id=body.participant_id,
+        participant_id=participant_id,
         outcome=body.outcome,
     )
 


### PR DESCRIPTION
## Ticket

[Issue 132](https://github.com/agency-fund/evidential-sprint/issues/132)


## Description
Fix bandit update outcome endpoint so it uses the participant ID from the pathspec
