### PR TITLE
Restrict CORS allowed origins.

### DIFF
--- a/src/xngin/apiserver/flags.py
+++ b/src/xngin/apiserver/flags.py
@@ -61,6 +61,15 @@ XNGIN_SUPPORT_EMAIL = os.environ.get("XNGIN_SUPPORT_EMAIL", "support@example.com
 LOG_SQL_APP_DB = truthy_env("LOG_SQL_APP_DB")
 LOG_SQL_DWH = truthy_env("LOG_SQL_DWH")
 
+# CORS_ALLOWED_ORIGINS: comma-separated list of frontends permitted by the CORS policy.
+# In dev mode (ENVIRONMENT unset or "dev"), defaults to ["*"] for convenience.
+# In all other environments this must be set explicitly; the server will refuse to start without it.
+# Example: CORS_ALLOWED_ORIGINS=https://app.example.com,https://staging.example.com
+_cors_env = os.environ.get("CORS_ALLOWED_ORIGINS", "")
+CORS_ALLOWED_ORIGINS: list[str] = (
+    [o.strip() for o in _cors_env.split(",") if o.strip()] if _cors_env else (["*"] if is_dev_environment() else [])
+)
+
 
 def get_public_api_base_url():
     if serving_domain := os.environ.get("RAILWAY_PUBLIC_DOMAIN"):

--- a/src/xngin/apiserver/main.py
+++ b/src/xngin/apiserver/main.py
@@ -9,6 +9,7 @@ from xngin.apiserver import (
     customlogging,
     database,
     exceptionhandlers,
+    flags,
     middleware,
     routes,
 )
@@ -43,9 +44,15 @@ async def lifespan(_app: FastAPI):
             "credentials on behalf of end-user requests. "
             "Please unset GOOGLE_APPLICATION_CREDENTIALS and try again."
         )
-    else:
-        async with database.setup():
-            yield
+    if not flags.is_dev_environment() and not flags.CORS_ALLOWED_ORIGINS:
+        raise MisconfiguredError(
+            "CORS_ALLOWED_ORIGINS environment variable is not set. "
+            "In non-development environments this must be set to a comma-separated list of "
+            "allowed origins (e.g. https://frontend.example.com)."
+        )
+
+    async with database.setup():
+        yield
 
 
 app = FastAPI(

--- a/src/xngin/apiserver/middleware.py
+++ b/src/xngin/apiserver/middleware.py
@@ -1,6 +1,7 @@
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 
+from xngin.apiserver import flags
 from xngin.apiserver.request_encapsulation_middleware import RequestEncapsulationMiddleware
 
 
@@ -16,7 +17,7 @@ def setup(app):
         allow_credentials=False,
         allow_headers=["*"],
         allow_methods=["*"],
-        allow_origins=["*"],
+        allow_origins=flags.CORS_ALLOWED_ORIGINS,
         max_age=7200,  # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
     )
     app.add_middleware(RequestEncapsulationMiddleware, path_prefix="/v1/experiments")


### PR DESCRIPTION
The CORS policy previously used allow_origins=["*"], permitting any website
to make cross-origin requests to the API with arbitrary headers including
Authorization.

Behavior by environment:
- Dev (ENVIRONMENT unset or "dev"): defaults to ["*"] as before, so local
  development workflows are unaffected.
- Non-dev: CORS_ALLOWED_ORIGINS must be set explicitly. If it is missing or
  empty the server refuses to start, preventing accidental wildcard exposure
  in production due to a misconfigured deployment.
