### PR TITLE
Fail startup if OpenAPI spec would have duplicate method names.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -110,6 +110,9 @@ jobs:
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: xngin-cli export-openapi-spec
+        run: |
+          XNGIN_PUBLISH_ALL_DOCS=true uv run xngin-cli export-openapi-spec
       - name: xngin-cli config validators
         run: |
           set -x

--- a/src/xngin/apiserver/openapi.py
+++ b/src/xngin/apiserver/openapi.py
@@ -20,12 +20,16 @@ def custom_openapi(app: FastAPI):
         return app.openapi_schema
 
     # Overrides the operationId values in the OpenAPI spec to generate humane names
-    # based on the method name. This avoids generating long, ugly names downstream.
+    # based on the Python method name. This avoids downstream code generating ugly names downstream.
     # Note: ensure all API methods have names you'd like to appear in the generated APIs.
+    seen = set()
     for route in app.routes:
         if isinstance(route, APIRoute):
+            if route.name in seen:
+                raise RuntimeError(f"Duplicate route name: {route.name}")
             # uses the Python API method name
             route.operation_id = route.name
+            seen.add(route.name)
 
     visible_tags = [
         TagDocumentation(


### PR DESCRIPTION
Every API method exported by FastAPI to the OpenAPI spec has an "operationId"
value containing the name of the Python method that implements the handler.
Example:

```json5
    "/v1/m/organizations/{organization_id}/members": {
      "post": {
        "description": "Adds a new member to an organization.",
        "operationId": "add_member_to_organization",   # <--- Python method name
```

It is [an error](https://swagger.io/docs/specification/v3_0/paths-and-operations/#operationid)
if operationId is ever duplicated. FastAPI doesn't care, but OpenAPI client
code generators can use this value in the code they generate and duplicates can cause
problems.  This PR changes the schema generation behavior to fail if there are
duplicate names.

