### PR TITLE
Remove experiment IDs hack.

### DIFF
--- a/src/xngin/apiserver/dwh/query_constructors.py
+++ b/src/xngin/apiserver/dwh/query_constructors.py
@@ -1,11 +1,10 @@
-import re
 from collections.abc import Sequence
 from datetime import date, datetime
 
 import sqlalchemy
-from sqlalchemy import ColumnElement, Table, and_, func, not_, or_, select
+from sqlalchemy import ColumnElement, Table, and_, or_, select
 
-from xngin.apiserver.routers.common_api_types import EXPERIMENT_IDS_SUFFIX, Filter, FilterValueTypes
+from xngin.apiserver.routers.common_api_types import Filter, FilterValueTypes
 from xngin.apiserver.routers.common_enums import DataType, Relation
 from xngin.apiserver.routers.experiments.property_filters import validate_filter_value
 from xngin.db_extensions import custom_functions
@@ -13,40 +12,12 @@ from xngin.db_extensions import custom_functions
 
 def create_one_filter(filter_: Filter, sa_table: sqlalchemy.Table):
     """Converts a Filter into a SQLAlchemy filter."""
-    if filter_.field_name.endswith(EXPERIMENT_IDS_SUFFIX):
-        return create_special_experiment_id_filter(sa_table.columns[filter_.field_name], filter_)
     return create_filter(sa_table.columns[filter_.field_name], filter_)
 
 
 def create_query_filters(sa_table: sqlalchemy.Table, filters: list[Filter]):
     """Converts a list of Filter into a list of SQLAlchemy filters."""
     return [create_one_filter(filter_, sa_table) for filter_ in filters]
-
-
-def create_special_experiment_id_filter(col: sqlalchemy.Column, filter_: Filter) -> ColumnElement:
-    matching_regex = make_csv_regex(filter_.value)
-    match filter_.relation:
-        case Relation.INCLUDES:
-            return func.lower(col).regexp_match(matching_regex)
-        case Relation.EXCLUDES:
-            return or_(
-                col.is_(None),
-                func.char_length(col) == 0,
-                not_(func.lower(col).regexp_match(matching_regex)),
-            )
-        case Relation.BETWEEN:
-            # This should be impossible as it's caught by the Filter validator:
-            raise ValueError(f"Experiment id filter on {filter_.field_name} has invalid relation: {filter_.relation}")
-
-
-def make_csv_regex(values):
-    """Constructs a regular expression for matching a CSV string against a list of values.
-
-    The generated regexp is to be used by re.search() or equivalent. We assume that most database engines
-    will support identical syntax.
-    """
-    value_regexp = r"(" + r"|".join(re.escape(str(v).lower()) for v in values if v is not None) + r")"
-    return r"(^x$)|(^x,)|(,x$)|(,x,)".replace("x", value_regexp)
 
 
 def general_excludes_filter(

--- a/src/xngin/apiserver/dwh/test_dialect_sql.py
+++ b/src/xngin/apiserver/dwh/test_dialect_sql.py
@@ -325,56 +325,6 @@ WHERE_TESTCASES = [
             ),
         },
     ),
-    # experiment_ids inclusion/exclusion tests
-    WhereTestCase(
-        filters=[
-            Filter(field_name="int_col", relation=Relation.INCLUDES, value=[42, -17]),
-            Filter(field_name="experiment_ids", relation=Relation.INCLUDES, value=["b", "C"]),
-        ],
-        where={
-            DbType.BQ: (
-                "`tt`.`int_col` IN (42, -17) AND "
-                "REGEXP_CONTAINS(lower(`tt`.`experiment_ids`), '(^(b|c)$)|(^(b|c),)|(,(b|c)$)|(,(b|c),)') "
-                "ORDER BY rand() LIMIT 3"
-            ),
-            DbType.PG: (
-                "tt.int_col IN (42, -17) AND "
-                "lower(tt.experiment_ids) ~ '(^(b|c)$)|(^(b|c),)|(,(b|c)$)|(,(b|c),)' "
-                "ORDER BY random()  LIMIT 3"
-            ),
-            DbType.RS: (
-                "tt.int_col IN (42, -17) AND "
-                "lower(tt.experiment_ids) ~ '(^(b|c)$)|(^(b|c),)|(,(b|c)$)|(,(b|c),)' "
-                "ORDER BY random()  LIMIT 3"
-            ),
-        },
-    ),
-    WhereTestCase(
-        filters=[
-            Filter(field_name="int_col", relation=Relation.INCLUDES, value=[42, -17]),
-            Filter(field_name="experiment_ids", relation=Relation.EXCLUDES, value=["b", "c"]),
-        ],
-        where={
-            DbType.BQ: (
-                "`tt`.`int_col` IN (42, -17) AND "
-                "(`tt`.`experiment_ids` IS NULL OR char_length(`tt`.`experiment_ids`) = 0 OR "
-                "NOT REGEXP_CONTAINS(lower(`tt`.`experiment_ids`), '(^(b|c)$)|(^(b|c),)|(,(b|c)$)|(,(b|c),)')) "
-                "ORDER BY rand() LIMIT 3"
-            ),
-            DbType.PG: (
-                "tt.int_col IN (42, -17) AND "
-                "(tt.experiment_ids IS NULL OR char_length(tt.experiment_ids) = 0 OR "
-                "lower(tt.experiment_ids) !~ '(^(b|c)$)|(^(b|c),)|(,(b|c)$)|(,(b|c),)') "
-                "ORDER BY random()  LIMIT 3"
-            ),
-            DbType.RS: (
-                "tt.int_col IN (42, -17) AND "
-                "(tt.experiment_ids IS NULL OR char_length(tt.experiment_ids) = 0 OR "
-                "lower(tt.experiment_ids) !~ '(^(b|c)$)|(^(b|c),)|(,(b|c)$)|(,(b|c),)') "
-                "ORDER BY random()  LIMIT 3"
-            ),
-        },
-    ),
     # BETWEEN tests, without and with NULL
     WhereTestCase(
         filters=[Filter(field_name="int_col", relation=Relation.BETWEEN, value=[-17, 42])],

--- a/src/xngin/apiserver/dwh/test_query_constructors.py
+++ b/src/xngin/apiserver/dwh/test_query_constructors.py
@@ -1,6 +1,5 @@
 """Stand-alone test cases for basic dynamic query generation."""
 
-import re
 from datetime import UTC, datetime
 from typing import Any
 
@@ -20,7 +19,7 @@ from xngin.apiserver.dwh.dwh_test_support import (
     Case,
     SampleTable,
 )
-from xngin.apiserver.dwh.query_constructors import compose_query, create_filter, create_query_filters, make_csv_regex
+from xngin.apiserver.dwh.query_constructors import compose_query, create_filter, create_query_filters
 from xngin.apiserver.exceptions_common import LateValidationError
 from xngin.apiserver.routers.common_api_types import Filter, Relation
 from xngin.apiserver.routers.common_enums import DataType
@@ -296,37 +295,6 @@ def test_is_nullable(testcase, queries_dwh_session, shared_sample_tables):
 
 
 RELATION_CASES = [
-    # compound filters
-    Case(
-        filters=[
-            Filter(
-                field_name="int_col",
-                relation=Relation.INCLUDES,
-                value=[ROW_100.int_col, ROW_200.int_col],
-            ),
-            Filter(
-                field_name="experiment_ids",
-                relation=Relation.INCLUDES,
-                value=["b", "C"],
-            ),
-        ],
-        matches=[ROW_200],
-    ),
-    Case(
-        filters=[
-            Filter(
-                field_name="int_col",
-                relation=Relation.INCLUDES,
-                value=[ROW_100.int_col, ROW_200.int_col],
-            ),
-            Filter(
-                field_name="experiment_ids",
-                relation=Relation.EXCLUDES,
-                value=["b", "c"],
-            ),
-        ],
-        matches=[ROW_100],
-    ),
     # int_col
     Case(
         filters=[
@@ -367,55 +335,6 @@ RELATION_CASES = [
             )
         ],
         matches=[ROW_100, ROW_300],
-    ),
-    # regexp hacks
-    Case(
-        filters=[Filter(field_name="experiment_ids", relation=Relation.INCLUDES, value=["a"])],
-        matches=[ROW_100, ROW_200, ROW_300],
-    ),
-    Case(
-        filters=[Filter(field_name="experiment_ids", relation=Relation.INCLUDES, value=["B"])],
-        matches=[ROW_200, ROW_300],
-    ),
-    Case(
-        filters=[Filter(field_name="experiment_ids", relation=Relation.INCLUDES, value=["c"])],
-        matches=[ROW_300],
-    ),
-    Case(
-        filters=[Filter(field_name="experiment_ids", relation=Relation.EXCLUDES, value=["a"])],
-        matches=[],
-    ),
-    Case(
-        filters=[Filter(field_name="experiment_ids", relation=Relation.EXCLUDES, value=["D"])],
-        matches=[ROW_100, ROW_200, ROW_300],
-    ),
-    Case(
-        filters=[
-            Filter(
-                field_name="experiment_ids",
-                relation=Relation.INCLUDES,
-                value=["a", "d"],
-            )
-        ],
-        matches=[ROW_100, ROW_200, ROW_300],
-    ),
-    Case(
-        filters=[
-            Filter(
-                field_name="experiment_ids",
-                relation=Relation.EXCLUDES,
-                value=["a", "d"],
-            )
-        ],
-        matches=[],
-    ),
-    Case(
-        filters=[Filter(field_name="experiment_ids", relation=Relation.INCLUDES, value=["d"])],
-        matches=[],
-    ),
-    Case(
-        filters=[Filter(field_name="experiment_ids", relation=Relation.EXCLUDES, value=["d"])],
-        matches=[ROW_100, ROW_200, ROW_300],
     ),
 ]
 
@@ -623,32 +542,4 @@ def test_allowed_date_or_datetime_filter_validation(column_type):
     create_filter(
         col,
         Filter(field_name="x", relation=Relation.BETWEEN, value=["2024-01-01", "2024-12-31"]),
-    )
-
-
-REGEX_TESTS = [
-    ("", ["a"], False),
-    ("a", [""], False),
-    ("a", ["a"], True),
-    ("a,b", ["a"], True),
-    ("b,a", ["a"], True),
-    ("b,a", ["a", "b"], True),
-    ("b,a", ["b", "a"], True),
-    ("b,a", ["b", ""], True),
-    ("c,a,b,d", ["a"], True),
-]
-
-
-@pytest.mark.parametrize("csv,values,expected", REGEX_TESTS)
-def test_make_csv_regex(csv, values, expected):
-    """Tests for the regular expression, generated in isolation of the database stack.
-
-    Null-, empty string, and negative cases are special and handled in SQL elsewhere.
-    """
-    r = make_csv_regex(values)
-    matches = re.search(r, csv)
-    actual = matches is not None
-    assert actual == expected, (
-        f'Expression {r} is expected to {"match" if expected else "not match"} in "{csv}". '
-        f"Values = {values}. Matches = {matches}."
     )

--- a/src/xngin/apiserver/routers/common_api_types.py
+++ b/src/xngin/apiserver/routers/common_api_types.py
@@ -699,9 +699,6 @@ class GetMetricsResponseElement(ApiBaseModel):
     description: Annotated[str, Field(max_length=MAX_LENGTH_OF_DESCRIPTION_VALUE)]
 
 
-EXPERIMENT_IDS_SUFFIX = "experiment_ids"
-
-
 class Filter(ApiBaseModel):
     """Defines criteria for filtering rows by value.
 
@@ -729,21 +726,6 @@ class Filter(ApiBaseModel):
     When the relation is BETWEEN, we allow for up to 3 values to support the special case of
     including null in addition to the values in the between range via an OR IS NULL clause, as
     indicated by a 3rd value of None. Any other 3rd value is invalid.
-
-    ## Special Handling for Comma-Separated Fields
-
-    When the filter name ends in "experiment_ids", the filter is interpreted as follows:
-
-    | Value | Filter         | Result   |
-    |-------|----------------|----------|
-    | "a,b" | INCLUDES ["a"] | Match    |
-    | "a,b" | INCLUDES ["d"] | No match |
-    | "a,b" | EXCLUDES ["d"] | Match    |
-    | "a,b" | EXCLUDES ["b"] | No match |
-
-    Note: The BETWEEN relation is not supported for comma-separated values.
-
-    Note: CSV field comparisons are case-insensitive.
 
     ## Handling of DATE, DATETIME and TIMESTAMP values
 
@@ -773,25 +755,6 @@ class Filter(ApiBaseModel):
         if isinstance(column_type, sqlalchemy.sql.sqltypes.UUID | sqlalchemy.sql.sqltypes.String):
             return pid
         raise LateValidationError(f"Unsupported participant ID type: {column_type}")
-
-    @model_validator(mode="after")
-    def ensure_experiment_ids_hack_compatible(self) -> Filter:
-        """Ensures that the filter is compatible with the "experiment_ids" hack."""
-        if not self.field_name.endswith(EXPERIMENT_IDS_SUFFIX):
-            return self
-        allowed_relations = (Relation.INCLUDES, Relation.EXCLUDES)
-        if self.relation not in allowed_relations:
-            raise ValueError(
-                f"filters on experiment_id fields must have relations of type {', '.join(sorted(allowed_relations))}"
-            )
-        for v in self.value:
-            if not isinstance(v, str):
-                continue
-            if "," in v:
-                raise ValueError("values in an experiment_id filter may not contain commas")
-            if v.strip() != v:
-                raise ValueError("values in an experiment_id filter may not contain leading or trailing whitespace")
-        return self
 
     @model_validator(mode="after")
     def ensure_value(self) -> Filter:

--- a/src/xngin/apiserver/routers/common_enums.py
+++ b/src/xngin/apiserver/routers/common_enums.py
@@ -219,15 +219,12 @@ class Relation(enum.StrEnum):
     """Defines operators for filtering values.
 
     INCLUDES matches when the value matches any of the provided values, including null if explicitly
-    specified. For CSV fields (i.e. experiment_ids), any value in the CSV that matches the provided
-    values will match, but nulls are unsupported. This is equivalent to NOT(EXCLUDES(values)).
+    specified. This is equivalent to NOT(EXCLUDES(values)).
 
     EXCLUDES matches when the value does not match any of the provided values, including null if
-    explicitly specified. If null is not explicitly excluded, we include nulls in the result.  CSV
-    fields (i.e. experiment_ids), the match will fail if any of the provided values are present
-    in the value, but nulls are unsupported.
+    explicitly specified. If null is not explicitly excluded, we include nulls in the result.
 
-    BETWEEN matches when the value is between the two provided values (inclusive). Not allowed for CSV fields.
+    BETWEEN matches when the value is between the two provided values (inclusive).
     """
 
     INCLUDES = "includes"

--- a/src/xngin/apiserver/routers/test_common_api_types.py
+++ b/src/xngin/apiserver/routers/test_common_api_types.py
@@ -124,31 +124,6 @@ def test_empty_value_list():
             Filter(field_name="col", relation=relation, value=[])
 
 
-EXPERIMENT_IDS_FILTER_BAD = [
-    (Relation.BETWEEN, ["a", "b"], "must have relations of type excludes, includes"),
-    (Relation.INCLUDES, ["a,b", "b"], "commas"),
-    (Relation.INCLUDES, [" a", "b"], "whitespace"),
-]
-
-
-@pytest.mark.parametrize("relation,value,descr", EXPERIMENT_IDS_FILTER_BAD)
-def test_experiment_ids_hack_validators_invalid(relation, value, descr):
-    with pytest.raises(ValidationError, match=descr):
-        print(Filter(field_name="_experiment_ids", relation=relation, value=value))
-
-
-EXPERIMENT_IDS_FILTER_GOOD = [
-    (Relation.INCLUDES, ["ab", "b"], "strings"),
-    (Relation.INCLUDES, ["ab", None], "None"),
-    (Relation.EXCLUDES, ["a"], "mixed"),
-]
-
-
-@pytest.mark.parametrize("relation,value,descr", EXPERIMENT_IDS_FILTER_GOOD)
-def test_experiment_ids_hack_validators_valid(relation, value, descr):
-    Filter(field_name="_experiment_ids", relation=relation, value=value)
-
-
 def test_arm_weights_validation():
     """Test validation of arm_weights in BaseFrequentistDesignSpec"""
     # Test: weights sum to 100 and match number of arms


### PR DESCRIPTION
## Summary
Removes the unused special-case handling for fields named experiment_ids.

## What changed
- removed the experiment_ids filter validator and related docs
- removed the SQL regex special case for experiment_ids
- removed tests that only covered the hack

## Validation
- task test -- src/xngin/apiserver/routers/test_common_api_types.py
- task test -- src/xngin/apiserver/dwh/test_query_constructors.py
- task test -- src/xngin/apiserver/dwh/test_dialect_sql.py
