### PR TITLE
pass DnsLookupError information onward to the frontend

### DIFF
--- a/src/xngin/apiserver/dns/safe_resolve.py
+++ b/src/xngin/apiserver/dns/safe_resolve.py
@@ -16,6 +16,10 @@ UNSAFE_IP_FOR_TESTING = "127.0.0.9"
 class DnsLookupError(Exception):
     """Raised when the DNS lookup of a customer-specified address failed."""
 
+    def __init__(self, host: str):
+        self.host = host
+        super().__init__(f"DNS issue with host: {host}")
+
 
 class DnsLookupUnsafeError(DnsLookupError):
     """Raised when the DNS lookup of a customer-specified address succeeded but the result was deemed unsafe."""
@@ -72,7 +76,7 @@ def safe_resolve(host: str):
         raise DnsLookupError(host)
     safe = is_safe_ipset(set(answers))
     if not safe:
-        raise DnsLookupUnsafeError(f"lookup({host}) => {answers}")
+        raise DnsLookupUnsafeError(f"{host} => {answers}")
     return answers.pop()
 
 

--- a/src/xngin/apiserver/exceptionhandlers.py
+++ b/src/xngin/apiserver/exceptionhandlers.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 
 from xngin.apiserver.apikeys import ApiKeyError
 from xngin.apiserver.dependencies import CannotFindDatasourceError
+from xngin.apiserver.dns.safe_resolve import DnsLookupError
 from xngin.apiserver.dwh.dwh_session import CannotFindTableError
 from xngin.apiserver.exceptions_common import DwhConnectionError, DwhDatabaseDoesNotExistError, LateValidationError
 from xngin.apiserver.routers.admin.admin_api_converters import (
@@ -83,3 +84,7 @@ def setup(app):
     @app.exception_handler(DwhDatabaseDoesNotExistError)
     async def exception_handler_dwhdatabasedoesnotexisterror(_request: Request, exc: DwhDatabaseDoesNotExistError):
         return JSONResponse(status_code=404, content={"message": str(exc)})
+
+    @app.exception_handler(DnsLookupError)
+    async def exception_handler_dnslookuperror(_request: Request, exc: DnsLookupError):
+        return JSONResponse(status_code=502, content={"message": str(exc)})


### PR DESCRIPTION
## Description

Add DnsLookupError to exceptionhandlers.py for the FE to handle more gracefully.

## How has this been tested?
Manually with `ALLOW_CONNECTING_TO_PRIVATE_IPS=0 task start` for live view of analysis, viewing a datasource, and viewing a participant type.

## Checklist

Fill with `x` for completed.

- [x] I have updated the automated tests
- [x] I have updated affected documentation
- [x] I have updated the CI/CD scripts in `.github/workflows/`
