### PR TITLE
Feature: backend support for OR IS NULL with BETWEEN / >= / <= relations on numeric Filter types; also adds Date support

### DIFF
--- a/src/xngin/apiserver/dwh/queries.py
+++ b/src/xngin/apiserver/dwh/queries.py
@@ -1,10 +1,12 @@
 import re
 from collections.abc import Sequence
-from datetime import datetime, timedelta
+from datetime import date, datetime, time, timedelta
+from typing import Literal
 
 import sqlalchemy
 from sqlalchemy import (
     ColumnElement,
+    Date,
     DateTime,
     Float,
     Integer,
@@ -219,8 +221,8 @@ def get_participant_metrics(
 
 def create_one_filter(filter_: Filter, sa_table: sqlalchemy.Table):
     """Converts a Filter into a SQLAlchemy filter."""
-    if isinstance(sa_table.columns[filter_.field_name].type, DateTime):
-        return create_datetime_filter(sa_table.columns[filter_.field_name], filter_)
+    if isinstance(sa_table.columns[filter_.field_name].type, (DateTime, Date)):
+        return create_date_or_datetime_filter(sa_table.columns[filter_.field_name], filter_)
     if filter_.field_name.endswith(EXPERIMENT_IDS_SUFFIX):
         return create_special_experiment_id_filter(sa_table.columns[filter_.field_name], filter_)
     return create_filter(sa_table.columns[filter_.field_name], filter_)
@@ -258,7 +260,7 @@ def make_csv_regex(values):
 
 
 def general_excludes_filter(
-    col: sqlalchemy.Column, value: FilterValueTypes | Sequence[datetime | None]
+    col: sqlalchemy.Column, value: FilterValueTypes | Sequence[datetime | None] | Sequence[date | None]
 ) -> ColumnElement[bool]:
     if None in value:
         non_null_list = [v for v in value if v is not None]
@@ -275,45 +277,62 @@ def general_excludes_filter(
     )
 
 
-def create_datetime_filter(col: sqlalchemy.Column, filter_: Filter) -> ColumnElement:
-    """Converts a single Filter for a DateTime-typed column into a sqlalchemy filter."""
+def create_date_or_datetime_filter(col: sqlalchemy.Column, filter_: Filter) -> ColumnElement:
+    """Converts a single Filter for a DateTime or Date-typed column into a sqlalchemy filter."""
 
-    def str_to_datetime(s: int | float | str | datetime | None) -> datetime | None:
-        """Convert an ISO8601 string to a timezone-unaware datetime.
+    def str_to_date_or_datetime(
+        s: int | float | str | date | datetime | None, target_type: Literal["date", "datetime"]
+    ) -> date | datetime | None:
+        """Convert an ISO8601 string to a date or datetime based on target_type.
 
         LateValidationError is raised if the ISO8601 string specifies a non-UTC timezone.
 
-        For maximum compatibility between backends, any microseconds value, if specified, is truncated to zero.
-
-        If `s` is already a datetime, it is returned as-is, but with microseconds set to zero.
+        For "datetime": microseconds are truncated to zero for maximum compatibility between backends.
+            If `s` is already a datetime, it is returned as-is, but with microseconds set to zero.
+        For "date": datetime strings are converted to dates, dropping time information.
+            If `s` is already a date, it is returned as-is.
         """
         if s is None:
             return None
+
         if isinstance(s, datetime):
-            return s.replace(microsecond=0)
+            return s.date() if target_type == "date" else s.replace(microsecond=0)
+
+        if isinstance(s, date):
+            # convert date to datetime at midnight if target_type is datetime
+            return s if target_type == "date" else datetime.combine(s, time.min)
+
         if not isinstance(s, str):
             raise LateValidationError(
-                f"{col.name}: datetime-type filter values must be strings containing an ISO8601 formatted date."
+                f"{col.name}: {target_type}-type filter values must be strings containing an ISO8601 formatted date."
             )
+
+        # Always parse as datetime first to validate timezone
         try:
             parsed = datetime.fromisoformat(s).replace(microsecond=0)
         except (ValueError, TypeError) as exc:
             raise LateValidationError(
-                "{col.name}: datetime-type filter values must be strings containing an ISO8601 formatted date."
+                f"{col.name}: {target_type}-type filter values must be strings containing an ISO8601 formatted date."
             ) from exc
-        if not parsed.tzinfo:
-            return parsed
-        offset = parsed.tzinfo.utcoffset(parsed)
-        if offset == timedelta():  # 0 timedelta is equivalent to UTC
-            return parsed.replace(tzinfo=None)
-        raise LateValidationError(
-            f"{col.name}: datetime-type filter values must be in UTC, or not be tagged with an explicit timezone: {s}"
-        )
 
-    if not isinstance(col.type, DateTime):
-        raise LateValidationError(f"Column {col.name} is not a DateTime type, cannot apply datetime filter.")
+        if parsed.tzinfo:
+            offset = parsed.tzinfo.utcoffset(parsed)
+            if offset != timedelta():  # 0 timedelta is equivalent to UTC
+                raise LateValidationError(
+                    f"{col.name}: {target_type}-type filter values must be in UTC, "
+                    f"or not be tagged with an explicit timezone: {s}"
+                )
+            parsed = parsed.replace(tzinfo=None)
 
-    parsed_values = list(map(str_to_datetime, filter_.value))
+        return parsed.date() if target_type == "date" else parsed
+
+    # First validate that we're working with the right column type.
+    if not isinstance(col.type, (DateTime, Date)):
+        raise LateValidationError(f"Column {col.name} is not a DateTime or Date type; cannot create filter.")
+
+    target_type: Literal["date", "datetime"] = "date" if isinstance(col.type, Date) else "datetime"
+    parsed_values = list(map(lambda s: str_to_date_or_datetime(s, target_type), filter_.value))
+
     if filter_.relation == Relation.EXCLUDES:
         return general_excludes_filter(col, parsed_values)
 

--- a/src/xngin/apiserver/dwh/queries.py
+++ b/src/xngin/apiserver/dwh/queries.py
@@ -328,6 +328,12 @@ def create_datetime_filter(col: sqlalchemy.Column, filter_: Filter) -> ColumnEle
             return col <= right
         case (left, right):
             return col.between(left, right)
+        case (left, None, None):
+            return or_(col >= left, col.is_(sqlalchemy.null()))
+        case (None, right, None):
+            return or_(col <= right, col.is_(sqlalchemy.null()))
+        case (left, right, None):
+            return or_(col.between(left, right), col.is_(sqlalchemy.null()))
         case _:
             raise RuntimeError("Bug: invalid filter.")
 
@@ -343,6 +349,12 @@ def create_filter(col: sqlalchemy.Column, filter_: Filter) -> ColumnElement:
                     return col <= right
                 case (left, right):
                     return col.between(left, right)
+                case (left, None, None):
+                    return or_(col >= left, col.is_(sqlalchemy.null()))
+                case (None, right, None):
+                    return or_(col <= right, col.is_(sqlalchemy.null()))
+                case (left, right, None):
+                    return or_(col.between(left, right), col.is_(sqlalchemy.null()))
                 case _:
                     raise RuntimeError("Bug: invalid filter.")
         case Relation.EXCLUDES if isinstance(col.type, sqlalchemy.Boolean):

--- a/src/xngin/apiserver/dwh/test_dialect_sql.py
+++ b/src/xngin/apiserver/dwh/test_dialect_sql.py
@@ -161,6 +161,7 @@ class WhereTable(HelpfulBase):
 
 
 WHERE_TESTCASES = [
+    # EXCLUDES basic tests
     WhereTestCase(
         filters=[Filter(field_name="float_col", relation=Relation.EXCLUDES, value=[2, 3])],
         where={
@@ -170,13 +171,7 @@ WHERE_TESTCASES = [
         },
     ),
     WhereTestCase(
-        filters=[
-            Filter(
-                field_name="int_col",
-                relation=Relation.EXCLUDES,
-                value=[None],
-            )
-        ],
+        filters=[Filter(field_name="int_col", relation=Relation.EXCLUDES, value=[None])],
         where={
             DbType.RS: "tt.int_col IS NOT NULL ORDER BY random()  LIMIT 3",
             DbType.PG: "tt.int_col IS NOT NULL ORDER BY random()  LIMIT 3",
@@ -184,13 +179,7 @@ WHERE_TESTCASES = [
         },
     ),
     WhereTestCase(
-        filters=[
-            Filter(
-                field_name="int_col",
-                relation=Relation.EXCLUDES,
-                value=[1],
-            )
-        ],
+        filters=[Filter(field_name="int_col", relation=Relation.EXCLUDES, value=[1])],
         where={
             DbType.RS: "tt.int_col IS NULL OR (tt.int_col NOT IN (1)) ORDER BY random()  LIMIT 3",
             DbType.PG: "tt.int_col IS NULL OR (tt.int_col NOT IN (1)) ORDER BY random()  LIMIT 3",
@@ -198,65 +187,26 @@ WHERE_TESTCASES = [
         },
     ),
     WhereTestCase(
-        filters=[
-            Filter(
-                field_name="int_col",
-                relation=Relation.EXCLUDES,
-                value=[None, 1],
-            )
-        ],
+        filters=[Filter(field_name="int_col", relation=Relation.EXCLUDES, value=[None, 1])],
         where={
             DbType.RS: "tt.int_col IS NOT NULL AND (tt.int_col NOT IN (1)) ORDER BY random()  LIMIT 3",
             DbType.PG: "tt.int_col IS NOT NULL AND (tt.int_col NOT IN (1)) ORDER BY random()  LIMIT 3",
             DbType.BQ: "`tt`.`int_col` IS NOT NULL AND (`tt`.`int_col` NOT IN (1)) ORDER BY rand() LIMIT 3",
         },
     ),
+    # INCLUDES basic tests
     WhereTestCase(
-        filters=[
-            Filter(
-                field_name="dt_col",
-                relation=Relation.EXCLUDES,
-                value=["2024-01-01"],
-            )
-        ],
+        filters=[Filter(field_name="string_col", relation=Relation.INCLUDES, value=["a", "b"])],
         where={
-            DbType.RS: "tt.dt_col IS NULL OR (tt.dt_col NOT IN ('2024-01-01 00:00:00')) ORDER BY random()  LIMIT 3",
-            DbType.PG: "tt.dt_col IS NULL OR (tt.dt_col NOT IN ('2024-01-01 00:00:00')) ORDER BY random()  LIMIT 3",
+            DbType.RS: "NOT (tt.string_col IS NULL OR (tt.string_col NOT IN ('a', 'b'))) ORDER BY random()  LIMIT 3",
+            DbType.PG: "NOT (tt.string_col IS NULL OR (tt.string_col NOT IN ('a', 'b'))) ORDER BY random()  LIMIT 3",
             DbType.BQ: (
-                "`tt`.`dt_col` IS NULL OR (`tt`.`dt_col` NOT IN (DATETIME '2024-01-01 00:00:00')) "
-                "ORDER BY rand() LIMIT 3"
+                "NOT (`tt`.`string_col` IS NULL OR (`tt`.`string_col` NOT IN ('a', 'b'))) ORDER BY rand() LIMIT 3"
             ),
         },
     ),
     WhereTestCase(
-        filters=[
-            Filter(
-                field_name="dt_col",
-                relation=Relation.EXCLUDES,
-                value=["2024-01-01", None],
-            )
-        ],
-        where={
-            DbType.RS: (
-                "tt.dt_col IS NOT NULL AND (tt.dt_col NOT IN ('2024-01-01 00:00:00')) ORDER BY random()  LIMIT 3"
-            ),
-            DbType.PG: (
-                "tt.dt_col IS NOT NULL AND (tt.dt_col NOT IN ('2024-01-01 00:00:00')) ORDER BY random()  LIMIT 3"
-            ),
-            DbType.BQ: (
-                "`tt`.`dt_col` IS NOT NULL AND (`tt`.`dt_col` NOT IN (DATETIME '2024-01-01 00:00:00')) "
-                "ORDER BY rand() LIMIT 3"
-            ),
-        },
-    ),
-    WhereTestCase(
-        filters=[
-            Filter(
-                field_name="int_col",
-                relation=Relation.INCLUDES,
-                value=[None],
-            )
-        ],
+        filters=[Filter(field_name="int_col", relation=Relation.INCLUDES, value=[None])],
         where={
             DbType.RS: "tt.int_col IS NULL ORDER BY random()  LIMIT 3",
             DbType.PG: "tt.int_col IS NULL ORDER BY random()  LIMIT 3",
@@ -264,13 +214,7 @@ WHERE_TESTCASES = [
         },
     ),
     WhereTestCase(
-        filters=[
-            Filter(
-                field_name="int_col",
-                relation=Relation.INCLUDES,
-                value=[42],
-            )
-        ],
+        filters=[Filter(field_name="int_col", relation=Relation.INCLUDES, value=[42])],
         where={
             DbType.RS: "NOT (tt.int_col IS NULL OR (tt.int_col NOT IN (42))) ORDER BY random()  LIMIT 3",
             DbType.PG: "NOT (tt.int_col IS NULL OR (tt.int_col NOT IN (42))) ORDER BY random()  LIMIT 3",
@@ -278,27 +222,16 @@ WHERE_TESTCASES = [
         },
     ),
     WhereTestCase(
-        filters=[
-            Filter(
-                field_name="int_col",
-                relation=Relation.INCLUDES,
-                value=[None, 1],
-            )
-        ],
+        filters=[Filter(field_name="int_col", relation=Relation.INCLUDES, value=[None, 1])],
         where={
             DbType.RS: "NOT (tt.int_col IS NOT NULL AND (tt.int_col NOT IN (1))) ORDER BY random()  LIMIT 3",
             DbType.PG: "NOT (tt.int_col IS NOT NULL AND (tt.int_col NOT IN (1))) ORDER BY random()  LIMIT 3",
             DbType.BQ: "NOT (`tt`.`int_col` IS NOT NULL AND (`tt`.`int_col` NOT IN (1))) ORDER BY rand() LIMIT 3",
         },
     ),
+    # DATETIME tests
     WhereTestCase(
-        filters=[
-            Filter(
-                field_name="dt_col",
-                relation=Relation.INCLUDES,
-                value=["2024-01-01"],
-            )
-        ],
+        filters=[Filter(field_name="dt_col", relation=Relation.INCLUDES, value=["2024-01-01"])],
         where={
             DbType.RS: (
                 "NOT (tt.dt_col IS NULL OR (tt.dt_col NOT IN ('2024-01-01 00:00:00'))) ORDER BY random()  LIMIT 3"
@@ -313,13 +246,7 @@ WHERE_TESTCASES = [
         },
     ),
     WhereTestCase(
-        filters=[
-            Filter(
-                field_name="dt_col",
-                relation=Relation.INCLUDES,
-                value=["2024-01-01", None],
-            )
-        ],
+        filters=[Filter(field_name="dt_col", relation=Relation.INCLUDES, value=["2024-01-01", None])],
         where={
             DbType.RS: (
                 "NOT (tt.dt_col IS NOT NULL AND (tt.dt_col NOT IN ('2024-01-01 00:00:00'))) ORDER BY random()  LIMIT 3"
@@ -334,13 +261,33 @@ WHERE_TESTCASES = [
         },
     ),
     WhereTestCase(
-        filters=[
-            Filter(
-                field_name="dt_col",
-                relation=Relation.BETWEEN,
-                value=["2024-01-01", "2024-01-02"],
-            )
-        ],
+        filters=[Filter(field_name="dt_col", relation=Relation.EXCLUDES, value=["2024-01-01"])],
+        where={
+            DbType.RS: "tt.dt_col IS NULL OR (tt.dt_col NOT IN ('2024-01-01 00:00:00')) ORDER BY random()  LIMIT 3",
+            DbType.PG: "tt.dt_col IS NULL OR (tt.dt_col NOT IN ('2024-01-01 00:00:00')) ORDER BY random()  LIMIT 3",
+            DbType.BQ: (
+                "`tt`.`dt_col` IS NULL OR (`tt`.`dt_col` NOT IN (DATETIME '2024-01-01 00:00:00')) "
+                "ORDER BY rand() LIMIT 3"
+            ),
+        },
+    ),
+    WhereTestCase(
+        filters=[Filter(field_name="dt_col", relation=Relation.EXCLUDES, value=["2024-01-01", None])],
+        where={
+            DbType.RS: (
+                "tt.dt_col IS NOT NULL AND (tt.dt_col NOT IN ('2024-01-01 00:00:00')) ORDER BY random()  LIMIT 3"
+            ),
+            DbType.PG: (
+                "tt.dt_col IS NOT NULL AND (tt.dt_col NOT IN ('2024-01-01 00:00:00')) ORDER BY random()  LIMIT 3"
+            ),
+            DbType.BQ: (
+                "`tt`.`dt_col` IS NOT NULL AND (`tt`.`dt_col` NOT IN (DATETIME '2024-01-01 00:00:00')) "
+                "ORDER BY rand() LIMIT 3"
+            ),
+        },
+    ),
+    WhereTestCase(
+        filters=[Filter(field_name="dt_col", relation=Relation.BETWEEN, value=["2024-01-01", "2024-01-02"])],
         where={
             DbType.RS: "tt.dt_col BETWEEN '2024-01-01 00:00:00' AND '2024-01-02 00:00:00' ORDER BY random()  LIMIT 3",
             DbType.PG: "tt.dt_col BETWEEN '2024-01-01 00:00:00' AND '2024-01-02 00:00:00' ORDER BY random()  LIMIT 3",
@@ -350,13 +297,25 @@ WHERE_TESTCASES = [
             ),
         },
     ),
+    # TIMESTAMP tests
+    WhereTestCase(
+        filters=[Filter(field_name="ts_col", relation=Relation.EXCLUDES, value=["2024-01-01T23:00:00+00:00", None])],
+        where={
+            DbType.RS: (
+                "tt.ts_col IS NOT NULL AND (tt.ts_col NOT IN ('2024-01-01 23:00:00')) ORDER BY random()  LIMIT 3"
+            ),
+            DbType.PG: (
+                "tt.ts_col IS NOT NULL AND (tt.ts_col NOT IN ('2024-01-01 23:00:00')) ORDER BY random()  LIMIT 3"
+            ),
+            DbType.BQ: (
+                "`tt`.`ts_col` IS NOT NULL AND (`tt`.`ts_col` NOT IN (TIMESTAMP '2024-01-01 23:00:00')) "
+                "ORDER BY rand() LIMIT 3"
+            ),
+        },
+    ),
     WhereTestCase(
         filters=[
-            Filter(
-                field_name="ts_col",
-                relation=Relation.BETWEEN,
-                value=["2024-01-01", "2024-01-02"],
-            )
+            Filter(field_name="ts_col", relation=Relation.BETWEEN, value=["2024-01-01", "2024-01-02"]),
         ],
         where={
             DbType.RS: "tt.ts_col BETWEEN '2024-01-01 00:00:00' AND '2024-01-02 00:00:00' ORDER BY random()  LIMIT 3",
@@ -369,11 +328,7 @@ WHERE_TESTCASES = [
     ),
     WhereTestCase(
         filters=[
-            Filter(
-                field_name="ts_col",
-                relation=Relation.BETWEEN,
-                value=["2024-01-01 01:02:03.100000", "2024-01-02"],
-            )
+            Filter(field_name="ts_col", relation=Relation.BETWEEN, value=["2024-01-01 01:02:03.100000", "2024-01-02"]),
         ],
         where={
             DbType.RS: "tt.ts_col BETWEEN '2024-01-01 01:02:03' AND '2024-01-02 00:00:00' ORDER BY random()  LIMIT 3",
@@ -384,18 +339,11 @@ WHERE_TESTCASES = [
             ),
         },
     ),
+    # experiment_ids inclusion/exclusion tests
     WhereTestCase(
         filters=[
-            Filter(
-                field_name="int_col",
-                relation=Relation.INCLUDES,
-                value=[42, -17],
-            ),
-            Filter(
-                field_name="experiment_ids",
-                relation=Relation.INCLUDES,
-                value=["b", "C"],
-            ),
+            Filter(field_name="int_col", relation=Relation.INCLUDES, value=[42, -17]),
+            Filter(field_name="experiment_ids", relation=Relation.INCLUDES, value=["b", "C"]),
         ],
         where={
             DbType.BQ: (
@@ -417,16 +365,8 @@ WHERE_TESTCASES = [
     ),
     WhereTestCase(
         filters=[
-            Filter(
-                field_name="int_col",
-                relation=Relation.INCLUDES,
-                value=[42, -17],
-            ),
-            Filter(
-                field_name="experiment_ids",
-                relation=Relation.EXCLUDES,
-                value=["b", "c"],
-            ),
+            Filter(field_name="int_col", relation=Relation.INCLUDES, value=[42, -17]),
+            Filter(field_name="experiment_ids", relation=Relation.EXCLUDES, value=["b", "c"]),
         ],
         where={
             DbType.BQ: (
@@ -449,6 +389,7 @@ WHERE_TESTCASES = [
             ),
         },
     ),
+    # BETWEEN tests, without and with NULL
     WhereTestCase(
         filters=[Filter(field_name="int_col", relation=Relation.BETWEEN, value=[-17, 42])],
         where={
@@ -465,6 +406,7 @@ WHERE_TESTCASES = [
             DbType.BQ: "`tt`.`int_col` BETWEEN -17 AND 42 OR `tt`.`int_col` IS NULL ORDER BY rand() LIMIT 3",
         },
     ),
+    # >=, <= with NULL tests
     WhereTestCase(
         filters=[Filter(field_name="float_col", relation=Relation.BETWEEN, value=[1.0, None, None])],
         where={
@@ -481,14 +423,9 @@ WHERE_TESTCASES = [
             DbType.BQ: "`tt`.`float_col` <= 1.0 OR `tt`.`float_col` IS NULL ORDER BY rand() LIMIT 3",
         },
     ),
+    # BOOLEAN tests
     WhereTestCase(
-        filters=[
-            Filter(
-                field_name="bool_col",
-                relation=Relation.INCLUDES,
-                value=[True],
-            )
-        ],
+        filters=[Filter(field_name="bool_col", relation=Relation.INCLUDES, value=[True])],
         where={
             DbType.RS: "tt.bool_col IS true ORDER BY random()  LIMIT 3",
             DbType.PG: "tt.bool_col IS true ORDER BY random()  LIMIT 3",
@@ -496,13 +433,15 @@ WHERE_TESTCASES = [
         },
     ),
     WhereTestCase(
-        filters=[
-            Filter(
-                field_name="bool_col",
-                relation=Relation.EXCLUDES,
-                value=[True],
-            )
-        ],
+        filters=[Filter(field_name="bool_col", relation=Relation.INCLUDES, value=[False])],
+        where={
+            DbType.RS: "tt.bool_col IS false ORDER BY random()  LIMIT 3",
+            DbType.PG: "tt.bool_col IS false ORDER BY random()  LIMIT 3",
+            DbType.BQ: "`tt`.`bool_col` IS false ORDER BY rand() LIMIT 3",
+        },
+    ),
+    WhereTestCase(
+        filters=[Filter(field_name="bool_col", relation=Relation.EXCLUDES, value=[True])],
         where={
             DbType.RS: "tt.bool_col IS NOT true ORDER BY random()  LIMIT 3",
             DbType.PG: "tt.bool_col IS NOT true ORDER BY random()  LIMIT 3",
@@ -510,27 +449,7 @@ WHERE_TESTCASES = [
         },
     ),
     WhereTestCase(
-        filters=[
-            Filter(
-                field_name="bool_col",
-                relation=Relation.EXCLUDES,
-                value=[None],
-            )
-        ],
-        where={
-            DbType.RS: "tt.bool_col IS NOT NULL ORDER BY random()  LIMIT 3",
-            DbType.PG: "tt.bool_col IS NOT NULL ORDER BY random()  LIMIT 3",
-            DbType.BQ: "`tt`.`bool_col` IS NOT NULL ORDER BY rand() LIMIT 3",
-        },
-    ),
-    WhereTestCase(
-        filters=[
-            Filter(
-                field_name="bool_col",
-                relation=Relation.INCLUDES,
-                value=[None],
-            )
-        ],
+        filters=[Filter(field_name="bool_col", relation=Relation.INCLUDES, value=[None])],
         where={
             DbType.RS: "tt.bool_col IS NULL ORDER BY random()  LIMIT 3",
             DbType.PG: "tt.bool_col IS NULL ORDER BY random()  LIMIT 3",
@@ -538,21 +457,15 @@ WHERE_TESTCASES = [
         },
     ),
     WhereTestCase(
-        filters=[Filter(field_name="bool_col", relation=Relation.INCLUDES, value=[False])],
+        filters=[Filter(field_name="bool_col", relation=Relation.EXCLUDES, value=[None])],
         where={
-            DbType.BQ: "`tt`.`bool_col` IS false ORDER BY rand() LIMIT 3",
-            DbType.RS: "tt.bool_col IS false ORDER BY random()  LIMIT 3",
-            DbType.PG: "tt.bool_col IS false ORDER BY random()  LIMIT 3",
+            DbType.RS: "tt.bool_col IS NOT NULL ORDER BY random()  LIMIT 3",
+            DbType.PG: "tt.bool_col IS NOT NULL ORDER BY random()  LIMIT 3",
+            DbType.BQ: "`tt`.`bool_col` IS NOT NULL ORDER BY rand() LIMIT 3",
         },
     ),
     WhereTestCase(
-        filters=[
-            Filter(
-                field_name="bool_col",
-                relation=Relation.EXCLUDES,
-                value=[None, True],
-            )
-        ],
+        filters=[Filter(field_name="bool_col", relation=Relation.EXCLUDES, value=[None, True])],
         where={
             DbType.RS: "tt.bool_col IS NOT NULL AND tt.bool_col IS NOT true ORDER BY random()  LIMIT 3",
             DbType.PG: "tt.bool_col IS NOT NULL AND tt.bool_col IS NOT true ORDER BY random()  LIMIT 3",
@@ -560,13 +473,15 @@ WHERE_TESTCASES = [
         },
     ),
     WhereTestCase(
-        filters=[
-            Filter(
-                field_name="bool_col",
-                relation=Relation.INCLUDES,
-                value=[None, False],
-            )
-        ],
+        filters=[Filter(field_name="bool_col", relation=Relation.EXCLUDES, value=[False, None])],
+        where={
+            DbType.BQ: "`tt`.`bool_col` IS NOT false AND `tt`.`bool_col` IS NOT NULL ORDER BY rand() LIMIT 3",
+            DbType.RS: "tt.bool_col IS NOT false AND tt.bool_col IS NOT NULL ORDER BY random()  LIMIT 3",
+            DbType.PG: "tt.bool_col IS NOT false AND tt.bool_col IS NOT NULL ORDER BY random()  LIMIT 3",
+        },
+    ),
+    WhereTestCase(
+        filters=[Filter(field_name="bool_col", relation=Relation.INCLUDES, value=[None, False])],
         where={
             DbType.RS: "tt.bool_col IS NULL OR tt.bool_col IS false ORDER BY random()  LIMIT 3",
             DbType.PG: "tt.bool_col IS NULL OR tt.bool_col IS false ORDER BY random()  LIMIT 3",
@@ -574,13 +489,7 @@ WHERE_TESTCASES = [
         },
     ),
     WhereTestCase(
-        filters=[
-            Filter(
-                field_name="bool_col",
-                relation=Relation.INCLUDES,
-                value=[True, None],
-            )
-        ],
+        filters=[Filter(field_name="bool_col", relation=Relation.INCLUDES, value=[True, None])],
         where={
             DbType.BQ: "`tt`.`bool_col` IS true OR `tt`.`bool_col` IS NULL ORDER BY rand() LIMIT 3",
             DbType.RS: "tt.bool_col IS true OR tt.bool_col IS NULL ORDER BY random()  LIMIT 3",
@@ -588,34 +497,14 @@ WHERE_TESTCASES = [
         },
     ),
     WhereTestCase(
-        filters=[
-            Filter(
-                field_name="bool_col",
-                relation=Relation.EXCLUDES,
-                value=[False, True],
-            )
-        ],
+        filters=[Filter(field_name="bool_col", relation=Relation.EXCLUDES, value=[False, True])],
         where={
             DbType.RS: "tt.bool_col IS NOT false AND tt.bool_col IS NOT true ORDER BY random()  LIMIT 3",
             DbType.PG: "tt.bool_col IS NOT false AND tt.bool_col IS NOT true ORDER BY random()  LIMIT 3",
             DbType.BQ: "`tt`.`bool_col` IS NOT false AND `tt`.`bool_col` IS NOT true ORDER BY rand() LIMIT 3",
         },
     ),
-    WhereTestCase(
-        filters=[
-            Filter(
-                field_name="bool_col",
-                relation=Relation.EXCLUDES,
-                value=[False, None],
-            )
-        ],
-        where={
-            DbType.BQ: "`tt`.`bool_col` IS NOT false AND `tt`.`bool_col` IS NOT NULL ORDER BY rand() LIMIT 3",
-            DbType.RS: "tt.bool_col IS NOT false AND tt.bool_col IS NOT NULL ORDER BY random()  LIMIT 3",
-            DbType.PG: "tt.bool_col IS NOT false AND tt.bool_col IS NOT NULL ORDER BY random()  LIMIT 3",
-        },
-    ),
-    # Date column tests
+    # DATE tests
     WhereTestCase(
         filters=[Filter(field_name="date_col", relation=Relation.EXCLUDES, value=["2024-01-01"])],
         where={
@@ -680,6 +569,7 @@ def test_where(testcase: WhereTestCase):
         sql = str(q.compile(dialect=dbtype.dialect(), compile_kwargs={"literal_binds": True}))
         normalized = sql.replace("\n", "")
         normalized = normalized[normalized.find("WHERE ") + len("WHERE ") :]
+        assert normalized == testcase.where[dbtype]
         if normalized != testcase.where[dbtype]:
             failures[str(dbtype)] = normalized
 

--- a/src/xngin/apiserver/dwh/test_queries.py
+++ b/src/xngin/apiserver/dwh/test_queries.py
@@ -2,7 +2,7 @@
 
 import re
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 
 import pytest
 import sqlalchemy
@@ -20,13 +20,14 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.orm import DeclarativeBase, Session, mapped_column
+from sqlalchemy.types import Date
 
 from xngin.apiserver import flags
 from xngin.apiserver.conftest import DbType, get_queries_test_uri
 from xngin.apiserver.dwh.analysis_types import MetricValue, ParticipantOutcome
 from xngin.apiserver.dwh.queries import (
     compose_query,
-    create_datetime_filter,
+    create_date_or_datetime_filter,
     create_query_filters,
     get_participant_metrics,
     get_stats_on_metrics,
@@ -64,7 +65,8 @@ class SampleNullableTable(Base):
     int_col = mapped_column(Integer, nullable=True)
     float_col = mapped_column(Float, nullable=True)
     string_col = mapped_column(String, nullable=True)
-    date_col = mapped_column(DateTime, nullable=True)
+    datetime_col = mapped_column(DateTime, nullable=True)
+    date_col = mapped_column(Date, nullable=True)
 
 
 @dataclass
@@ -74,7 +76,8 @@ class NullableRow:
     int_col: int | None
     float_col: float | None
     string_col: str | None
-    date_col: datetime | None
+    datetime_col: datetime | None
+    date_col: date | None
 
 
 ROW_10 = NullableRow(
@@ -83,7 +86,8 @@ ROW_10 = NullableRow(
     int_col=None,
     float_col=1.01,
     string_col="10",
-    date_col=datetime(2025, 1, 1, 0, 0),
+    datetime_col=datetime(2025, 1, 1, 0, 0),
+    date_col=date(2025, 1, 1),
 )
 ROW_20 = NullableRow(
     id=20,
@@ -91,7 +95,8 @@ ROW_20 = NullableRow(
     int_col=1,
     float_col=2.02,
     string_col=None,
-    date_col=datetime.fromisoformat("2025-01-02"),
+    datetime_col=datetime.fromisoformat("2025-01-02"),
+    date_col=date(2025, 1, 2),
 )
 ROW_30 = NullableRow(
     id=30,
@@ -99,6 +104,7 @@ ROW_30 = NullableRow(
     int_col=3,
     float_col=None,
     string_col="30",
+    datetime_col=None,
     date_col=None,
 )
 SAMPLE_NULLABLE_TABLE_ROWS = [
@@ -345,7 +351,7 @@ IS_NULLABLE_CASES = [
             Filter(
                 field_name="date_col",
                 relation=Relation.EXCLUDES,
-                value=[None, ROW_10.date_col and ROW_10.date_col.isoformat()],
+                value=[None, ROW_10.datetime_col and ROW_10.datetime_col.isoformat()],
             ),
         ],
         matches=[ROW_20],
@@ -421,7 +427,7 @@ IS_NULLABLE_CASES = [
             Filter(
                 field_name="date_col",
                 relation=Relation.INCLUDES,
-                value=[None, ROW_10.date_col and ROW_10.date_col.isoformat()],
+                value=[None, ROW_10.datetime_col and ROW_10.datetime_col.isoformat()],
             ),
         ],
         matches=[ROW_10, ROW_30],
@@ -454,6 +460,21 @@ IS_NULLABLE_CASES = [
         matches=[ROW_10, ROW_30],
     ),
     # between datetimes
+    Case(
+        filters=[
+            Filter(
+                field_name="date_col",
+                relation=Relation.BETWEEN,
+                value=[
+                    ROW_10.datetime_col and ROW_10.datetime_col.isoformat(),
+                    ROW_20.datetime_col and ROW_20.datetime_col.isoformat(),
+                    None,
+                ],
+            ),
+        ],
+        matches=[ROW_10, ROW_20, ROW_30],
+    ),
+    # Between dates
     Case(
         filters=[
             Filter(
@@ -618,18 +639,20 @@ def test_relations(testcase, queries_session, use_deterministic_random):
     assert list(sorted([r.id for r in query_results])) == list(sorted(r.id for r in testcase.matches)), testcase
 
 
-def test_datetime_filter_validation():
-    col = Column("x", DateTime)
+@pytest.mark.parametrize("column_type", [DateTime, Date])
+def test_date_or_datetime_filter_validation(column_type):
+    """Test validation for DateTime and Date-typed columns."""
+    col = Column("x", column_type)
 
     with pytest.raises(LateValidationError) as exc:
-        create_datetime_filter(
+        create_date_or_datetime_filter(
             col,
             Filter(field_name="x", relation=Relation.INCLUDES, value=[123, 456]),
         )
-    assert "ISO8601 formatted date" in str(exc)
+    assert "must be strings containing an ISO8601 formatted date" in str(exc)
 
     with pytest.raises(LateValidationError) as exc:
-        create_datetime_filter(
+        create_date_or_datetime_filter(
             col,
             Filter(
                 field_name="x",
@@ -637,10 +660,11 @@ def test_datetime_filter_validation():
                 value=["2024-01-01 00:00:00", "bark"],
             ),
         )
-    assert "ISO8601 formatted date" in str(exc)
+    assert "must be strings containing an ISO8601 formatted date" in str(exc)
 
+    # Test timezone validation for both DateTime and Date columns
     with pytest.raises(LateValidationError) as exc:
-        create_datetime_filter(
+        create_date_or_datetime_filter(
             col,
             Filter(
                 field_name="x",
@@ -648,33 +672,32 @@ def test_datetime_filter_validation():
                 value=["2024-01-01 00:00:00", "2024-01-01 00:00:00+08:00"],
             ),
         )
-    assert "timezone" in str(exc)
+    assert "must be in UTC" in str(exc)
 
 
-def test_allowed_datetime_filter_validation():
-    col = Column("x", DateTime)
+def test_date_or_datetime_filter_wrong_column_type():
+    """Test that we reject non-DateTime/Date columns for datetime/date filters."""
+    col = Column("x", String)
+    with pytest.raises(LateValidationError) as exc:
+        create_date_or_datetime_filter(col, Filter(field_name="x", relation=Relation.INCLUDES, value=["2024-01-01"]))
+    assert "not a DateTime or Date type" in str(exc)
 
-    create_datetime_filter(
-        col,
-        Filter(
-            field_name="x",
-            relation=Relation.EXCLUDES,
-            value=[None],
-        ),
-    )
 
-    create_datetime_filter(
-        col,
-        Filter(
-            field_name="x",
-            relation=Relation.INCLUDES,
-            value=[None],
-        ),
-    )
+@pytest.mark.parametrize("column_type", [DateTime, Date])
+def test_allowed_date_or_datetime_filter_validation(column_type):
+    """Test valid Date and DateTime filter scenarios."""
+    col = Column("x", column_type)
+
+    # Singular None is allowed for both column types
+    create_date_or_datetime_filter(col, Filter(field_name="x", relation=Relation.EXCLUDES, value=[None]))
+    create_date_or_datetime_filter(col, Filter(field_name="x", relation=Relation.INCLUDES, value=[None]))
+    # as are mixed None and date values
+    create_date_or_datetime_filter(col, Filter(field_name="x", relation=Relation.BETWEEN, value=[None, "2024-12-31"]))
+    create_date_or_datetime_filter(col, Filter(field_name="x", relation=Relation.BETWEEN, value=["2024-01-01", None]))
 
     # now without microseconds
     now = datetime.now(UTC).replace(microsecond=0)
-    create_datetime_filter(
+    create_date_or_datetime_filter(
         col,
         Filter(
             field_name="x",
@@ -683,11 +706,11 @@ def test_allowed_datetime_filter_validation():
         ),
     )
 
-    # zero offset is allowed
+    # zero offset is allowed (i.e. UTC timezone)
     # We strip the tz info because in the test below we want to control the tz format;
     # `now.isoformat()` by default will render with +00:00.
     now_no_tz = now.replace(tzinfo=None)
-    create_datetime_filter(
+    create_date_or_datetime_filter(
         col,
         Filter(
             field_name="x",
@@ -695,10 +718,18 @@ def test_allowed_datetime_filter_validation():
             value=[now_no_tz.isoformat() + "Z", now_no_tz.isoformat() + "-00:00"],
         ),
     )
+    create_date_or_datetime_filter(
+        col,
+        Filter(field_name="x", relation=Relation.INCLUDES, value=["2024-01-01T12:30:00Z"]),
+    )
+    create_date_or_datetime_filter(
+        col,
+        Filter(field_name="x", relation=Relation.INCLUDES, value=["2024-01-01T12:30:00+00:00"]),
+    )
 
     # now with microseconds
     now_with_microsecond = now.replace(microsecond=1)
-    create_datetime_filter(
+    create_date_or_datetime_filter(
         col,
         Filter(
             field_name="x",
@@ -707,23 +738,23 @@ def test_allowed_datetime_filter_validation():
         ),
     )
 
+    # Check strings with and without the time delimiter.
     midnight = "2024-01-01 00:00:00"
-    create_datetime_filter(
+    create_date_or_datetime_filter(
         col,
         Filter(field_name="x", relation=Relation.BETWEEN, value=[None, midnight]),
     )
 
     midnight_with_delim = "2024-01-01T00:00:00"
-    create_datetime_filter(
+    create_date_or_datetime_filter(
         col,
         Filter(field_name="x", relation=Relation.BETWEEN, value=[None, midnight_with_delim]),
     )
 
-    # bare dates are allowed
-    bare_date = "2024-01-01"
-    create_datetime_filter(
+    # Bare dates are allowed
+    create_date_or_datetime_filter(
         col,
-        Filter(field_name="x", relation=Relation.BETWEEN, value=[None, bare_date]),
+        Filter(field_name="x", relation=Relation.BETWEEN, value=["2024-01-01", "2024-12-31"]),
     )
 
 

--- a/src/xngin/apiserver/dwh/test_queries.py
+++ b/src/xngin/apiserver/dwh/test_queries.py
@@ -685,25 +685,6 @@ def test_allowed_datetime_filter_validation():
     )
 
 
-# TODO: move to api_types
-def test_boolean_filter_validation():
-    with pytest.raises(ValueError) as excinfo:
-        Filter(field_name="bool", relation=Relation.BETWEEN, value=[True, False])
-    assert "Values do not support BETWEEN." in str(excinfo.value)
-
-    with pytest.raises(ValueError) as excinfo:
-        Filter(field_name="bool", relation=Relation.INCLUDES, value=[True, True, True])
-    assert "Duplicate values" in str(excinfo.value)
-
-    with pytest.raises(ValueError) as excinfo:
-        Filter(field_name="bool", relation=Relation.INCLUDES, value=[True, False, None])
-    assert "allows all possible values" in str(excinfo.value)
-
-    with pytest.raises(ValueError) as excinfo:
-        Filter(field_name="bool", relation=Relation.EXCLUDES, value=[True, False, None])
-    assert "rejects all possible values" in str(excinfo.value)
-
-
 REGEX_TESTS = [
     ("", ["a"], False),
     ("a", [""], False),

--- a/src/xngin/apiserver/dwh/test_queries.py
+++ b/src/xngin/apiserver/dwh/test_queries.py
@@ -426,6 +426,48 @@ IS_NULLABLE_CASES = [
         ],
         matches=[ROW_10, ROW_30],
     ),
+    # verify BETWEEN
+    Case(
+        filters=[
+            Filter(field_name="float_col", relation=Relation.BETWEEN, value=[1, 3]),
+        ],
+        matches=[ROW_10, ROW_20],
+    ),
+    Case(
+        filters=[
+            Filter(field_name="float_col", relation=Relation.BETWEEN, value=[1, 3, None]),
+        ],
+        matches=[ROW_10, ROW_20, ROW_30],
+    ),
+    # >=
+    Case(
+        filters=[
+            Filter(field_name="float_col", relation=Relation.BETWEEN, value=[2, None, None]),
+        ],
+        matches=[ROW_20, ROW_30],
+    ),
+    # <=
+    Case(
+        filters=[
+            Filter(field_name="float_col", relation=Relation.BETWEEN, value=[None, 2, None]),
+        ],
+        matches=[ROW_10, ROW_30],
+    ),
+    # between datetimes
+    Case(
+        filters=[
+            Filter(
+                field_name="date_col",
+                relation=Relation.BETWEEN,
+                value=[
+                    ROW_10.date_col and ROW_10.date_col.isoformat(),
+                    ROW_20.date_col and ROW_20.date_col.isoformat(),
+                    None,
+                ],
+            ),
+        ],
+        matches=[ROW_10, ROW_20, ROW_30],
+    ),
 ]
 
 

--- a/src/xngin/apiserver/routers/common_api_types.py
+++ b/src/xngin/apiserver/routers/common_api_types.py
@@ -580,7 +580,7 @@ class Filter(ApiBaseModel):
 
     String comparisons are case-sensitive.
 
-    ## Special Handling for BETWEEN support of including null
+    ## Special Handling for BETWEEN support of including NULL
 
     When the relation is BETWEEN, we allow for up to 3 values to support the special case of
     including null in addition to the values in the between range via an OR IS NULL clause, as
@@ -601,9 +601,9 @@ class Filter(ApiBaseModel):
 
     Note: CSV field comparisons are case-insensitive.
 
-    ## Handling of datetime and timestamp values
+    ## Handling of DATE, DATETIME and TIMESTAMP values
 
-    DATETIME or TIMESTAMP-type columns support INCLUDES/EXCLUDES/BETWEEN, similar to numerics.
+    DATE, DATETIME or TIMESTAMP-type columns support INCLUDES/EXCLUDES/BETWEEN, similar to numerics.
 
     Values must be expressed as ISO8601 datetime strings compatible with Python's datetime.fromisoformat()
     (https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat).

--- a/src/xngin/apiserver/routers/test_common_api_types.py
+++ b/src/xngin/apiserver/routers/test_common_api_types.py
@@ -18,6 +18,24 @@ def test_valid_field_names(name):
     Filter(field_name=name, relation=Relation.INCLUDES, value=[1])
 
 
+def test_boolean_filter_validation():
+    with pytest.raises(ValueError) as excinfo:
+        Filter(field_name="bool", relation=Relation.BETWEEN, value=[True, False])
+    assert "Values do not support BETWEEN." in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        Filter(field_name="bool", relation=Relation.INCLUDES, value=[True, True, True])
+    assert "Duplicate values" in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        Filter(field_name="bool", relation=Relation.INCLUDES, value=[True, False, None])
+    assert "allows all possible values" in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        Filter(field_name="bool", relation=Relation.EXCLUDES, value=[True, False, None])
+    assert "rejects all possible values" in str(excinfo.value)
+
+
 INVALID_COLUMN_NAMES = [
     "123column",  # Can't start with number
     "column-name",  # No hyphens allowed

--- a/src/xngin/apiserver/routers/test_common_api_types.py
+++ b/src/xngin/apiserver/routers/test_common_api_types.py
@@ -63,6 +63,9 @@ VALID_BETWEEN = [
     ([None, 1], "with left None"),
     ([1.0, 2], "float and int"),  # pydantic coerces to [1.0, 2.0]
     ([1.5, 2.5], "floats again"),
+    ([1, 2, None], "between integers or None"),
+    ([1, None, None], "greater than integer or None"),
+    ([None, 1, None], "less than integer or None"),
 ]
 
 


### PR DESCRIPTION
## Description

Adds support for "include NULL" in the FE for the "between-like" relations, by allowing for a special 3rd value set to `None` to be included in the array that originally defined extents for between/gte/lte. This None value signals the inclusion of NULL values using an "OR _x_ IS NULL" clause. All other values in the 3rd position if present are invalid.

date-type support is fixed by piggy-backing on the logic used with datetime.

Also cleans up ordering and adds minor comments of some unittests.


## Future Tasks (optional)

The frontend needs updating:
* for numerics: BETWEEN / GREATER THAN / LESS THAN 
* for date & timestamp w/o tz: BETWEEN / BEFORE / AFTER

## How has this been tested?

unittests

## Checklist

Fill with `x` for completed.

- [x] I have updated the automated tests
- [x] I have updated affected documentation
- [x] I have updated the CI/CD scripts in `.github/workflows/`
