### PR TITLE
Redact JWT error details from 401 HTTP responses

### DIFF
--- a/src/xngin/apiserver/routers/auth/auth_api.py
+++ b/src/xngin/apiserver/routers/auth/auth_api.py
@@ -112,9 +112,9 @@ def _validate_idtoken(oidc_config: GoogleOidcConfig, id_token: str) -> dict:
     try:
         header = jwt.get_unverified_header(id_token)
     except JWTError as e:
+        logger.warning(f"JWT header parsing failed: {e}")
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"Invalid authentication credentials: {e}",
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid authentication credentials"
         ) from e
     key = next((jwk for jwk in oidc_config.jwks["keys"] if jwk["kid"] == header["kid"]), None)
     if not key:
@@ -142,8 +142,8 @@ def _validate_idtoken(oidc_config: GoogleOidcConfig, id_token: str) -> dict:
         if decoded["azp"] != decoded["aud"]:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid azp/aud")
     except JWTError as e:
+        logger.warning(f"JWT validation failed: {e}")
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"Invalid authentication credentials: {e}",
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid authentication credentials"
         ) from e
     return decoded


### PR DESCRIPTION
Both JWTError catch blocks in _validate_idtoken() previously interpolated
the raw exception message into the HTTP response body:

  detail=f"Invalid authentication credentials: {e}"

The error strings may describe specific expectations about the failed
validations which can aid an attacker in crafting probes.

The fix logs the full error server-side (where it is useful for debugging)
and returns only the generic string "Invalid authentication credentials" to
the client. The cause is preserved on the exception chain (from e) so that
any framework-level error reporting still has the full context.
