### PR TITLE
fix: validate webhook hostnames when creating/updating/using them

### DIFF
--- a/src/xngin/apiserver/dns/safe_resolve.py
+++ b/src/xngin/apiserver/dns/safe_resolve.py
@@ -2,7 +2,7 @@ import ipaddress
 import socket
 from sys import platform
 
-import dns.resolver
+from dns.exception import DNSException
 from dns.resolver import resolve
 
 from xngin.apiserver.flags import ALLOW_CONNECTING_TO_PRIVATE_IPS
@@ -37,7 +37,7 @@ def lookup_v4(host: str) -> list[str] | None:
     try:
         dns_answer = resolve(host, "A", lifetime=DNS_TIMEOUT_SECS)
         return [r.to_text() for r in dns_answer]
-    except dns.exception.DNSException:
+    except DNSException:
         return None
 
 
@@ -63,7 +63,10 @@ def is_safe_ipset(ips: set[str]):
     return all(is_safe_ip(address) for address in ips)
 
 
-def safe_resolve(host: str):
+def safe_resolve(host: str | None):
+    if not host:
+        raise DnsLookupError("Missing hostname.")
+
     if host == UNSAFE_IP_FOR_TESTING:
         raise DnsLookupError("Detected sentinel value of invalid IP used for testing purposes.")
 
@@ -76,7 +79,7 @@ def safe_resolve(host: str):
         raise DnsLookupError(host)
     safe = is_safe_ipset(set(answers))
     if not safe:
-        raise DnsLookupUnsafeError(f"{host} => {answers}")
+        raise DnsLookupUnsafeError(host)
     return answers.pop()
 
 

--- a/src/xngin/apiserver/routers/admin/admin_api_types.py
+++ b/src/xngin/apiserver/routers/admin/admin_api_types.py
@@ -7,7 +7,9 @@ from annotated_types import Ge, Le
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from xngin.apiserver.common_field_types import FieldName
+from xngin.apiserver.dns.safe_resolve import DnsLookupError, safe_resolve
 from xngin.apiserver.dwh.inspection_types import FieldDescriptor, ParticipantsSchema
+from xngin.apiserver.exceptions_common import LateValidationError
 from xngin.apiserver.limits import (
     MAX_LENGTH_OF_DESCRIPTION_VALUE,
     MAX_LENGTH_OF_EMAIL_VALUE,
@@ -36,9 +38,13 @@ def validate_webhook_url(url: str) -> str:
     """Validates that a URL is a properly formatted HTTP or HTTPS URL."""
     parsed = urlparse(url)
     if not parsed.scheme or parsed.scheme not in {"http", "https"}:
-        raise ValueError("URL must use http or https scheme")
+        raise LateValidationError("URL must use http or https scheme")
     if not parsed.netloc:
-        raise ValueError("URL must include a valid domain")
+        raise LateValidationError("URL must include a valid domain")
+    try:
+        safe_resolve(parsed.hostname)
+    except DnsLookupError as e:
+        raise LateValidationError(f"URL hostname failed safety validation: {parsed.hostname}") from e
     return url
 
 

--- a/src/xngin/apiserver/routers/admin/admin_api_types.py
+++ b/src/xngin/apiserver/routers/admin/admin_api_types.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from xngin.apiserver.common_field_types import FieldName
 from xngin.apiserver.dns.safe_resolve import DnsLookupError, safe_resolve
 from xngin.apiserver.dwh.inspection_types import FieldDescriptor, ParticipantsSchema
-from xngin.apiserver.exceptions_common import LateValidationError
 from xngin.apiserver.limits import (
     MAX_LENGTH_OF_DESCRIPTION_VALUE,
     MAX_LENGTH_OF_EMAIL_VALUE,
@@ -38,13 +37,13 @@ def validate_webhook_url(url: str) -> str:
     """Validates that a URL is a properly formatted HTTP or HTTPS URL."""
     parsed = urlparse(url)
     if not parsed.scheme or parsed.scheme not in {"http", "https"}:
-        raise LateValidationError("URL must use http or https scheme")
+        raise ValueError("URL must use http or https scheme")
     if not parsed.netloc:
-        raise LateValidationError("URL must include a valid domain")
+        raise ValueError("URL must include a valid domain")
     try:
         safe_resolve(parsed.hostname)
     except DnsLookupError as e:
-        raise LateValidationError(f"URL hostname failed safety validation: {parsed.hostname}") from e
+        raise ValueError(f"Failed to resolve hostname from webhook URL: {parsed.hostname}") from e
     return url
 
 

--- a/src/xngin/apiserver/routers/admin/test_admin.py
+++ b/src/xngin/apiserver/routers/admin/test_admin.py
@@ -982,7 +982,7 @@ async def test_webhook_lifecycle(aclient: AdminAPIClient):
     assert webhooks[0].auth_token is not None
 
     # Update the webhook URL
-    new_url = "https://updated-example.com/webhook"
+    new_url = "https://example.com/updated_webhook"
     new_name = "new name"
     aclient.update_organization_webhook(
         organization_id=org_id, webhook_id=webhook_id, body=UpdateOrganizationWebhookRequest(url=new_url, name=new_name)
@@ -1017,12 +1017,48 @@ async def test_webhook_lifecycle(aclient: AdminAPIClient):
         aclient.update_organization_webhook(
             organization_id=org_id,
             webhook_id=webhook_id,
-            body=UpdateOrganizationWebhookRequest(url="https://should-fail.com/webhook", name="fail"),
+            body=UpdateOrganizationWebhookRequest.model_construct(url="https://example.com/should-fail", name="fail"),
         )
 
     # Try to delete a non-existent webhook
     with expect_status_code(404):
         aclient.delete_webhook_from_organization(organization_id=org_id, webhook_id=webhook_id)
+
+
+def test_create_webhook_rejects_ssrf_url(aclient: AdminAPIClient):
+    """Creating a webhook with an internal/unsafe hostname is rejected."""
+    org_id = aclient.create_organizations(body=CreateOrganizationRequest(name="add_webhook_rejects_ssrf")).data.id
+    with expect_status_code(422, detail_contains="URL hostname failed safety validation"):
+        aclient.add_webhook_to_organization(
+            organization_id=org_id,
+            body=AddWebhookToOrganizationRequest.model_construct(
+                type="experiment.created",
+                url=f"http://{safe_resolve.UNSAFE_IP_FOR_TESTING}/steal-creds",
+                name="ssrf attempt",
+            ),
+        )
+
+
+def test_update_webhook_rejects_ssrf_url(aclient: AdminAPIClient):
+    """Updating a webhook to point at an internal/unsafe hostname is rejected."""
+    org_id = aclient.create_organizations(body=CreateOrganizationRequest(name="update_webhook_rejects_ssrf")).data.id
+    webhook_id = aclient.add_webhook_to_organization(
+        organization_id=org_id,
+        body=AddWebhookToOrganizationRequest(
+            type="experiment.created",
+            url="http://8.8.8.8/webhook",
+            name="safe webhook",
+        ),
+    ).data.id
+    with expect_status_code(422, detail_contains="URL hostname failed safety validation"):
+        aclient.update_organization_webhook(
+            organization_id=org_id,
+            webhook_id=webhook_id,
+            body=UpdateOrganizationWebhookRequest.model_construct(
+                url=f"http://{safe_resolve.UNSAFE_IP_FOR_TESTING}/steal-creds",
+                name="ssrf attempt",
+            ),
+        )
 
 
 def test_participants_lifecycle(testing_datasource, aclient: AdminAPIClient):

--- a/src/xngin/apiserver/routers/admin/test_admin.py
+++ b/src/xngin/apiserver/routers/admin/test_admin.py
@@ -1028,7 +1028,7 @@ async def test_webhook_lifecycle(aclient: AdminAPIClient):
 def test_create_webhook_rejects_ssrf_url(aclient: AdminAPIClient):
     """Creating a webhook with an internal/unsafe hostname is rejected."""
     org_id = aclient.create_organizations(body=CreateOrganizationRequest(name="add_webhook_rejects_ssrf")).data.id
-    with expect_status_code(422, detail_contains="URL hostname failed safety validation"):
+    with expect_status_code(422, detail_contains="Failed to resolve hostname from webhook URL"):
         aclient.add_webhook_to_organization(
             organization_id=org_id,
             body=AddWebhookToOrganizationRequest.model_construct(
@@ -1050,7 +1050,7 @@ def test_update_webhook_rejects_ssrf_url(aclient: AdminAPIClient):
             name="safe webhook",
         ),
     ).data.id
-    with expect_status_code(422, detail_contains="URL hostname failed safety validation"):
+    with expect_status_code(422, detail_contains="Failed to resolve hostname from webhook URL"):
         aclient.update_organization_webhook(
             organization_id=org_id,
             webhook_id=webhook_id,

--- a/src/xngin/tq/conftest.py
+++ b/src/xngin/tq/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+from sqlalchemy import make_url
+
+from xngin.apiserver import database
+
+
+@pytest.fixture
+def tq_dsn() -> str:
+    """Converts a SQLAlchemy DSN to a Psycopg-compatible DSN."""
+    url = make_url(database.get_sqlalchemy_database_url()).set(drivername="postgresql")
+    return url.render_as_string(hide_password=False)

--- a/src/xngin/tq/handlers.py
+++ b/src/xngin/tq/handlers.py
@@ -1,6 +1,6 @@
 """Task handlers for the task queue."""
 
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 import httpx
 import sqlalchemy
@@ -13,6 +13,24 @@ from xngin.apiserver.sqla import tables
 from xngin.events.webhook_sent import WebhookSentEvent
 from xngin.tq.task_payload_types import WebhookOutboundTask
 from xngin.tq.task_queue import TQ_DB_APPLICATION_NAME, Task
+
+
+def _record_webhook_sent_event(
+    session: Session,
+    request: WebhookOutboundTask,
+    *,
+    success: bool,
+    response_summary: str,
+    log_exc_message: str | None = None,
+) -> None:
+    if log_exc_message is not None:
+        logger.exception(log_exc_message)
+    session.add(
+        tables.Event(
+            organization_id=request.organization_id,
+            type=WebhookSentEvent.TYPE,
+        ).set_data(WebhookSentEvent(request=request, success=success, response=response_summary))
+    )
 
 
 def make_webhook_outbound_handler(dsn: str):
@@ -37,56 +55,73 @@ def make_webhook_outbound_handler(dsn: str):
         request = WebhookOutboundTask.model_validate(task.payload)
         logger.info(f"Processing {request}")
 
-        parsed_url = urlparse(request.url)
-        try:
-            safe_resolve(parsed_url.hostname)
-        except DnsLookupError as e:
-            logger.warning(f"Webhook URL failed safety check at delivery time: {request.url} ({e})")
-            raise
+        parsed = urlparse(request.url)
 
         with Session(engine) as session:
             try:
-                response = httpx.request(
-                    request.method,
-                    request.url,
-                    json=request.body,
-                    timeout=10.0,
-                    headers=request.headers,
-                )
+                scheme = parsed.scheme
+                hostname = parsed.hostname
+                safe_ip = safe_resolve(hostname)
+                assert hostname is not None  # safe_resolve() checks this but mypy doesn't know that
+                port = parsed.port
+
+                ip_host = f"[{safe_ip}]" if ":" in safe_ip else safe_ip
+                ip_host_port = f"{ip_host}:{port}" if port else ip_host
+                connect_url = urlunparse((
+                    scheme,
+                    ip_host_port,
+                    parsed.path or "/",
+                    parsed.params,
+                    parsed.query,
+                    parsed.fragment,
+                ))
+
+                host_header = f"{hostname}:{port}" if port else hostname
+                outbound_headers = {**request.headers, "Host": host_header}
+
+                extensions = {"sni_hostname": hostname} if scheme == "https" else None
+
+                response: httpx.Response | None = None
+                with httpx.Client(timeout=10.0) as client:
+                    response = client.request(
+                        request.method,
+                        connect_url,
+                        json=request.body,
+                        headers=outbound_headers,
+                        extensions=extensions,
+                    )
 
                 if 200 <= response.status_code < 300:
                     logger.info(f"Successfully sent event data to {request.url}: {response.status_code}")
                     if response.content:
                         logger.debug(f"Response has content: {response.text}")
-                    session.add(
-                        tables.Event(
-                            organization_id=request.organization_id,
-                            type=WebhookSentEvent.TYPE,
-                        ).set_data(
-                            WebhookSentEvent(
-                                request=request,
-                                success=True,
-                                response=f"{response.status_code}",
-                            )
-                        )
+                    _record_webhook_sent_event(
+                        session,
+                        request,
+                        success=True,
+                        response_summary=f"{response.status_code}",
                     )
                 else:
                     logger.info(f"Outbound webhook failed with status {response.status_code}")
                     response.raise_for_status()
+            except DnsLookupError as err:
+                message = f"Failed to resolve hostname from webhook URL: ({err!s})"
+                _record_webhook_sent_event(
+                    session,
+                    request,
+                    success=False,
+                    response_summary=message,
+                    log_exc_message=message,
+                )
+                raise
             except httpx.HTTPError as err:
-                logger.exception("Outbound webhook failed")
-                message = f"status={response.status_code} message={err!s}" if "response" in locals() else str(err)
-                session.add(
-                    tables.Event(
-                        organization_id=request.organization_id,
-                        type=WebhookSentEvent.TYPE,
-                    ).set_data(
-                        WebhookSentEvent(
-                            request=request,
-                            success=False,
-                            response=message,
-                        )
-                    )
+                message = f"status={response.status_code} message={err!s}" if response else str(err)
+                _record_webhook_sent_event(
+                    session,
+                    request,
+                    success=False,
+                    response_summary=message,
+                    log_exc_message="Outbound webhook failed",
                 )
                 raise
             finally:

--- a/src/xngin/tq/handlers.py
+++ b/src/xngin/tq/handlers.py
@@ -1,11 +1,14 @@
 """Task handlers for the task queue."""
 
+from urllib.parse import urlparse
+
 import httpx
 import sqlalchemy
 from loguru import logger
 from sqlalchemy import NullPool
 from sqlalchemy.orm import Session
 
+from xngin.apiserver.dns.safe_resolve import DnsLookupError, safe_resolve
 from xngin.apiserver.sqla import tables
 from xngin.events.webhook_sent import WebhookSentEvent
 from xngin.tq.task_payload_types import WebhookOutboundTask
@@ -33,6 +36,13 @@ def make_webhook_outbound_handler(dsn: str):
 
         request = WebhookOutboundTask.model_validate(task.payload)
         logger.info(f"Processing {request}")
+
+        parsed_url = urlparse(request.url)
+        try:
+            safe_resolve(parsed_url.hostname)
+        except DnsLookupError as e:
+            logger.warning(f"Webhook URL failed safety check at delivery time: {request.url} ({e})")
+            raise
 
         with Session(engine) as session:
             try:

--- a/src/xngin/tq/handlers.py
+++ b/src/xngin/tq/handlers.py
@@ -67,11 +67,13 @@ def make_webhook_outbound_handler(dsn: str, *, transport: httpx.BaseTransport | 
                 assert hostname is not None  # safe_resolve() checks this but mypy doesn't know that
                 port = parsed.port
 
-                ip_host = f"[{safe_ip}]" if ":" in safe_ip else safe_ip
-                ip_host_port = f"{ip_host}:{port}" if port else ip_host
+                ip_host_port = f"{safe_ip}:{port}" if port else safe_ip
+                # Retain any credentials in the reconstruction e.g. user:pw if they were provided
+                userinfo = parsed.netloc.rsplit("@", 1)[0] if "@" in parsed.netloc else None
+                authority = f"{userinfo}@{ip_host_port}" if userinfo else ip_host_port
                 connect_url = urlunparse((
                     scheme,
-                    ip_host_port,
+                    authority,
                     parsed.path or "/",
                     parsed.params,
                     parsed.query,

--- a/src/xngin/tq/handlers.py
+++ b/src/xngin/tq/handlers.py
@@ -33,11 +33,13 @@ def _record_webhook_sent_event(
     )
 
 
-def make_webhook_outbound_handler(dsn: str):
+def make_webhook_outbound_handler(dsn: str, *, transport: httpx.BaseTransport | None = None):
     """Returns a webhook outbound handler bound with the DSN via a SQLAlchemy engine.
 
     Also creates an entry in the Event table with information that will be useful for
     customers when debugging.
+
+    ``transport`` is forwarded to ``httpx.Client`` and exists primarily for testing.
     """
     engine = sqlalchemy.create_engine(
         dsn, connect_args={"application_name": TQ_DB_APPLICATION_NAME}, poolclass=NullPool
@@ -82,7 +84,7 @@ def make_webhook_outbound_handler(dsn: str):
                 extensions = {"sni_hostname": hostname} if scheme == "https" else None
 
                 response: httpx.Response | None = None
-                with httpx.Client(timeout=10.0) as client:
+                with httpx.Client(timeout=10.0, transport=transport) as client:
                     response = client.request(
                         request.method,
                         connect_url,

--- a/src/xngin/tq/test_handlers.py
+++ b/src/xngin/tq/test_handlers.py
@@ -86,3 +86,43 @@ async def test_webhook_outbound_handler_records_success_event(
     assert isinstance(event_data, WebhookSentEvent)
     assert event_data.success is True
     assert event_data.response == "200"
+
+
+async def test_webhook_outbound_handler_preserves_url_credentials(xngin_session: AsyncSession, tq_dsn: str):
+    org = tables.Organization(name="test-org")
+    xngin_session.add(org)
+    await xngin_session.commit()
+    await xngin_session.refresh(org)
+
+    captured_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(200, request=request)
+
+    task_queue = TaskQueue(dsn=tq_dsn, max_retries=0, poll_interval_secs=1)
+    task_queue.register_handler(
+        WEBHOOK_OUTBOUND_TASK_TYPE,
+        make_webhook_outbound_handler(tq_dsn, transport=httpx.MockTransport(handler)),
+    )
+    with tq_runner(task_queue):
+        task = await insert_task(
+            xngin_session,
+            task_type=WEBHOOK_OUTBOUND_TASK_TYPE,
+            payload={
+                "url": "http://infra:password@localhost:8000/hook",
+                "organization_id": org.id,
+            },
+        )
+        success_task = await wait_for_task_status(task.id, "success")
+
+    assert success_task.message is None
+    assert len(captured_requests) == 1
+    request = captured_requests[0]
+    assert request.url.host == "127.0.0.1"
+    assert request.url.port == 8000
+    assert request.headers["host"] == "localhost:8000"
+    assert request.url.username == "infra"
+    assert request.url.password == "password"
+    # Credentials in the URL are emitted as a Basic auth header by httpx
+    assert request.headers["authorization"] == "Basic aW5mcmE6cGFzc3dvcmQ="

--- a/src/xngin/tq/test_handlers.py
+++ b/src/xngin/tq/test_handlers.py
@@ -1,5 +1,4 @@
 import httpx
-import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -54,21 +53,15 @@ async def test_webhook_outbound_handler_records_dns_failure_event(
 async def test_webhook_outbound_handler_records_success_event(
     xngin_session: AsyncSession,
     tq_dsn: str,
-    monkeypatch: pytest.MonkeyPatch,
 ):
     org = tables.Organization(name="test-org")
     xngin_session.add(org)
     await xngin_session.commit()
     await xngin_session.refresh(org)
 
-    fake_response = httpx.Response(
-        200,
-        request=httpx.Request("POST", "http://203.0.113.1/hook"),
-    )
-    monkeypatch.setattr(httpx.Client, "request", lambda *_args, **_kwargs: fake_response)
-
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, request=request))
     task_queue = TaskQueue(dsn=tq_dsn, max_retries=0, poll_interval_secs=1)
-    task_queue.register_handler(WEBHOOK_OUTBOUND_TASK_TYPE, make_webhook_outbound_handler(tq_dsn))
+    task_queue.register_handler(WEBHOOK_OUTBOUND_TASK_TYPE, make_webhook_outbound_handler(tq_dsn, transport=transport))
     with tq_runner(task_queue):
         task = await insert_task(
             xngin_session,

--- a/src/xngin/tq/test_handlers.py
+++ b/src/xngin/tq/test_handlers.py
@@ -1,10 +1,9 @@
 import httpx
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from xngin.apiserver.dns import safe_resolve
-from xngin.apiserver.sqla import tables
-from xngin.events.webhook_sent import WebhookSentEvent
+from xngin.apiserver.routers.admin.admin_api_types import CreateOrganizationRequest
+from xngin.apiserver.testing.admin_api_client import AdminAPIClient
 from xngin.tq.handlers import make_webhook_outbound_handler
 from xngin.tq.task_payload_types import WEBHOOK_OUTBOUND_TASK_TYPE
 from xngin.tq.task_queue import TaskQueue
@@ -13,14 +12,16 @@ from xngin.tq.tq_test_support import insert_task, tq_runner, wait_for_task_statu
 pytest_plugins = ("xngin.apiserver.conftest",)
 
 
+def _create_organization(aclient: AdminAPIClient, name: str) -> str:
+    return aclient.create_organizations(body=CreateOrganizationRequest(name=name)).data.id
+
+
 async def test_webhook_outbound_handler_records_dns_failure_event(
+    aclient: AdminAPIClient,
     xngin_session: AsyncSession,
     tq_dsn: str,
 ):
-    org = tables.Organization(name="test-org")
-    xngin_session.add(org)
-    await xngin_session.commit()
-    await xngin_session.refresh(org)
+    org_id = _create_organization(aclient, "test-webhook-dns-failure")
 
     task_queue = TaskQueue(dsn=tq_dsn, max_retries=0, poll_interval_secs=1)
     task_queue.register_handler(WEBHOOK_OUTBOUND_TASK_TYPE, make_webhook_outbound_handler(tq_dsn))
@@ -30,34 +31,29 @@ async def test_webhook_outbound_handler_records_dns_failure_event(
             task_type=WEBHOOK_OUTBOUND_TASK_TYPE,
             payload={
                 "url": f"http://{safe_resolve.UNSAFE_IP_FOR_TESTING}/hook",
-                "organization_id": org.id,
+                "organization_id": org_id,
             },
         )
         dead_task = await wait_for_task_status(task.id, "dead")
 
     assert dead_task.message == "DNS issue with host: Detected sentinel value of invalid IP used for testing purposes."
 
-    events = (
-        (await xngin_session.execute(select(tables.Event).where(tables.Event.organization_id == org.id)))
-        .scalars()
-        .all()
-    )
+    events = aclient.list_organization_events(organization_id=org_id).data.items
 
     assert len(events) == 1
-    event_data = events[0].get_data()
-    assert isinstance(event_data, WebhookSentEvent)
-    assert event_data.success is False
-    assert "Failed to resolve hostname" in event_data.response
+    event = events[0]
+    assert event.type == "webhook.sent"
+    assert event.details is not None
+    assert event.details["success"] is False
+    assert "Failed to resolve hostname" in event.details["response"]
 
 
 async def test_webhook_outbound_handler_records_success_event(
+    aclient: AdminAPIClient,
     xngin_session: AsyncSession,
     tq_dsn: str,
 ):
-    org = tables.Organization(name="test-org")
-    xngin_session.add(org)
-    await xngin_session.commit()
-    await xngin_session.refresh(org)
+    org_id = _create_organization(aclient, "test-webhook-success")
 
     transport = httpx.MockTransport(lambda request: httpx.Response(200, request=request))
     task_queue = TaskQueue(dsn=tq_dsn, max_retries=0, poll_interval_secs=1)
@@ -68,31 +64,29 @@ async def test_webhook_outbound_handler_records_success_event(
             task_type=WEBHOOK_OUTBOUND_TASK_TYPE,
             payload={
                 "url": "http://203.0.113.1/hook",
-                "organization_id": org.id,
+                "organization_id": org_id,
             },
         )
         success_task = await wait_for_task_status(task.id, "success")
 
     assert success_task.message is None
 
-    events = (
-        (await xngin_session.execute(select(tables.Event).where(tables.Event.organization_id == org.id)))
-        .scalars()
-        .all()
-    )
+    events = aclient.list_organization_events(organization_id=org_id).data.items
 
     assert len(events) == 1
-    event_data = events[0].get_data()
-    assert isinstance(event_data, WebhookSentEvent)
-    assert event_data.success is True
-    assert event_data.response == "200"
+    event = events[0]
+    assert event.type == "webhook.sent"
+    assert event.details is not None
+    assert event.details["success"] is True
+    assert event.details["response"] == "200"
 
 
-async def test_webhook_outbound_handler_preserves_url_credentials(xngin_session: AsyncSession, tq_dsn: str):
-    org = tables.Organization(name="test-org")
-    xngin_session.add(org)
-    await xngin_session.commit()
-    await xngin_session.refresh(org)
+async def test_webhook_outbound_handler_preserves_url_credentials(
+    aclient: AdminAPIClient,
+    xngin_session: AsyncSession,
+    tq_dsn: str,
+):
+    org_id = _create_organization(aclient, "test-webhook-url-credentials")
 
     captured_requests: list[httpx.Request] = []
 
@@ -111,7 +105,7 @@ async def test_webhook_outbound_handler_preserves_url_credentials(xngin_session:
             task_type=WEBHOOK_OUTBOUND_TASK_TYPE,
             payload={
                 "url": "http://infra:password@localhost:8000/hook",
-                "organization_id": org.id,
+                "organization_id": org_id,
             },
         )
         success_task = await wait_for_task_status(task.id, "success")

--- a/src/xngin/tq/test_handlers.py
+++ b/src/xngin/tq/test_handlers.py
@@ -1,0 +1,95 @@
+import httpx
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from xngin.apiserver.dns import safe_resolve
+from xngin.apiserver.sqla import tables
+from xngin.events.webhook_sent import WebhookSentEvent
+from xngin.tq.handlers import make_webhook_outbound_handler
+from xngin.tq.task_payload_types import WEBHOOK_OUTBOUND_TASK_TYPE
+from xngin.tq.task_queue import TaskQueue
+from xngin.tq.tq_test_support import insert_task, tq_runner, wait_for_task_status
+
+pytest_plugins = ("xngin.apiserver.conftest",)
+
+
+async def test_webhook_outbound_handler_records_dns_failure_event(
+    xngin_session: AsyncSession,
+    tq_dsn: str,
+):
+    org = tables.Organization(name="test-org")
+    xngin_session.add(org)
+    await xngin_session.commit()
+    await xngin_session.refresh(org)
+
+    task_queue = TaskQueue(dsn=tq_dsn, max_retries=0, poll_interval_secs=1)
+    task_queue.register_handler(WEBHOOK_OUTBOUND_TASK_TYPE, make_webhook_outbound_handler(tq_dsn))
+    with tq_runner(task_queue):
+        task = await insert_task(
+            xngin_session,
+            task_type=WEBHOOK_OUTBOUND_TASK_TYPE,
+            payload={
+                "url": f"http://{safe_resolve.UNSAFE_IP_FOR_TESTING}/hook",
+                "organization_id": org.id,
+            },
+        )
+        dead_task = await wait_for_task_status(task.id, "dead")
+
+    assert dead_task.message == "DNS issue with host: Detected sentinel value of invalid IP used for testing purposes."
+
+    events = (
+        (await xngin_session.execute(select(tables.Event).where(tables.Event.organization_id == org.id)))
+        .scalars()
+        .all()
+    )
+
+    assert len(events) == 1
+    event_data = events[0].get_data()
+    assert isinstance(event_data, WebhookSentEvent)
+    assert event_data.success is False
+    assert "Failed to resolve hostname" in event_data.response
+
+
+async def test_webhook_outbound_handler_records_success_event(
+    xngin_session: AsyncSession,
+    tq_dsn: str,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    org = tables.Organization(name="test-org")
+    xngin_session.add(org)
+    await xngin_session.commit()
+    await xngin_session.refresh(org)
+
+    fake_response = httpx.Response(
+        200,
+        request=httpx.Request("POST", "http://203.0.113.1/hook"),
+    )
+    monkeypatch.setattr(httpx.Client, "request", lambda *_args, **_kwargs: fake_response)
+
+    task_queue = TaskQueue(dsn=tq_dsn, max_retries=0, poll_interval_secs=1)
+    task_queue.register_handler(WEBHOOK_OUTBOUND_TASK_TYPE, make_webhook_outbound_handler(tq_dsn))
+    with tq_runner(task_queue):
+        task = await insert_task(
+            xngin_session,
+            task_type=WEBHOOK_OUTBOUND_TASK_TYPE,
+            payload={
+                "url": "http://203.0.113.1/hook",
+                "organization_id": org.id,
+            },
+        )
+        success_task = await wait_for_task_status(task.id, "success")
+
+    assert success_task.message is None
+
+    events = (
+        (await xngin_session.execute(select(tables.Event).where(tables.Event.organization_id == org.id)))
+        .scalars()
+        .all()
+    )
+
+    assert len(events) == 1
+    event_data = events[0].get_data()
+    assert isinstance(event_data, WebhookSentEvent)
+    assert event_data.success is True
+    assert event_data.response == "200"

--- a/src/xngin/tq/test_tq.py
+++ b/src/xngin/tq/test_tq.py
@@ -6,14 +6,19 @@ from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from datetime import timedelta
 
+import httpx
 import psycopg
 import pytest
-from sqlalchemy import make_url
+from sqlalchemy import make_url, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from xngin.apiserver import database
+from xngin.apiserver.dns import safe_resolve
 from xngin.apiserver.sqla import tables
+from xngin.events.webhook_sent import WebhookSentEvent
 from xngin.tq import task_queue as task_queue_module
+from xngin.tq.handlers import make_webhook_outbound_handler
+from xngin.tq.task_payload_types import WEBHOOK_OUTBOUND_TASK_TYPE
 from xngin.tq.task_queue import Task, TaskQueue
 
 pytest_plugins = ("xngin.apiserver.conftest",)
@@ -191,3 +196,87 @@ def test_task_queue_retries_after_operational_error(monkeypatch: pytest.MonkeyPa
     task_queue.run(cancel=cancel)
 
     assert sleep_calls == [5]
+
+
+async def test_webhook_outbound_handler_records_dns_failure_event(
+    xngin_session: AsyncSession,
+    tq_dsn: str,
+):
+    # First add a valid organization to later associate with the db Event record
+    org = tables.Organization(name="test-org")
+    xngin_session.add(org)
+    await xngin_session.commit()
+    await xngin_session.refresh(org)
+
+    # Then insert a task that should fail due to the unsafe IP
+    task_queue = TaskQueue(dsn=tq_dsn, max_retries=0, poll_interval_secs=1)
+    task_queue.register_handler(WEBHOOK_OUTBOUND_TASK_TYPE, make_webhook_outbound_handler(tq_dsn))
+    with tq_runner(task_queue):
+        task = await insert_task(
+            xngin_session,
+            task_type=WEBHOOK_OUTBOUND_TASK_TYPE,
+            payload={
+                "url": f"http://{safe_resolve.UNSAFE_IP_FOR_TESTING}/hook",
+                "organization_id": org.id,
+            },
+        )
+        dead_task = await wait_for_task_status(task.id, "dead")
+
+    assert dead_task.message == "DNS issue with host: Detected sentinel value of invalid IP used for testing purposes."
+
+    # Lastly assert that the db has the correct event record
+    events = (
+        (await xngin_session.execute(select(tables.Event).where(tables.Event.organization_id == org.id)))
+        .scalars()
+        .all()
+    )
+
+    assert len(events) == 1
+    event_data = events[0].get_data()
+    assert isinstance(event_data, WebhookSentEvent)
+    assert event_data.success is False
+    assert "Failed to resolve hostname" in event_data.response
+
+
+async def test_webhook_outbound_handler_records_success_event(
+    xngin_session: AsyncSession,
+    tq_dsn: str,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    org = tables.Organization(name="test-org")
+    xngin_session.add(org)
+    await xngin_session.commit()
+    await xngin_session.refresh(org)
+
+    fake_response = httpx.Response(
+        200,
+        request=httpx.Request("POST", "http://localhost/hook"),
+    )
+    monkeypatch.setattr(httpx.Client, "request", lambda *_args, **_kwargs: fake_response)
+
+    task_queue = TaskQueue(dsn=tq_dsn, max_retries=0, poll_interval_secs=1)
+    task_queue.register_handler(WEBHOOK_OUTBOUND_TASK_TYPE, make_webhook_outbound_handler(tq_dsn))
+    with tq_runner(task_queue):
+        task = await insert_task(
+            xngin_session,
+            task_type=WEBHOOK_OUTBOUND_TASK_TYPE,
+            payload={
+                "url": "http://localhost/hook",
+                "organization_id": org.id,
+            },
+        )
+        success_task = await wait_for_task_status(task.id, "success")
+
+    assert success_task.message is None
+
+    events = (
+        (await xngin_session.execute(select(tables.Event).where(tables.Event.organization_id == org.id)))
+        .scalars()
+        .all()
+    )
+
+    assert len(events) == 1
+    event_data = events[0].get_data()
+    assert isinstance(event_data, WebhookSentEvent)
+    assert event_data.success is True
+    assert event_data.response == "200"

--- a/src/xngin/tq/test_tq.py
+++ b/src/xngin/tq/test_tq.py
@@ -1,107 +1,16 @@
-import asyncio
 import queue
 import threading
-import time
-from collections.abc import Callable, Generator
-from contextlib import contextmanager
 from datetime import timedelta
 
-import httpx
 import psycopg
 import pytest
-from sqlalchemy import make_url, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from xngin.apiserver import database
-from xngin.apiserver.dns import safe_resolve
-from xngin.apiserver.sqla import tables
-from xngin.events.webhook_sent import WebhookSentEvent
 from xngin.tq import task_queue as task_queue_module
-from xngin.tq.handlers import make_webhook_outbound_handler
-from xngin.tq.task_payload_types import WEBHOOK_OUTBOUND_TASK_TYPE
 from xngin.tq.task_queue import Task, TaskQueue
+from xngin.tq.tq_test_support import insert_task, tq_runner, wait_for_task_status
 
 pytest_plugins = ("xngin.apiserver.conftest",)
-
-STATUS_TIMEOUT_SECS = 5.0
-
-
-def start_task_queue_in_thread(
-    task_queue: TaskQueue, cancel: threading.Event
-) -> tuple[threading.Thread, queue.SimpleQueue[BaseException]]:
-    """Starts a TaskQueue in a new thread."""
-    error_collector: queue.SimpleQueue[BaseException] = queue.SimpleQueue()
-
-    def run_task_queue() -> None:
-        try:
-            task_queue.run(cancel=cancel)
-        except BaseException as exc:
-            error_collector.put(exc)
-
-    thread = threading.Thread(target=run_task_queue, name="test-task-queue")
-    thread.start()
-    return thread, error_collector
-
-
-async def wait_for_task_status(
-    task_id: str,
-    expected_status: str,
-    *,
-    predicate: Callable[[tables.Task], bool] | None = None,
-) -> tables.Task:
-    """Polls for a specific task reaching a certain status within STATUS_TIMEOUT_SECS."""
-    deadline = time.monotonic() + STATUS_TIMEOUT_SECS
-    latest_task: tables.Task | None = None
-    while time.monotonic() < deadline:
-        async with database.async_session() as session:
-            latest_task = await session.get(tables.Task, task_id)
-        if (
-            latest_task is not None
-            and latest_task.status == expected_status
-            and (predicate is None or predicate(latest_task))
-        ):
-            return latest_task
-        await asyncio.sleep(0.10)
-    raise AssertionError(
-        f"Task {task_id} did not reach status {expected_status!r} before timeout. Last observed task: {latest_task!r}"
-    )
-
-
-async def insert_task(
-    xngin_session: AsyncSession,
-    *,
-    task_type: str,
-    payload: dict | None = None,
-) -> tables.Task:
-    """Inserts a task using SQLAlchemy."""
-    task = tables.Task(task_type=task_type, payload=payload)
-    xngin_session.add(task)
-    await xngin_session.commit()
-    await xngin_session.refresh(task)
-    return task
-
-
-@pytest.fixture
-def tq_dsn() -> str:
-    """Converts a SQLAlchemy DSN to a Psycopg-compatible DSN."""
-    url = make_url(database.get_sqlalchemy_database_url()).set(drivername="postgresql")
-    return url.render_as_string(hide_password=False)
-
-
-@contextmanager
-def tq_runner(queue_instance: TaskQueue) -> Generator[None]:
-    """Context manager for running a TaskQueue in a thread with graceful shutdown."""
-    cancel = threading.Event()
-    thread, error_collector = start_task_queue_in_thread(queue_instance, cancel)
-    try:
-        yield
-    finally:
-        cancel.set()
-        thread.join(timeout=3)
-        if thread.is_alive():
-            raise AssertionError("TaskQueue thread did not stop within timeout")
-        if not error_collector.empty():
-            raise AssertionError(f"TaskQueue thread raised an exception: {error_collector.get()!r}")
 
 
 async def test_task_queue_processes_pending_task_successfully(xngin_session: AsyncSession, tq_dsn: str):
@@ -196,87 +105,3 @@ def test_task_queue_retries_after_operational_error(monkeypatch: pytest.MonkeyPa
     task_queue.run(cancel=cancel)
 
     assert sleep_calls == [5]
-
-
-async def test_webhook_outbound_handler_records_dns_failure_event(
-    xngin_session: AsyncSession,
-    tq_dsn: str,
-):
-    # First add a valid organization to later associate with the db Event record
-    org = tables.Organization(name="test-org")
-    xngin_session.add(org)
-    await xngin_session.commit()
-    await xngin_session.refresh(org)
-
-    # Then insert a task that should fail due to the unsafe IP
-    task_queue = TaskQueue(dsn=tq_dsn, max_retries=0, poll_interval_secs=1)
-    task_queue.register_handler(WEBHOOK_OUTBOUND_TASK_TYPE, make_webhook_outbound_handler(tq_dsn))
-    with tq_runner(task_queue):
-        task = await insert_task(
-            xngin_session,
-            task_type=WEBHOOK_OUTBOUND_TASK_TYPE,
-            payload={
-                "url": f"http://{safe_resolve.UNSAFE_IP_FOR_TESTING}/hook",
-                "organization_id": org.id,
-            },
-        )
-        dead_task = await wait_for_task_status(task.id, "dead")
-
-    assert dead_task.message == "DNS issue with host: Detected sentinel value of invalid IP used for testing purposes."
-
-    # Lastly assert that the db has the correct event record
-    events = (
-        (await xngin_session.execute(select(tables.Event).where(tables.Event.organization_id == org.id)))
-        .scalars()
-        .all()
-    )
-
-    assert len(events) == 1
-    event_data = events[0].get_data()
-    assert isinstance(event_data, WebhookSentEvent)
-    assert event_data.success is False
-    assert "Failed to resolve hostname" in event_data.response
-
-
-async def test_webhook_outbound_handler_records_success_event(
-    xngin_session: AsyncSession,
-    tq_dsn: str,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    org = tables.Organization(name="test-org")
-    xngin_session.add(org)
-    await xngin_session.commit()
-    await xngin_session.refresh(org)
-
-    fake_response = httpx.Response(
-        200,
-        request=httpx.Request("POST", "http://localhost/hook"),
-    )
-    monkeypatch.setattr(httpx.Client, "request", lambda *_args, **_kwargs: fake_response)
-
-    task_queue = TaskQueue(dsn=tq_dsn, max_retries=0, poll_interval_secs=1)
-    task_queue.register_handler(WEBHOOK_OUTBOUND_TASK_TYPE, make_webhook_outbound_handler(tq_dsn))
-    with tq_runner(task_queue):
-        task = await insert_task(
-            xngin_session,
-            task_type=WEBHOOK_OUTBOUND_TASK_TYPE,
-            payload={
-                "url": "http://localhost/hook",
-                "organization_id": org.id,
-            },
-        )
-        success_task = await wait_for_task_status(task.id, "success")
-
-    assert success_task.message is None
-
-    events = (
-        (await xngin_session.execute(select(tables.Event).where(tables.Event.organization_id == org.id)))
-        .scalars()
-        .all()
-    )
-
-    assert len(events) == 1
-    event_data = events[0].get_data()
-    assert isinstance(event_data, WebhookSentEvent)
-    assert event_data.success is True
-    assert event_data.response == "200"

--- a/src/xngin/tq/tq_test_support.py
+++ b/src/xngin/tq/tq_test_support.py
@@ -1,0 +1,87 @@
+"""Shared test helpers for the tq package."""
+
+import asyncio
+import queue
+import threading
+import time
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from xngin.apiserver import database
+from xngin.apiserver.sqla import tables
+from xngin.tq.task_queue import TaskQueue
+
+STATUS_TIMEOUT_SECS = 5.0
+
+
+def start_task_queue_in_thread(
+    task_queue: TaskQueue, cancel: threading.Event
+) -> tuple[threading.Thread, queue.SimpleQueue[BaseException]]:
+    """Starts a TaskQueue in a new thread."""
+    error_collector: queue.SimpleQueue[BaseException] = queue.SimpleQueue()
+
+    def run_task_queue() -> None:
+        try:
+            task_queue.run(cancel=cancel)
+        except BaseException as exc:
+            error_collector.put(exc)
+
+    thread = threading.Thread(target=run_task_queue, name="test-task-queue")
+    thread.start()
+    return thread, error_collector
+
+
+@contextmanager
+def tq_runner(queue_instance: TaskQueue) -> Generator[None]:
+    """Context manager for running a TaskQueue in a thread with graceful shutdown."""
+    cancel = threading.Event()
+    thread, error_collector = start_task_queue_in_thread(queue_instance, cancel)
+    try:
+        yield
+    finally:
+        cancel.set()
+        thread.join(timeout=3)
+        if thread.is_alive():
+            raise AssertionError("TaskQueue thread did not stop within timeout")
+        if not error_collector.empty():
+            raise AssertionError(f"TaskQueue thread raised an exception: {error_collector.get()!r}")
+
+
+async def wait_for_task_status(
+    task_id: str,
+    expected_status: str,
+    *,
+    predicate: Callable[[tables.Task], bool] | None = None,
+) -> tables.Task:
+    """Polls for a specific task reaching a certain status within STATUS_TIMEOUT_SECS."""
+    deadline = time.monotonic() + STATUS_TIMEOUT_SECS
+    latest_task: tables.Task | None = None
+    while time.monotonic() < deadline:
+        async with database.async_session() as session:
+            latest_task = await session.get(tables.Task, task_id)
+        if (
+            latest_task is not None
+            and latest_task.status == expected_status
+            and (predicate is None or predicate(latest_task))
+        ):
+            return latest_task
+        await asyncio.sleep(0.10)
+    raise AssertionError(
+        f"Task {task_id} did not reach status {expected_status!r} before timeout. Last observed task: {latest_task!r}"
+    )
+
+
+async def insert_task(
+    xngin_session: AsyncSession,
+    *,
+    task_type: str,
+    payload: dict | None = None,
+) -> tables.Task:
+    """Inserts a task using SQLAlchemy."""
+    task = tables.Task(task_type=task_type, payload=payload)
+    xngin_session.add(task)
+    await xngin_session.commit()
+    await xngin_session.refresh(task)
+    return task


### PR DESCRIPTION
Prevents possible SSRF risk by having admin_api_types.py::validate_webhook_url() also check if the hostname resolves to a safe IP address, and similarly do that check every time we use the webhook to deliver events. Updates existing tests accordingly and adds 2 more to verify we're raising the expected LateValidationError when the hostname fails the safety check.