### PR TITLE
Fix balance check's categorical coding

### DIFF
--- a/src/xngin/stats/assignment.py
+++ b/src/xngin/stats/assignment.py
@@ -37,7 +37,8 @@ def assign_treatment_and_check_balance(
     """
     Perform stratified random assignment and do a balance check of the arm assignments.
 
-    Note: Python Decimal types must be converted to float before calling this function.
+    Note: Python Decimal types must be converted to float before calling this function, else will be
+    treated as a Categorical variable.
 
     Args:
         df: pandas DataFrame containing the data (Decimal types should be converted to float)

--- a/src/xngin/stats/balance.py
+++ b/src/xngin/stats/balance.py
@@ -139,16 +139,9 @@ def check_balance_of_preprocessed_df(
     # Convert all non-numeric columns into dummy vars, including booleans
     non_numeric_columns = {c for c in data.columns if not is_any_real_numeric_dtype(data[c])}
     cols_to_dummies = list(non_numeric_columns - exclude_col_set)
-    df_analysis = pd.get_dummies(
-        data,
-        columns=cols_to_dummies,
-        prefix=cols_to_dummies,
-        dummy_na=False,
-        drop_first=True,
-    )
 
     # Create formula excluding specified columns
-    covariates = [col for col in df_analysis.columns if col != treatment_col and col not in exclude_col_set]
+    covariates = [col for col in data.columns if col != treatment_col and col not in exclude_col_set]
     if len(covariates) == 0:
         raise StatsBalanceError(
             "No usable fields for performing a balance check found. Please check your metrics "
@@ -157,9 +150,10 @@ def check_balance_of_preprocessed_df(
 
     # TODO(roboton): Run multi-class regression via MVLogit
     # df_analysis[treatment_col] = pd.Categorical(df_analysis[treatment_col])
-    # only check the first two treatment groups
-    df_analysis = df_analysis[df_analysis[treatment_col].isin([0, 1])]
-
+    # Only check the first two treatment groups
+    df_analysis = data[data[treatment_col].isin([0, 1])]
+    # Use Patsy's C() to handle categoricals: https://patsy.readthedocs.io/en/latest/categorical-coding.html
+    covariates = [f"C({col})" if col in cols_to_dummies else col for col in covariates]
     formula = f"{treatment_col} ~ " + " + ".join(covariates)
     # print(f"------FORMULA:\n\t{formula}")
 

--- a/src/xngin/stats/balance.py
+++ b/src/xngin/stats/balance.py
@@ -141,16 +141,14 @@ def check_balance_of_preprocessed_df(
     cols_to_dummies = list(non_numeric_columns - exclude_col_set)
 
     # Create formula excluding specified columns
-    covariates = [col for col in data.columns if col != treatment_col and col not in exclude_col_set]
+    covariates = [col for col in data.columns if col not in {*exclude_col_set, treatment_col}]
     if len(covariates) == 0:
         raise StatsBalanceError(
             "No usable fields for performing a balance check found. Please check your metrics "
             "and fields used for stratification."
         )
 
-    # TODO(roboton): Run multi-class regression via MVLogit
-    # df_analysis[treatment_col] = pd.Categorical(df_analysis[treatment_col])
-    # Only check the first two treatment groups
+    # We only check the first two treatment groups right now.
     df_analysis = data[data[treatment_col].isin([0, 1])]
     # Use Patsy's C() to handle categoricals: https://patsy.readthedocs.io/en/latest/categorical-coding.html
     covariates = [f"C({col})" if col in cols_to_dummies else col for col in covariates]

--- a/src/xngin/stats/test_assignment.py
+++ b/src/xngin/stats/test_assignment.py
@@ -173,11 +173,11 @@ def test_assign_treatment_with_infer_objects():
     assert result.orig_stratum_cols == ["col1", "col2", "col3"]
 
 
-def test_assign_treatment_decimal_strata_columns_are_not_supported(sample_df):
-    """Test that unconverted Decimal strata columns raise an error."""
+def test_assign_treatment_decimal_strata_columns_does_not_raise_error(sample_df):
+    """Test that unconverted Decimal strata columns does NOT raise an error."""
     sample_df["decimal"] = sample_df["income"].apply(Decimal)
-    with pytest.raises(RecursionError):
-        assign_treatment_and_check_balance(df=sample_df, stratum_cols=["decimal"], id_col="id", n_arms=2)
+    # Ok since we treat it as a categorical (for better or worse).
+    assign_treatment_and_check_balance(df=sample_df, stratum_cols=["decimal"], id_col="id", n_arms=2)
 
 
 def test_assign_treatment_with_problematic_values():


### PR DESCRIPTION
## Description

Fixes our use of pd.dummies for generating indicator variables out of categoricals by using patsy's support for coding categorical data. Our old approach would naively embed strings into the dummy column name then join them together to make the final formula, which could break if the strings had improper characters.

## How has this been tested?

unittests

## To-do before merge (optional)

## Checklist

Fill with `x` for completed.

- [x] I have updated the automated tests
