### PR TITLE
Refuse to start with NoopProvider in non-dev envs.

### DIFF
--- a/src/xngin/cli/main.py
+++ b/src/xngin/cli/main.py
@@ -47,7 +47,7 @@ app.add_typer(snapshots_app, name="snapshots")
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s - %(message)s")
 
-secretservice.setup()
+secretservice.setup(allow_noop=True)
 
 async_command = lambda f: functools.wraps(f)(lambda *args, **kwargs: asyncio.run(f(*args, **kwargs)))  # noqa: E731
 
@@ -655,7 +655,6 @@ def decrypt(
     aad: Annotated[str, typer.Option(help="The AAD specified when the ciphertext was encrypted.")] = "cli",
 ):
     """Decrypts a string using the same encryption configuration that the API server does."""
-    secretservice.setup()
     ciphertext = sys.stdin.read()
     print(secretservice.get_symmetric().decrypt(ciphertext, aad))
 

--- a/src/xngin/xsecrets/secretservice.py
+++ b/src/xngin/xsecrets/secretservice.py
@@ -20,7 +20,7 @@ from xngin.xsecrets.provider import Registry
 _SERVICE: SecretService | None = None
 
 
-def setup():
+def setup(*, allow_noop: bool = False):
     """Configures a secrets service according to environment variables."""
     global _SERVICE
 
@@ -33,7 +33,7 @@ def setup():
 
     backend_spec = os.environ.get(ENV_XNGIN_SECRETS_BACKEND, noop_provider.NAME)
     if backend_spec == noop_provider.NAME:
-        if not flags.is_dev_environment():
+        if not flags.is_dev_environment() and not allow_noop:
             raise InvalidSecretStoreConfigurationError(
                 f"{ENV_XNGIN_SECRETS_BACKEND} is unset or set to '{noop_provider.NAME}', which stores secrets "
                 f"in plaintext. This is not allowed outside of development environments. "

--- a/src/xngin/xsecrets/secretservice.py
+++ b/src/xngin/xsecrets/secretservice.py
@@ -4,6 +4,7 @@ import os
 
 from loguru import logger
 
+from xngin.apiserver import flags
 from xngin.xsecrets import (
     gcp_kms_provider,
     nacl_provider,
@@ -32,6 +33,13 @@ def setup():
 
     backend_spec = os.environ.get(ENV_XNGIN_SECRETS_BACKEND, noop_provider.NAME)
     if backend_spec == noop_provider.NAME:
+        if not flags.is_dev_environment():
+            raise InvalidSecretStoreConfigurationError(
+                f"{ENV_XNGIN_SECRETS_BACKEND} is unset or set to '{noop_provider.NAME}', which stores secrets "
+                f"in plaintext. This is not allowed outside of development environments. "
+                f"Set {ENV_XNGIN_SECRETS_BACKEND} to a real encryption backend (e.g. '{nacl_provider.NAME}' "
+                f"or '{gcp_kms_provider.NAME}')."
+            )
         logger.warning(
             f"Secrets: Encryption is disabled because {ENV_XNGIN_SECRETS_BACKEND} is unset "
             f"or set to {noop_provider.NAME}."


### PR DESCRIPTION
The fix raises InvalidSecretStoreConfigurationError at startup when the noop
backend is selected outside of a development environment (ENVIRONMENT unset
or "dev"). This is the same pattern used for CORS_ALLOWED_ORIGINS and
GOOGLE_APPLICATION_CREDENTIALS: non-negotiable startup checks for
configuration that would silently undermine security if misconfigured.

In development the behavior is unchanged: a warning is logged and the server
starts normally.
