### PR TITLE
restrict encapsulation middleware to experiments api

### DIFF
--- a/src/xngin/apiserver/middleware.py
+++ b/src/xngin/apiserver/middleware.py
@@ -13,4 +13,4 @@ def setup(app):
         allow_origins=["*"],
         max_age=7200,  # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
     )
-    app.add_middleware(RequestEncapsulationMiddleware)
+    app.add_middleware(RequestEncapsulationMiddleware, path_prefix="/v1/experiments")


### PR DESCRIPTION
## Ticket
Fixes [issue 232](https://github.com/agency-fund/evidential-sprint/issues/232)

## Related PRs
Docs: [PR 30](https://github.com/agency-fund/evidential-docs/pull/30)

## Description
Restrict unwrapping parameters middleware only to integration (experiments API)


## How has this been tested?
Added a test for this

## Checklist

Fill with `x` for completed.

- [x] I have updated the automated tests
- [x] I have updated affected documentation
