### PR TITLE
Small refactorings: clean up some fixed random_state use; extract an experiments_common function

### DIFF
--- a/src/xngin/apiserver/routers/admin/admin_api.py
+++ b/src/xngin/apiserver/routers/admin/admin_api.py
@@ -1468,10 +1468,10 @@ async def analyze_cmab_experiment(
 
     context_inputs = body.context_inputs
     context_defns = experiment.contexts
-    context_inputs = sort_contexts_by_id_or_raise(context_defns, context_inputs)
+    sorted_context_inputs = sort_contexts_by_id_or_raise(context_defns, context_inputs)
 
     return experiments_common.analyze_experiment_bandit_impl(
-        experiment, contexts=[ci.context_value for ci in context_inputs]
+        experiment, context_vals=[ci.context_value for ci in sorted_context_inputs]
     )
 
 
@@ -1621,28 +1621,12 @@ async def get_experiment_assignment_for_participant(
     ds = await get_datasource_or_raise(session, user, datasource_id)
     experiment = await get_experiment_via_ds_or_raise(session, ds, experiment_id)
 
-    # Look up the participant's assignment if it exists
-    assignment = await experiments_common.get_existing_assignment_for_participant(
-        session, experiment.id, participant_id, experiment.experiment_type
-    )
-
-    if not assignment and create_if_none and experiment.stopped_assignments_at is None:
-        if experiment.experiment_type == ExperimentsType.CMAB_ONLINE.value:
-            raise LateValidationError(
-                f"New arm assignments for {ExperimentsType.CMAB_ONLINE.value} cannot be created at this endpoint, "
-                f"please use the corresponding POST endpoint instead."
-            )
-        assignment = await experiments_common.create_assignment_for_participant(
-            xngin_session=session,
-            experiment=experiment,
-            participant_id=participant_id,
-            random_state=random_state,
-        )
-
-    return GetParticipantAssignmentResponse(
-        experiment_id=experiment_id,
+    return await experiments_common.get_or_create_assignment_for_participant(
+        xngin_session=session,
+        experiment=experiment,
         participant_id=participant_id,
-        assignment=assignment,
+        create_if_none=create_if_none,
+        random_state=random_state,
     )
 
 

--- a/src/xngin/apiserver/routers/experiments/dependencies.py
+++ b/src/xngin/apiserver/routers/experiments/dependencies.py
@@ -75,6 +75,9 @@ class ExperimentDependency:
 # Default dependency for experiments that only need arms joined in.
 experiment_dependency = ExperimentDependency()
 
+# Use this version when you also want contexts for assignment responses.
+experiment_with_contexts_dependency = ExperimentDependency(preload=[tables.Experiment.contexts])
+
 # Use this version when a full GetExperimentResponse is needed.
 experiment_response_dependency = ExperimentDependency(preload=[tables.Experiment.webhooks, tables.Experiment.contexts])
 

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -40,6 +40,7 @@ from xngin.apiserver.routers.common_api_types import (
     FreqExperimentAnalysisResponse,
     GetExperimentAssignmentsResponse,
     GetExperimentResponse,
+    GetParticipantAssignmentResponse,
     ListExperimentsResponse,
     MetricAnalysis,
     Strata,
@@ -58,7 +59,8 @@ from xngin.apiserver.webhooks.webhook_types import ExperimentCreatedWebhookBody
 from xngin.events.experiment_created import ExperimentCreatedEvent
 from xngin.stats.analysis import analyze_experiment as analyze_freq_experiment
 from xngin.stats.bandit_analysis import analyze_experiment as analyze_bandit_experiment
-from xngin.stats.bandit_sampling import choose_arm, update_arm
+from xngin.stats.bandit_sampling import choose_arm as choose_bandit_arm
+from xngin.stats.bandit_sampling import update_arm as update_bandit_arm
 from xngin.stats.stats_errors import StatsAnalysisError
 from xngin.tq.task_payload_types import WEBHOOK_OUTBOUND_TASK_TYPE, WebhookOutboundTask
 
@@ -636,14 +638,56 @@ async def get_existing_assignment_for_participant(
     return None
 
 
+async def get_or_create_assignment_for_participant(
+    xngin_session: AsyncSession,
+    experiment: tables.Experiment,
+    participant_id: str,
+    create_if_none: bool,
+    random_state: int | None = None,
+) -> GetParticipantAssignmentResponse:
+    """Get or create the arm assignment for a specific participant in a non-CMAB experiment.
+
+    Set create_if_none=False to only get an assignment if it already exists; do not create a new one.
+    """
+
+    assignment = await get_existing_assignment_for_participant(
+        xngin_session=xngin_session,
+        experiment_id=experiment.id,
+        participant_id=participant_id,
+        experiment_type=experiment.experiment_type,
+    )
+
+    if not assignment and create_if_none and experiment.stopped_assignments_at is None:
+        if experiment.experiment_type == ExperimentsType.CMAB_ONLINE.value:
+            raise LateValidationError(
+                f"New arm assignments for {ExperimentsType.CMAB_ONLINE.value} cannot be created at this endpoint, "
+                f"please use the corresponding POST endpoint instead."
+            )
+
+        assignment = await create_assignment_for_participant(
+            xngin_session=xngin_session,
+            experiment=experiment,
+            participant_id=participant_id,
+            random_state=random_state,
+        )
+
+    return GetParticipantAssignmentResponse(
+        experiment_id=experiment.id,
+        participant_id=participant_id,
+        assignment=assignment,
+    )
+
+
 async def create_assignment_for_participant(
     xngin_session: AsyncSession,
     experiment: tables.Experiment,
     participant_id: str,
-    context_vals: list[float] | None = None,
+    sorted_context_vals: list[float] | None = None,
     random_state: int | None = None,
 ) -> Assignment | None:
     """Helper to persist a new assignment for a participant. Returned value excludes strata.
+
+    sorted_context_vals are assumed to be sorted by the experiment's corresponding context ids in ascending order.
 
     Has side effect of updating the experiment's stopped_at and stopped_reason if we discover we should stop assigning.
     """
@@ -667,13 +711,13 @@ async def create_assignment_for_participant(
         raise ValueError("Bayesian A/B experiments are not supported for assignments")
 
     if experiment_type == ExperimentsType.CMAB_ONLINE:
-        if not context_vals:
+        if not sorted_context_vals:
             raise ExperimentsAssignmentError(
                 "Context values are required for contextual multi-armed bandit experiments"
             )
-        if len(context_vals) != len(experiment.contexts):
+        if len(sorted_context_vals) != len(experiment.contexts):
             raise ExperimentsAssignmentError(
-                f"Expected {len(experiment.contexts)} context values, got {len(context_vals)}"
+                f"Expected {len(experiment.contexts)} context values, got {len(sorted_context_vals)}"
             )
 
     # Don't allow new assignments for experiments that have ended.
@@ -684,18 +728,20 @@ async def create_assignment_for_participant(
         return None
 
     if not random_state:
+        # TODO: Remove this once tests use a fixed value
         random_state = 66  # Default seed for deterministic behavior in tests.
     # For online frequentist or Bayesian A/B experiments, create a new assignment
     # with simple random assignment.
     match experiment_type:
         case ExperimentsType.FREQ_ONLINE | ExperimentsType.BAYESAB_ONLINE:
             # Sort by arm name to ensure deterministic assignment with seed for tests.
-            chosen_arm = random_choice(
-                sorted(experiment.arms, key=lambda a: a.name),
-                seed=random_state,
-            )
+            chosen_arm = random_choice(sorted(experiment.arms, key=lambda a: a.name), seed=random_state)
         case ExperimentsType.MAB_ONLINE | ExperimentsType.CMAB_ONLINE:
-            chosen_arm = choose_arm(experiment=experiment, context=context_vals, random_state=random_state)
+            chosen_arm = choose_bandit_arm(
+                experiment=experiment,
+                sorted_context_vals=sorted_context_vals,
+                random_state=random_state,
+            )
 
     chosen_arm_id = chosen_arm.id
 
@@ -726,7 +772,7 @@ async def create_assignment_for_participant(
                             participant_id=participant_id,
                             participant_type=experiment.participant_type,
                             arm_id=chosen_arm_id,
-                            context_vals=context_vals,
+                            context_vals=sorted_context_vals,
                         )
                         .returning(tables.Draw.created_at)
                     )
@@ -750,7 +796,7 @@ async def create_assignment_for_participant(
         arm_name=chosen_arm.name,
         created_at=created_at,
         strata=[],
-        context_values=context_vals,
+        context_values=sorted_context_vals,
     )
 
 
@@ -831,7 +877,7 @@ async def update_bandit_arm_with_outcome_impl(
         outcomes = outcomes[:100]
         context_vals = context_vals[:100] if context_vals else None
 
-        updated_parameters = update_arm(
+        updated_parameters = update_bandit_arm(
             experiment=experiment,
             arm_to_update=arm_to_update,
             outcomes=outcomes,
@@ -973,7 +1019,7 @@ async def analyze_experiment_freq_impl(
 
 def analyze_experiment_bandit_impl(
     experiment: tables.Experiment,
-    contexts: list[float] | None = None,
+    context_vals: list[float] | None = None,
 ) -> BanditExperimentAnalysisResponse:
     """Analyze a bandit experiment. Assumes arms and draws are preloaded."""
 
@@ -981,12 +1027,16 @@ def analyze_experiment_bandit_impl(
     outcomes = [draw.outcome for draw in draws if draw.outcome is not None]
 
     outcome_std_dev = np.std(outcomes).astype(float) if len(outcomes) > 1 else 0.0
-    arm_analyses = analyze_bandit_experiment(experiment=experiment, outcome_std_dev=outcome_std_dev, contexts=contexts)
+    arm_analyses = analyze_bandit_experiment(
+        experiment=experiment,
+        outcome_std_dev=outcome_std_dev,
+        contexts=context_vals,
+    )
 
     return BanditExperimentAnalysisResponse(
         experiment_id=experiment.id,
         arm_analyses=arm_analyses,
         n_outcomes=len(outcomes),
         created_at=datetime.now(UTC),
-        contexts=contexts,
+        contexts=context_vals,
     )

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -1027,7 +1027,7 @@ def analyze_experiment_bandit_impl(
     arm_analyses = analyze_bandit_experiment(
         experiment=experiment,
         outcome_std_dev=outcome_std_dev,
-        contexts=context_vals,
+        context_vals=context_vals,
     )
 
     return BanditExperimentAnalysisResponse(

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -727,9 +727,6 @@ async def create_assignment_for_participant(
         await xngin_session.commit()
         return None
 
-    if not random_state:
-        # TODO: Remove this once tests use a fixed value
-        random_state = 66  # Default seed for deterministic behavior in tests.
     # For online frequentist or Bayesian A/B experiments, create a new assignment
     # with simple random assignment.
     match experiment_type:

--- a/src/xngin/apiserver/snapshots/snapshotter.py
+++ b/src/xngin/apiserver/snapshots/snapshotter.py
@@ -172,7 +172,7 @@ async def _query_dwh_for_snapshot_data(
                     for m, context in zip(mean_context_val, sorted_context_defns, strict=False)
                 ]
 
-        return experiments_common.analyze_experiment_bandit_impl(experiment=experiment, contexts=context_vals)
+        return experiments_common.analyze_experiment_bandit_impl(experiment=experiment, context_vals=context_vals)
 
     if ExperimentsType(experiment.experiment_type).is_freq():
         # We always assume the first arm is the baseline.

--- a/src/xngin/apiserver/sqla/tables.py
+++ b/src/xngin/apiserver/sqla/tables.py
@@ -489,6 +489,7 @@ class Draw(Base):
     # after arm parameters are updated.
     observed_at: Mapped[datetime | None] = mapped_column()
     outcome: Mapped[float | None] = mapped_column()
+    # Context values are assumed to be sorted by the experiment's corresponding context ids in ascending order.
     context_vals: Mapped[list[float] | None] = mapped_column(ARRAY(Float))
     current_mu: Mapped[list[float] | None] = mapped_column(ARRAY(Float))
     current_covariance: Mapped[list[list[float]] | None] = mapped_column(ARRAY(Float))

--- a/src/xngin/stats/bandit_analysis.py
+++ b/src/xngin/stats/bandit_analysis.py
@@ -77,7 +77,7 @@ def _analyze_normal_binary(
 def analyze_experiment(
     experiment: tables.Experiment,
     outcome_std_dev: float = 1.0,
-    contexts: list | None = None,
+    context_vals: list | None = None,
     random_state: int | None = None,
 ) -> list[BanditArmAnalysis]:
     """
@@ -86,7 +86,7 @@ def analyze_experiment(
     Args:
         experiment: The bandit experiment to analyze.
         outcome_std_dev: Standard deviation of the outcomes. Only used for Normal likelihood.
-        contexts: Optional context values for CMAB experiments.
+        context_vals: Optional context values for CMAB experiments.
         random_state: Use a fixed int for deterministic behavior in tests.
     """
     # TODO: Does not support Bayes A/B experiments
@@ -94,7 +94,7 @@ def analyze_experiment(
         raise ValueError(f"Invalid experiment type: {experiment.experiment_type}.")
     if not experiment.prior_type or not experiment.reward_type:
         raise ValueError("Experiment must have prior and reward types defined.")
-    if (experiment.experiment_type == ExperimentsType.CMAB_ONLINE.value) and (contexts is None):
+    if (experiment.experiment_type == ExperimentsType.CMAB_ONLINE.value) and (context_vals is None):
         raise ValueError("Contexts must be provided for CMAB experiment analysis.")
 
     likelihood_type = LikelihoodTypes(experiment.reward_type)
@@ -122,7 +122,7 @@ def analyze_experiment(
                     np.array([arm.mu_init] * max(len(experiment.contexts), 1)),
                     np.diag([arm.sigma_init] * max(len(experiment.contexts), 1)),
                     outcome_std_dev,
-                    context=np.array(contexts) if contexts else None,
+                    context=np.array(context_vals) if context_vals else None,
                 )
 
                 assert arm.mu is not None and arm.covariance is not None, "Arm must have mu and covariance parameters."
@@ -130,7 +130,7 @@ def analyze_experiment(
                     np.array(arm.mu),
                     np.array(arm.covariance),
                     outcome_std_dev,
-                    context=np.array(contexts) if contexts else None,
+                    context=np.array(context_vals) if context_vals else None,
                 )
 
             case PriorTypes.NORMAL, LikelihoodTypes.BERNOULLI:
@@ -141,7 +141,7 @@ def analyze_experiment(
                     np.array([arm.mu_init] * max(len(experiment.contexts), 1)),
                     np.diag([arm.sigma_init] * max(len(experiment.contexts), 1)),
                     ContextLinkFunctions.LOGISTIC,
-                    context=np.array(contexts) if contexts else None,
+                    context=np.array(context_vals) if context_vals else None,
                     random_state=random_state,
                 )
 
@@ -150,7 +150,7 @@ def analyze_experiment(
                     np.array(arm.mu),
                     np.array(arm.covariance),
                     ContextLinkFunctions.LOGISTIC,
-                    context=np.array(contexts) if contexts else None,
+                    context=np.array(context_vals) if context_vals else None,
                     random_state=random_state,
                 )
 

--- a/src/xngin/stats/bandit_analysis.py
+++ b/src/xngin/stats/bandit_analysis.py
@@ -47,6 +47,7 @@ def _analyze_normal_binary(
     covariance: np.ndarray,
     context_link_functions: ContextLinkFunctions,
     context: np.ndarray | None = None,
+    random_state: int | None = None,
 ) -> tuple[float, float]:
     """
     Analyze a single arm with Normal model for binary outcomes.
@@ -55,8 +56,8 @@ def _analyze_normal_binary(
         covariance: The posterior covariance matrix of the arm.
         context_link_functions: The link function to use.
         context: Optional context vector.
+        random_state: Use a fixed int for deterministic behavior in tests.
     """
-    random_state = 66  # TODO: Make this configurable
     rng = np.random.default_rng(random_state)
     num_samples = 10000  # TODO: Make this configurable
 
@@ -74,7 +75,10 @@ def _analyze_normal_binary(
 
 
 def analyze_experiment(
-    experiment: tables.Experiment, outcome_std_dev: float = 1.0, contexts: list | None = None
+    experiment: tables.Experiment,
+    outcome_std_dev: float = 1.0,
+    contexts: list | None = None,
+    random_state: int | None = None,
 ) -> list[BanditArmAnalysis]:
     """
     Analyze a bandit experiment. Assumes arms and draws are preloaded.
@@ -83,6 +87,7 @@ def analyze_experiment(
         experiment: The bandit experiment to analyze.
         outcome_std_dev: Standard deviation of the outcomes. Only used for Normal likelihood.
         contexts: Optional context values for CMAB experiments.
+        random_state: Use a fixed int for deterministic behavior in tests.
     """
     # TODO: Does not support Bayes A/B experiments
     if experiment.experiment_type == ExperimentsType.BAYESAB_ONLINE.value:
@@ -137,6 +142,7 @@ def analyze_experiment(
                     np.diag([arm.sigma_init] * max(len(experiment.contexts), 1)),
                     ContextLinkFunctions.LOGISTIC,
                     context=np.array(contexts) if contexts else None,
+                    random_state=random_state,
                 )
 
                 assert arm.mu is not None and arm.covariance is not None, "Arm must have mu and covariance parameters."
@@ -145,6 +151,7 @@ def analyze_experiment(
                     np.array(arm.covariance),
                     ContextLinkFunctions.LOGISTIC,
                     context=np.array(contexts) if contexts else None,
+                    random_state=random_state,
                 )
 
             case _:

--- a/src/xngin/stats/test_bandit_analysis.py
+++ b/src/xngin/stats/test_bandit_analysis.py
@@ -57,7 +57,7 @@ def test_cmab_analysis(prior_type, reward_type):
         arm.covariance = np.diag([arm.sigma_init * (i + 2)] * len(cmab_experiment.contexts)).tolist()
 
     contexts = [1.0] * len(cmab_experiment.contexts)
-    arm_analyses = analyze_experiment(cmab_experiment, contexts=contexts, random_state=66)
+    arm_analyses = analyze_experiment(cmab_experiment, context_vals=contexts, random_state=66)
     assert len(arm_analyses) == len(cmab_experiment.arms)
     for arm_analysis in arm_analyses:
         assert arm_analysis.prior_pred_mean != arm_analysis.post_pred_mean

--- a/src/xngin/stats/test_bandit_analysis.py
+++ b/src/xngin/stats/test_bandit_analysis.py
@@ -31,7 +31,7 @@ def test_mab_analysis(prior_type, reward_type):
             arm.alpha = arm.alpha_init + (i + 1) * 10
             arm.beta = arm.beta_init + (2 - i) * 10
 
-    arm_analyses = analyze_experiment(mab_experiment)
+    arm_analyses = analyze_experiment(mab_experiment, random_state=66)
     assert len(arm_analyses) == len(mab_experiment.arms)
     for arm_analysis in arm_analyses:
         assert arm_analysis.prior_pred_mean != arm_analysis.post_pred_mean
@@ -57,7 +57,7 @@ def test_cmab_analysis(prior_type, reward_type):
         arm.covariance = np.diag([arm.sigma_init * (i + 2)] * len(cmab_experiment.contexts)).tolist()
 
     contexts = [1.0] * len(cmab_experiment.contexts)
-    arm_analyses = analyze_experiment(cmab_experiment, contexts=contexts)
+    arm_analyses = analyze_experiment(cmab_experiment, contexts=contexts, random_state=66)
     assert len(arm_analyses) == len(cmab_experiment.arms)
     for arm_analysis in arm_analyses:
         assert arm_analysis.prior_pred_mean != arm_analysis.post_pred_mean


### PR DESCRIPTION
## Description

Some code de-duplication, cleanup of some random_state, and variable renaming for readability.

## How has this been tested?

unittests

## Checklist

Fill with `x` for completed.

- [x] I have updated the automated tests
- [x] I have updated affected documentation
- [x] I have updated the CI/CD scripts in `.github/workflows/`
