### PR TITLE
Disable unused expensive min/max/distinct queries by default.

### DIFF
--- a/src/xngin/apiserver/routers/admin/admin_api.py
+++ b/src/xngin/apiserver/routers/admin/admin_api.py
@@ -1112,6 +1112,7 @@ async def inspect_participant_types(
     session: Annotated[AsyncSession, Depends(xngin_db_session)],
     user: Annotated[tables.User, Depends(require_user_from_token)],
     refresh: Annotated[bool, Query(description="Refresh the cache.")] = False,
+    expensive: Annotated[bool, Query(description="Whether to run expensive metadata queries.")] = False,
 ) -> InspectParticipantTypesResponse:
     """Returns filter, strata, and metric field metadata for a participant type, including exemplars for
     filter fields."""
@@ -1144,11 +1145,7 @@ async def inspect_participant_types(
         async with DwhSession(dsconfig.dwh) as dwh:
             result = await dwh.inspect_table_with_descriptors(pconfig.table_name, pconfig.get_unique_id_field())
             filter_data = await asyncio.to_thread(
-                get_stats_on_filters,
-                dwh.session,
-                result.sa_table,
-                result.db_schema,
-                filter_fields,
+                get_stats_on_filters, dwh.session, result.sa_table, result.db_schema, filter_fields, expensive
             )
 
         return InspectParticipantTypesResponse(


### PR DESCRIPTION
Disabling these queries because we don't use these values for anything worth their default cost.

Frontend: https://github.com/agency-fund/evidential-fe/pull/215