### PR TITLE
get_assignments 1M support and a bugfix in get_assignment_cmab

### DIFF
--- a/src/xngin/apiserver/routers/admin/admin_api.py
+++ b/src/xngin/apiserver/routers/admin/admin_api.py
@@ -1666,9 +1666,9 @@ async def analyze_cmab_experiment(
             f"retrieve an experiment analysis."
         )
 
-    context_inputs = body.context_inputs
-    context_defns = experiment.contexts
-    sorted_context_inputs = sort_contexts_by_id_or_raise(context_defns, context_inputs)
+    if body.context_inputs is None:
+        raise LateValidationError("context_inputs must be provided when analyzing a CMAB experiment.")
+    sorted_context_inputs = sort_contexts_by_id_or_raise(experiment.contexts, body.context_inputs)
 
     return experiments_common.analyze_experiment_bandit_impl(
         experiment, context_vals=[ci.context_value for ci in sorted_context_inputs]

--- a/src/xngin/apiserver/routers/admin/test_admin.py
+++ b/src/xngin/apiserver/routers/admin/test_admin.py
@@ -1638,6 +1638,9 @@ async def test_create_and_get_freq_preassigned_experiment(
     assert parsed_experiment_id is not None
     parsed_arm_ids = {arm.arm_id for arm in created_experiment.design_spec.arms}
     assert len(parsed_arm_ids) == 2
+    assert isinstance(created_experiment.design_spec, PreassignedFrequentistExperimentSpec)
+    assert len(created_experiment.design_spec.strata) == 1, created_experiment.design_spec.strata
+    assert created_experiment.design_spec.strata[0].field_name == "gender"
 
     # Verify basic response
     assert created_experiment.stopped_assignments_at is not None
@@ -1683,6 +1686,21 @@ async def test_create_and_get_freq_preassigned_experiment(
         ignore_type_in_groups=[(CreateExperimentResponse, GetExperimentResponse)],
     )
     assert not diff, f"Objects differ:\n{diff.pretty()}"
+    # Verify that participant field metadata was stored correctly.
+    experiment_fields = admin_experiment.participant_type.fields
+    assert len(experiment_fields) == 3
+    unique_id_field = next((f for f in experiment_fields if f.is_unique_id), None)
+    assert unique_id_field is not None
+    assert unique_id_field.data_type == "bigint"
+    gender_field = next((f for f in experiment_fields if f.field_name == "gender"), None)
+    assert gender_field is not None
+    assert gender_field.is_strata
+    assert gender_field.data_type == "character varying"
+    is_onboarded_field = next((f for f in experiment_fields if f.field_name == "is_onboarded"), None)
+    assert is_onboarded_field is not None
+    assert is_onboarded_field.is_metric
+    assert is_onboarded_field.is_strata is False
+    assert is_onboarded_field.data_type == "boolean"
 
     # Verify assignments were created
     actual_assignments = eclient.get_experiment_assignments(
@@ -1693,9 +1711,9 @@ async def test_create_and_get_freq_preassigned_experiment(
     # Check one assignment to see if it looks roughly right
     sample_assignment = actual_assignments.assignments[0]
     assert sample_assignment.arm_id in {arm1_id, arm2_id}
-    assert sample_assignment.strata is not None and len(sample_assignment.strata) == 2
-    for stratum in sample_assignment.strata:
-        assert stratum.field_name in {"is_onboarded", "gender"}
+    assert sample_assignment.strata is not None
+    assert len(sample_assignment.strata) == 1
+    assert sample_assignment.strata[0].field_name == "gender"
 
     # Check for approximate balance in arm assignment
     num_control = sum(1 for a in actual_assignments.assignments if a.arm_id == arm1_id)

--- a/src/xngin/apiserver/routers/common_api_types.py
+++ b/src/xngin/apiserver/routers/common_api_types.py
@@ -3,7 +3,7 @@ import json
 import math
 import uuid
 from collections.abc import Sequence
-from typing import Annotated, Literal, Self, TypedDict
+from typing import Annotated, Literal, NotRequired, Self, TypedDict
 
 import sqlalchemy.sql
 from annotated_types import MaxLen, MinLen
@@ -1147,7 +1147,10 @@ class PowerResponse(ApiBaseModel):
 
 
 class StrataTypedDict(TypedDict):
-    """Strata as a TypedDict to avoid Pydantic model work on hot paths."""
+    """Strata as a TypedDict to avoid Pydantic model work on hot paths.
+
+    TypedDict provides some type safety without a runtime cost.
+    """
 
     field_name: str
     strata_value: str | None
@@ -1161,6 +1164,22 @@ class Strata(ApiBaseModel):
     # from data warehouse.
     # strata_type: Optional[StrataType]
     strata_value: str | None = None
+
+
+class AssignmentTypedDict(TypedDict):
+    """Assignment as a TypedDict to avoid Pydantic model work on hot paths.
+
+    TypedDict provides some type safety without a runtime cost.
+    """
+
+    arm_id: str
+    participant_id: str
+    arm_name: str
+    created_at: NotRequired[str | None]
+    strata: NotRequired[list[StrataTypedDict] | None]
+    observed_at: NotRequired[str | None]
+    outcome: NotRequired[float | None]
+    context_values: NotRequired[list[float] | None]
 
 
 class Assignment(ApiBaseModel):

--- a/src/xngin/apiserver/routers/common_api_types.py
+++ b/src/xngin/apiserver/routers/common_api_types.py
@@ -240,7 +240,7 @@ class CMABContextInputRequest(ApiBaseModel):
         "cmab_assignment"  # Adding type field to allow for type-discriminated unions in future
     )
     context_inputs: Annotated[
-        list[ContextInput],
+        list[ContextInput] | None,
         Field(
             description="""
             List of context values for the assignment.

--- a/src/xngin/apiserver/routers/experiments/dependencies.py
+++ b/src/xngin/apiserver/routers/experiments/dependencies.py
@@ -187,6 +187,4 @@ experiment_response_dependency = ExperimentDependency(
 )
 
 # This version is used with processing assignments, e.g. exporting them.
-experiment_with_assignments_dependency = ExperimentDependency(
-    preload=[tables.Experiment.draws],
-)
+experiment_with_assignments_dependency = ExperimentDependency(preload=[tables.Experiment.draws])

--- a/src/xngin/apiserver/routers/experiments/dependencies.py
+++ b/src/xngin/apiserver/routers/experiments/dependencies.py
@@ -185,6 +185,3 @@ experiment_response_dependency = ExperimentDependency(
         ],
     ],
 )
-
-# This version is used with processing assignments, e.g. exporting them.
-experiment_with_assignments_dependency = ExperimentDependency(preload=[tables.Experiment.draws])

--- a/src/xngin/apiserver/routers/experiments/dependencies.py
+++ b/src/xngin/apiserver/routers/experiments/dependencies.py
@@ -188,5 +188,5 @@ experiment_response_dependency = ExperimentDependency(
 
 # This version is used with processing assignments, e.g. exporting them.
 experiment_with_assignments_dependency = ExperimentDependency(
-    preload=[tables.Experiment.arm_assignments, tables.Experiment.draws],
+    preload=[tables.Experiment.draws],
 )

--- a/src/xngin/apiserver/routers/experiments/experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_api.py
@@ -64,7 +64,7 @@ from xngin.apiserver.settings import Datasource
 from xngin.apiserver.sqla import tables
 from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter
 
-JSON_STREAM_ROWS_PER_YIELD = 1024
+JSON_STREAM_ROWS_PER_YIELD = 1_000
 
 
 @asynccontextmanager
@@ -303,7 +303,7 @@ async def get_assignment_filtered(
     description="""
     Get or create a CMAB arm assignment for a specific participant. This endpoint is used only for CMAB assignments.
     If there is a pre-existing assignment for a given participant ID, the context inputs in the
-    CreateCMABAssignmentRequest can be None, and will be disregarded if they are not None.
+    CMABContextInputRequest can be None, and will be disregarded if they are not None.
     """,
 )
 async def get_assignment_cmab(
@@ -341,6 +341,8 @@ async def get_assignment_cmab(
 
     if not assignment and create_if_none and experiment.stopped_assignments_at is None:
         context_inputs = body.context_inputs
+        if context_inputs is None:
+            raise LateValidationError("context_inputs must be provided when creating a new CMAB assignment.")
         context_defns = experiment.contexts
         sorted_context_inputs = sort_contexts_by_id_or_raise(context_defns, context_inputs)
         sorted_context_vals = [ctx.context_value for ctx in sorted_context_inputs]

--- a/src/xngin/apiserver/routers/experiments/experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_api.py
@@ -3,10 +3,12 @@ This module defines the public API for clients to integrate with experiments.
 (See admin_api.py for Evidential UI-facing endpoints.)
 """
 
+from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import timedelta
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
+import orjson
 from annotated_types import Ge, Le
 from fastapi import (
     APIRouter,
@@ -16,6 +18,7 @@ from fastapi import (
     Query,
     Response,
 )
+from fastapi.responses import StreamingResponse
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -49,15 +52,20 @@ from xngin.apiserver.routers.experiments.dependencies import (
 from xngin.apiserver.routers.experiments.experiments_common import (
     create_assignment_for_participant,
     get_existing_assignment_for_participant,
-    get_experiment_assignments_impl,
     get_experiment_impl,
     get_or_create_assignment_for_participant,
     list_organization_or_datasource_experiments_impl,
     update_bandit_arm_with_outcome_impl,
 )
-from xngin.apiserver.routers.experiments.experiments_common_csv import CsvStreamingResponse
+from xngin.apiserver.routers.experiments.experiments_common_csv import (
+    CsvStreamingResponse,
+    get_experiment_assignments_impl,
+)
 from xngin.apiserver.settings import Datasource
 from xngin.apiserver.sqla import tables
+from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter
+
+JSON_STREAM_ROWS_PER_YIELD = 1024
 
 
 @asynccontextmanager
@@ -104,6 +112,38 @@ async def list_experiments(
     )
 
 
+async def _stream_experiment_assignments_response(
+    experiment: tables.Experiment, assignments: AsyncGenerator[dict[str, object]]
+) -> AsyncIterator[bytes]:
+    """Efficiently streams assignments/draws to the client."""
+    balance_check = ExperimentStorageConverter(experiment).get_balance_check()
+    yield (
+        b'{"balance_check":'
+        + orjson.dumps(None if balance_check is None else balance_check.model_dump(mode="json"))
+        + b',"experiment_id":'
+        + orjson.dumps(experiment.id)
+        + b',"assignments":['
+    )
+
+    sample_size = 0
+    buffered = 0
+    needs_comma = False
+    batch: list[bytes] = []
+    async for assignment in assignments:
+        if needs_comma:
+            batch.append(b",")
+        batch.append(orjson.dumps(assignment))
+        needs_comma = True
+        sample_size += 1
+        buffered += 1
+        if buffered == JSON_STREAM_ROWS_PER_YIELD:
+            yield b"".join(batch)
+            batch.clear()
+            buffered = 0
+
+    yield b"".join(batch) + b'],"sample_size":' + str(sample_size).encode() + b"}"
+
+
 @router.get(
     "/experiments/{experiment_id}",
     summary="Get experiment metadata (design & assignment specs) for a single experiment.",
@@ -118,14 +158,22 @@ async def get_experiment(
 @router.get(
     "/experiments/{experiment_id}/assignments",
     summary="Fetch list of participant=>arm assignments for the given experiment id.",
-    description="This endpoint is inefficient for large experiments. Large experiments should use "
-    "`/experiments/{experiment_id}/assignments/csv`.",
 )
 async def get_experiment_assignments(
     xngin_session: Annotated[AsyncSession, Depends(xngin_db_session)],
     experiment: Annotated[tables.Experiment, Depends(experiment_with_assignments_dependency)],
 ) -> GetExperimentAssignmentsResponse:
-    return await get_experiment_assignments_impl(xngin_session, experiment)
+    assignments = get_experiment_assignments_impl(xngin_session, experiment)
+    return cast(
+        GetExperimentAssignmentsResponse,
+        cast(
+            object,
+            StreamingResponse(
+                _stream_experiment_assignments_response(experiment, assignments),
+                media_type="application/json",
+            ),
+        ),
+    )
 
 
 @router.get(

--- a/src/xngin/apiserver/routers/experiments/experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_api.py
@@ -46,7 +46,6 @@ from xngin.apiserver.routers.experiments.dependencies import (
     experiment_and_datasource_dependency,
     experiment_dependency,
     experiment_response_dependency,
-    experiment_with_assignments_dependency,
     experiment_with_contexts_dependency,
 )
 from xngin.apiserver.routers.experiments.experiments_common import (
@@ -161,7 +160,7 @@ async def get_experiment(
 )
 async def get_experiment_assignments(
     xngin_session: Annotated[AsyncSession, Depends(xngin_db_session)],
-    experiment: Annotated[tables.Experiment, Depends(experiment_with_assignments_dependency)],
+    experiment: Annotated[tables.Experiment, Depends(experiment_dependency)],
 ) -> GetExperimentAssignmentsResponse:
     assignments = get_experiment_assignments_impl(xngin_session, experiment)
     return cast(

--- a/src/xngin/apiserver/routers/experiments/experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_api.py
@@ -31,6 +31,7 @@ from xngin.apiserver.exceptions_common import LateValidationError
 from xngin.apiserver.routers.admin.admin_api import sort_contexts_by_id_or_raise
 from xngin.apiserver.routers.common_api_types import (
     ArmBandit,
+    AssignmentTypedDict,
     CMABContextInputRequest,
     ExperimentsType,
     GetExperimentAssignmentsResponse,
@@ -112,9 +113,9 @@ async def list_experiments(
 
 
 async def _stream_experiment_assignments_response(
-    experiment: tables.Experiment, assignments: AsyncGenerator[dict[str, object]]
+    experiment: tables.Experiment, assignments: AsyncGenerator[AssignmentTypedDict]
 ) -> AsyncIterator[bytes]:
-    """Efficiently streams assignments/draws to the client."""
+    """Efficiently streams Assignments to the client."""
     balance_check = ExperimentStorageConverter(experiment).get_balance_check()
     yield (
         b'{"balance_check":'

--- a/src/xngin/apiserver/routers/experiments/experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_api.py
@@ -115,15 +115,17 @@ async def get_experiment(
     return await get_experiment_impl(xngin_session, experiment)
 
 
-# TODO: add a query param to include strata; default to false
 @router.get(
     "/experiments/{experiment_id}/assignments",
     summary="Fetch list of participant=>arm assignments for the given experiment id.",
+    description="This endpoint is inefficient for large experiments. Large experiments should use "
+    "`/experiments/{experiment_id}/assignments/csv`.",
 )
 async def get_experiment_assignments(
+    xngin_session: Annotated[AsyncSession, Depends(xngin_db_session)],
     experiment: Annotated[tables.Experiment, Depends(experiment_with_assignments_dependency)],
 ) -> GetExperimentAssignmentsResponse:
-    return get_experiment_assignments_impl(experiment)
+    return await get_experiment_assignments_impl(xngin_session, experiment)
 
 
 @router.get(

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -44,7 +44,6 @@ from xngin.apiserver.routers.common_api_types import (
     ListExperimentsResponse,
     MetricAnalysis,
     ParticipantProperty,
-    Strata,
 )
 from xngin.apiserver.routers.common_enums import (
     DataType,
@@ -55,6 +54,7 @@ from xngin.apiserver.routers.common_enums import (
     UpdateTypeBeta,
     UpdateTypeNormal,
 )
+from xngin.apiserver.routers.experiments.experiments_common_csv import get_experiment_assignments_fast
 from xngin.apiserver.routers.experiments.property_filters import passes_filters, validate_filter_value
 from xngin.apiserver.settings import DatasourceConfig, ParticipantsDef
 from xngin.apiserver.sql.queries import select_as_csv
@@ -62,6 +62,7 @@ from xngin.apiserver.sqla import tables
 from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter
 from xngin.apiserver.webhooks.webhook_types import ExperimentCreatedWebhookBody
 from xngin.events.experiment_created import ExperimentCreatedEvent
+from xngin.ops import performance
 from xngin.stats.analysis import analyze_experiment as analyze_freq_experiment
 from xngin.stats.assignment import AssignmentResult
 from xngin.stats.bandit_analysis import analyze_experiment as analyze_bandit_experiment
@@ -567,28 +568,19 @@ async def list_organization_or_datasource_experiments_impl(
     return ListExperimentsResponse(items=items)
 
 
-def get_experiment_assignments_impl(
+async def get_experiment_assignments_impl(
+    xngin_session: AsyncSession,
     experiment: tables.Experiment,
 ) -> GetExperimentAssignmentsResponse:
-    # Map arm IDs to names
-    arm_id_to_name = {arm.id: arm.name for arm in experiment.arms}
-    # Convert ArmAssignment models to Assignment API types
-
-    assignments: list[Assignment]
+    assignments: list[Assignment] = []
 
     match experiment.experiment_type:
         case ExperimentsType.FREQ_ONLINE | ExperimentsType.FREQ_PREASSIGNED:
-            assignments = [
-                Assignment(
-                    participant_id=arm_assignment.participant_id,
-                    arm_id=arm_assignment.arm_id,
-                    arm_name=arm_id_to_name[arm_assignment.arm_id],
-                    created_at=arm_assignment.created_at,
-                    strata=[Strata.model_validate(s) for s in arm_assignment.strata],
-                )
-                for arm_assignment in experiment.arm_assignments
-            ]
+            with performance.timing("async for"):
+                async for assignment in get_experiment_assignments_fast(xngin_session, experiment):
+                    assignments.append(assignment)
         case ExperimentsType.MAB_ONLINE | ExperimentsType.CMAB_ONLINE:
+            arm_id_to_name = {arm.id: arm.name for arm in experiment.arms}
             assignments = [
                 Assignment(
                     participant_id=draw.participant_id,
@@ -603,7 +595,6 @@ def get_experiment_assignments_impl(
             ]
         case _:
             raise LateValidationError(f"Invalid experiment type: {experiment.experiment_type}")
-
     return GetExperimentAssignmentsResponse(
         balance_check=ExperimentStorageConverter(experiment).get_balance_check(),
         experiment_id=experiment.id,

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -38,7 +38,6 @@ from xngin.apiserver.routers.common_api_types import (
     CreateExperimentResponse,
     DesignSpecMetricRequest,
     FreqExperimentAnalysisResponse,
-    GetExperimentAssignmentsResponse,
     GetExperimentResponse,
     GetParticipantAssignmentResponse,
     ListExperimentsResponse,
@@ -54,7 +53,6 @@ from xngin.apiserver.routers.common_enums import (
     UpdateTypeBeta,
     UpdateTypeNormal,
 )
-from xngin.apiserver.routers.experiments.experiments_common_csv import get_experiment_assignments_fast
 from xngin.apiserver.routers.experiments.property_filters import passes_filters, validate_filter_value
 from xngin.apiserver.settings import DatasourceConfig, ParticipantsDef
 from xngin.apiserver.sql.queries import select_as_csv
@@ -62,7 +60,6 @@ from xngin.apiserver.sqla import tables
 from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter
 from xngin.apiserver.webhooks.webhook_types import ExperimentCreatedWebhookBody
 from xngin.events.experiment_created import ExperimentCreatedEvent
-from xngin.ops import performance
 from xngin.stats.analysis import analyze_experiment as analyze_freq_experiment
 from xngin.stats.assignment import AssignmentResult
 from xngin.stats.bandit_analysis import analyze_experiment as analyze_bandit_experiment
@@ -566,41 +563,6 @@ async def list_organization_or_datasource_experiments_impl(
         webhook_ids = [webhook.id for webhook in e.webhooks]
         items.append(await converter.get_experiment_config(assign_summary, webhook_ids))
     return ListExperimentsResponse(items=items)
-
-
-async def get_experiment_assignments_impl(
-    xngin_session: AsyncSession,
-    experiment: tables.Experiment,
-) -> GetExperimentAssignmentsResponse:
-    assignments: list[Assignment] = []
-
-    match experiment.experiment_type:
-        case ExperimentsType.FREQ_ONLINE | ExperimentsType.FREQ_PREASSIGNED:
-            with performance.timing("async for"):
-                async for assignment in get_experiment_assignments_fast(xngin_session, experiment):
-                    assignments.append(assignment)
-        case ExperimentsType.MAB_ONLINE | ExperimentsType.CMAB_ONLINE:
-            arm_id_to_name = {arm.id: arm.name for arm in experiment.arms}
-            assignments = [
-                Assignment(
-                    participant_id=draw.participant_id,
-                    arm_id=draw.arm_id,
-                    arm_name=arm_id_to_name[draw.arm_id],
-                    created_at=draw.created_at,
-                    observed_at=draw.observed_at,
-                    outcome=draw.outcome,
-                    context_values=draw.context_vals,
-                )
-                for draw in experiment.draws
-            ]
-        case _:
-            raise LateValidationError(f"Invalid experiment type: {experiment.experiment_type}")
-    return GetExperimentAssignmentsResponse(
-        balance_check=ExperimentStorageConverter(experiment).get_balance_check(),
-        experiment_id=experiment.id,
-        sample_size=len(assignments),
-        assignments=assignments,
-    )
 
 
 async def get_existing_assignment_for_participant(

--- a/src/xngin/apiserver/routers/experiments/experiments_common_csv.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common_csv.py
@@ -192,7 +192,7 @@ async def get_experiment_assignments_impl(
                     "arm_id": arm_id,
                     "arm_name": arm_name,
                     "created_at": created_at,
-                    "strata": [],
+                    "strata": None,
                     "observed_at": observed_at,
                     "outcome": outcome,
                     "context_values": context_values,

--- a/src/xngin/apiserver/routers/experiments/experiments_common_csv.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common_csv.py
@@ -1,11 +1,13 @@
 # mypy: disable-error-code="misc"
 from collections.abc import AsyncGenerator
+from typing import cast
 
 from fastapi.responses import StreamingResponse
 from psycopg import sql
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from xngin.apiserver.exceptions_common import LateValidationError
+from xngin.apiserver.routers.common_api_types import AssignmentTypedDict, StrataTypedDict
 from xngin.apiserver.routers.common_enums import ExperimentsType
 from xngin.apiserver.sql.queries import select_as_csv, stream
 from xngin.apiserver.sqla import tables
@@ -150,7 +152,7 @@ async def get_experiment_assignments_as_csv_impl(
 
 async def get_experiment_assignments_impl(
     xngin_session: AsyncSession, experiment: tables.Experiment
-) -> AsyncGenerator[dict[str, object]]:
+) -> AsyncGenerator[AssignmentTypedDict]:
     match experiment.experiment_type:
         case ExperimentsType.FREQ_ONLINE.value | ExperimentsType.FREQ_PREASSIGNED.value:
             strata_names = await _get_assignment_csv_strata_names_from_experiment(experiment)
@@ -168,7 +170,7 @@ async def get_experiment_assignments_impl(
                     "arm_name": arm_name,
                     "created_at": created_at,
                     "strata": [
-                        {"field_name": strata_names[i], "strata_value": strata_values[i]}
+                        cast(StrataTypedDict, {"field_name": strata_names[i], "strata_value": strata_values[i]})
                         for i, _ in enumerate(strata_names)
                     ],
                     "observed_at": None,

--- a/src/xngin/apiserver/routers/experiments/experiments_common_csv.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common_csv.py
@@ -1,6 +1,5 @@
 # mypy: disable-error-code="misc"
 from collections.abc import AsyncGenerator
-from typing import cast
 
 from fastapi.responses import StreamingResponse
 from psycopg import sql
@@ -164,15 +163,16 @@ async def get_experiment_assignments_impl(
             )
             async for assignment in stream(xngin_session, select_query, JSON_STREAM_FETCH_SIZE_ROWS):
                 participant_id, arm_id, arm_name, created_at, *strata_values = assignment
+                strata: list[StrataTypedDict] = [
+                    {"field_name": strata_names[i], "strata_value": strata_values[i]}
+                    for i, _ in enumerate(strata_names)
+                ]
                 yield {
                     "participant_id": participant_id,
                     "arm_id": arm_id,
                     "arm_name": arm_name,
                     "created_at": created_at,
-                    "strata": [
-                        cast(StrataTypedDict, {"field_name": strata_names[i], "strata_value": strata_values[i]})
-                        for i, _ in enumerate(strata_names)
-                    ],
+                    "strata": strata,
                     "observed_at": None,
                     "outcome": None,
                     "context_values": None,

--- a/src/xngin/apiserver/routers/experiments/experiments_common_csv.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common_csv.py
@@ -1,13 +1,14 @@
 # mypy: disable-error-code="misc"
-
+from collections.abc import AsyncGenerator
 
 from fastapi.responses import StreamingResponse
 from psycopg import sql
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from xngin.apiserver.exceptions_common import LateValidationError
+from xngin.apiserver.routers.common_api_types import Assignment, Strata
 from xngin.apiserver.routers.common_enums import ExperimentsType
-from xngin.apiserver.sql.queries import select_as_csv
+from xngin.apiserver.sql.queries import select_as_csv, with_driver_connection
 from xngin.apiserver.sqla import tables
 
 CSV_STREAM_CHUNK_SIZE_BYTES = 1 << 20
@@ -17,10 +18,10 @@ class CsvStreamingResponse(StreamingResponse):
     media_type = "text/csv"
 
 
-def _get_assignment_csv_strata_names_from_experiment(experiment: tables.Experiment) -> list[str]:
+async def _get_assignment_csv_strata_names_from_experiment(experiment: tables.Experiment) -> list[str]:
     if experiment.experiment_type not in {ExperimentsType.FREQ_ONLINE.value, ExperimentsType.FREQ_PREASSIGNED.value}:
         return []
-    return sorted([ef.field_name for ef in experiment.experiment_fields if ef.is_strata])
+    return sorted([ef.field_name for ef in await experiment.awaitable_attrs.experiment_fields if ef.is_strata])
 
 
 def _build_experiment_assignments_select_query(experiment_id: str, experiment_type: str, strata_names: list[str]):
@@ -86,10 +87,31 @@ async def get_experiment_assignments_as_csv_impl(
     xngin_session: AsyncSession,
     experiment: tables.Experiment,
 ) -> CsvStreamingResponse:
-    strata_names = _get_assignment_csv_strata_names_from_experiment(experiment)
+    strata_names = await _get_assignment_csv_strata_names_from_experiment(experiment)
     select_query = _build_experiment_assignments_select_query(experiment.id, experiment.experiment_type, strata_names)
     filename = f"experiment_{experiment.id}_assignments.csv"
     return CsvStreamingResponse(
         select_as_csv(xngin_session, select_query, buffer_size_bytes=CSV_STREAM_CHUNK_SIZE_BYTES, include_header=True),
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
+
+
+async def get_experiment_assignments_fast(
+    xngin_session: AsyncSession, experiment: tables.Experiment
+) -> AsyncGenerator[Assignment]:
+    strata_names = await _get_assignment_csv_strata_names_from_experiment(experiment)
+    select_query = _build_experiment_assignments_select_query(experiment.id, experiment.experiment_type, strata_names)
+
+    async with with_driver_connection(xngin_session) as driver_conn, driver_conn.cursor() as cursor:
+        async for assignment in cursor.stream(select_query, size=10000):
+            participant_id, arm_id, arm_name, created_at, *strata_values = assignment
+            yield Assignment(
+                participant_id=participant_id,
+                arm_id=arm_id,
+                arm_name=arm_name,
+                created_at=created_at,
+                strata=[
+                    Strata(field_name=strata_names[i], strata_value=strata_values[i])
+                    for i, _ in enumerate(strata_names)
+                ],
+            )

--- a/src/xngin/apiserver/routers/experiments/experiments_common_csv.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common_csv.py
@@ -6,12 +6,12 @@ from psycopg import sql
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from xngin.apiserver.exceptions_common import LateValidationError
-from xngin.apiserver.routers.common_api_types import Assignment, Strata
 from xngin.apiserver.routers.common_enums import ExperimentsType
-from xngin.apiserver.sql.queries import select_as_csv, with_driver_connection
+from xngin.apiserver.sql.queries import select_as_csv, stream
 from xngin.apiserver.sqla import tables
 
 CSV_STREAM_CHUNK_SIZE_BYTES = 1 << 20
+JSON_STREAM_FETCH_SIZE_ROWS = 16_384
 
 
 class CsvStreamingResponse(StreamingResponse):
@@ -83,6 +83,27 @@ def _build_experiment_assignments_select_query(experiment_id: str, experiment_ty
             raise LateValidationError(f"unsupported experiment type for CSV export: {experiment_type}")
 
 
+def _build_bandit_experiment_assignments_json_select_query(experiment_id: str, experiment_type: str):
+    extra_columns = sql.SQL(", NULL::float8[] AS context_vals")
+    if experiment_type == ExperimentsType.CMAB_ONLINE.value:
+        extra_columns = sql.SQL(", draw.context_vals AS context_vals")
+    return t"""
+        SELECT
+            draw.participant_id AS participant_id,
+            draw.arm_id AS arm_id,
+            a.name AS arm_name,
+            to_char(draw.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at,
+            to_char(draw.observed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS observed_at,
+            draw.outcome AS outcome
+            {extra_columns:q}
+        FROM draws AS draw
+        JOIN arms AS a
+            ON a.id = draw.arm_id
+            AND a.experiment_id = draw.experiment_id
+        WHERE draw.experiment_id = {experiment_id}
+    """
+
+
 async def get_experiment_assignments_as_csv_impl(
     xngin_session: AsyncSession,
     experiment: tables.Experiment,
@@ -96,22 +117,45 @@ async def get_experiment_assignments_as_csv_impl(
     )
 
 
-async def get_experiment_assignments_fast(
+async def get_experiment_assignments_impl(
     xngin_session: AsyncSession, experiment: tables.Experiment
-) -> AsyncGenerator[Assignment]:
-    strata_names = await _get_assignment_csv_strata_names_from_experiment(experiment)
-    select_query = _build_experiment_assignments_select_query(experiment.id, experiment.experiment_type, strata_names)
-
-    async with with_driver_connection(xngin_session) as driver_conn, driver_conn.cursor() as cursor:
-        async for assignment in cursor.stream(select_query, size=10000):
-            participant_id, arm_id, arm_name, created_at, *strata_values = assignment
-            yield Assignment(
-                participant_id=participant_id,
-                arm_id=arm_id,
-                arm_name=arm_name,
-                created_at=created_at,
-                strata=[
-                    Strata(field_name=strata_names[i], strata_value=strata_values[i])
-                    for i, _ in enumerate(strata_names)
-                ],
+) -> AsyncGenerator[dict[str, object]]:
+    match experiment.experiment_type:
+        case ExperimentsType.FREQ_ONLINE.value | ExperimentsType.FREQ_PREASSIGNED.value:
+            strata_names = await _get_assignment_csv_strata_names_from_experiment(experiment)
+            select_query = _build_experiment_assignments_select_query(
+                experiment.id, experiment.experiment_type, strata_names
             )
+            async for assignment in stream(xngin_session, select_query, JSON_STREAM_FETCH_SIZE_ROWS):
+                participant_id, arm_id, arm_name, created_at, *strata_values = assignment
+                yield {
+                    "participant_id": participant_id,
+                    "arm_id": arm_id,
+                    "arm_name": arm_name,
+                    "created_at": created_at,
+                    "strata": [
+                        {"field_name": strata_names[i], "strata_value": strata_values[i]}
+                        for i, _ in enumerate(strata_names)
+                    ],
+                    "observed_at": None,
+                    "outcome": None,
+                    "context_values": None,
+                }
+        case ExperimentsType.MAB_ONLINE.value | ExperimentsType.CMAB_ONLINE.value:
+            select_query = _build_bandit_experiment_assignments_json_select_query(
+                experiment.id, experiment.experiment_type
+            )
+            async for assignment in stream(xngin_session, select_query, JSON_STREAM_FETCH_SIZE_ROWS):
+                participant_id, arm_id, arm_name, created_at, observed_at, outcome, context_values = assignment
+                yield {
+                    "participant_id": participant_id,
+                    "arm_id": arm_id,
+                    "arm_name": arm_name,
+                    "created_at": created_at,
+                    "strata": None,
+                    "observed_at": observed_at,
+                    "outcome": outcome,
+                    "context_values": context_values,
+                }
+        case _:
+            raise LateValidationError(f"unsupported experiment type for JSON export: {experiment.experiment_type}")

--- a/src/xngin/apiserver/routers/experiments/experiments_common_csv.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common_csv.py
@@ -24,89 +24,100 @@ async def _get_assignment_csv_strata_names_from_experiment(experiment: tables.Ex
     return sorted([ef.field_name for ef in await experiment.awaitable_attrs.experiment_fields if ef.is_strata])
 
 
-def _build_experiment_assignments_select_query(
+def _build_freq_experiment_assignments_select_query(
     experiment_id: str,
     experiment_type: str,
     strata_names: list[str],
     *,
     with_microseconds: bool = False,
 ):
-    match experiment_type:
-        case ExperimentsType.FREQ_ONLINE.value | ExperimentsType.FREQ_PREASSIGNED.value:
-            if strata_names:
-                projected_columns = [sql.Identifier("strata", strata_name) for strata_name in strata_names]
-                joined_projected_columns = sql.SQL(", ").join(projected_columns)
-                extra_columns = t", {joined_projected_columns:q}"
+    if experiment_type not in {ExperimentsType.FREQ_ONLINE.value, ExperimentsType.FREQ_PREASSIGNED.value}:
+        raise LateValidationError(f"unsupported experiment type for frequentist export: {experiment_type}")
 
-                # Use MAX(... FILTER ...) to pivot validated single-value strata rows into columns.
-                lateral_columns = [
-                    t"MAX(elem.strata_value) FILTER (WHERE elem.field_name = {strata_name}) AS {strata_name:i}"
-                    for strata_name in strata_names
-                ]
-                joined_lateral_columns = sql.SQL(", ").join(lateral_columns)
-                lateral_join = t"""
-                    LEFT JOIN LATERAL (
-                        SELECT {joined_lateral_columns:q}
-                        FROM jsonb_to_recordset(aa.strata) AS elem(field_name text, strata_value text)
-                    ) AS strata ON TRUE
-                """
-            else:
-                extra_columns = sql.SQL("")
-                lateral_join = sql.SQL("")
-            created_at_column = sql.SQL("aa.created_at AS created_at")
-            if not with_microseconds:
-                created_at_column = sql.SQL(
-                    """to_char(aa.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at"""
-                )
-            return t"""
-                SELECT
-                    aa.participant_id AS participant_id,
-                    aa.arm_id AS arm_id,
-                    a.name AS arm_name,
-                    {created_at_column:q}
-                    {extra_columns:q}
-                FROM arm_assignments AS aa
-                JOIN arms AS a
-                    ON a.id = aa.arm_id
-                    AND a.experiment_id = aa.experiment_id
-                {lateral_join:q}
-                WHERE aa.experiment_id = {experiment_id}
-            """
-        case ExperimentsType.MAB_ONLINE.value | ExperimentsType.CMAB_ONLINE.value:
-            extra_columns = sql.SQL("")
-            if experiment_type == ExperimentsType.CMAB_ONLINE.value:
-                extra_columns = sql.SQL(", draw.context_vals AS context_vals")
-            return t"""
-                SELECT
-                    draw.participant_id AS participant_id,
-                    draw.arm_id AS arm_id,
-                    a.name AS arm_name,
-                    to_char(draw.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at,
-                    draw.outcome as outcome
-                    {extra_columns:q}
-                FROM draws AS draw
-                JOIN arms AS a
-                    ON a.id = draw.arm_id
-                    AND a.experiment_id = draw.experiment_id
-                WHERE draw.experiment_id = {experiment_id}
-            """
-        case _:
-            raise LateValidationError(f"unsupported experiment type for CSV export: {experiment_type}")
+    if strata_names:
+        projected_columns = [sql.Identifier("strata", strata_name) for strata_name in strata_names]
+        joined_projected_columns = sql.SQL(", ").join(projected_columns)
+        extra_columns = t", {joined_projected_columns:q}"
 
+        # Use MAX(... FILTER ...) to pivot validated single-value strata rows into columns.
+        lateral_columns = [
+            t"MAX(elem.strata_value) FILTER (WHERE elem.field_name = {strata_name}) AS {strata_name:i}"
+            for strata_name in strata_names
+        ]
+        joined_lateral_columns = sql.SQL(", ").join(lateral_columns)
+        lateral_join = t"""
+            LEFT JOIN LATERAL (
+                SELECT {joined_lateral_columns:q}
+                FROM jsonb_to_recordset(aa.strata) AS elem(field_name text, strata_value text)
+            ) AS strata ON TRUE
+        """
+    else:
+        extra_columns = sql.SQL("")
+        lateral_join = sql.SQL("")
 
-def _build_bandit_experiment_assignments_json_select_query(experiment_id: str, experiment_type: str):
-    extra_columns = sql.SQL(", NULL::float8[] AS context_vals")
-    if experiment_type == ExperimentsType.CMAB_ONLINE.value:
-        extra_columns = sql.SQL(", draw.context_vals AS context_vals")
+    created_at_column = sql.SQL("aa.created_at AS created_at")
+    if not with_microseconds:
+        created_at_column = sql.SQL(
+            """to_char(aa.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at"""
+        )
+
     return t"""
         SELECT
-            draw.participant_id AS participant_id,
-            draw.arm_id AS arm_id,
+            aa.participant_id AS participant_id,
+            aa.arm_id AS arm_id,
             a.name AS arm_name,
-            draw.created_at AS created_at,
-            draw.observed_at AS observed_at,
-            draw.outcome AS outcome
+            {created_at_column:q}
             {extra_columns:q}
+        FROM arm_assignments AS aa
+        JOIN arms AS a
+            ON a.id = aa.arm_id
+            AND a.experiment_id = aa.experiment_id
+        {lateral_join:q}
+        WHERE aa.experiment_id = {experiment_id}
+    """
+
+
+def _build_bandit_experiment_assignments_select_query(
+    experiment_id: str,
+    experiment_type: str,
+    *,
+    with_microseconds: bool = False,
+    include_observed_at: bool = False,
+    include_context_vals: bool = False,
+):
+    if experiment_type not in {ExperimentsType.MAB_ONLINE.value, ExperimentsType.CMAB_ONLINE.value}:
+        raise LateValidationError(f"unsupported experiment type for bandit export: {experiment_type}")
+
+    created_at_column = sql.SQL(
+        """to_char(draw.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at"""
+    )
+    if with_microseconds:
+        created_at_column = sql.SQL("draw.created_at AS created_at")
+
+    projected_columns = [
+        sql.SQL("draw.participant_id AS participant_id"),
+        sql.SQL("draw.arm_id AS arm_id"),
+        sql.SQL("a.name AS arm_name"),
+        created_at_column,
+        sql.SQL("draw.outcome AS outcome"),
+    ]
+    if include_observed_at:
+        observed_at_column = sql.SQL(
+            """to_char(draw.observed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS observed_at"""
+        )
+        if with_microseconds:
+            observed_at_column = sql.SQL("draw.observed_at AS observed_at")
+        projected_columns.append(observed_at_column)
+    if include_context_vals:
+        context_values_column = sql.SQL("NULL::float8[] AS context_vals")
+        if experiment_type == ExperimentsType.CMAB_ONLINE.value:
+            context_values_column = sql.SQL("draw.context_vals AS context_vals")
+        projected_columns.append(context_values_column)
+    joined_projected_columns = sql.SQL(", ").join(projected_columns)
+
+    return t"""
+        SELECT
+            {joined_projected_columns:q}
         FROM draws AS draw
         JOIN arms AS a
             ON a.id = draw.arm_id
@@ -120,7 +131,16 @@ async def get_experiment_assignments_as_csv_impl(
     experiment: tables.Experiment,
 ) -> CsvStreamingResponse:
     strata_names = await _get_assignment_csv_strata_names_from_experiment(experiment)
-    select_query = _build_experiment_assignments_select_query(experiment.id, experiment.experiment_type, strata_names)
+    if experiment.experiment_type in {ExperimentsType.FREQ_ONLINE.value, ExperimentsType.FREQ_PREASSIGNED.value}:
+        select_query = _build_freq_experiment_assignments_select_query(
+            experiment.id, experiment.experiment_type, strata_names
+        )
+    else:
+        select_query = _build_bandit_experiment_assignments_select_query(
+            experiment.id,
+            experiment.experiment_type,
+            include_context_vals=experiment.experiment_type == ExperimentsType.CMAB_ONLINE.value,
+        )
     filename = f"experiment_{experiment.id}_assignments.csv"
     return CsvStreamingResponse(
         select_as_csv(xngin_session, select_query, buffer_size_bytes=CSV_STREAM_CHUNK_SIZE_BYTES, include_header=True),
@@ -134,7 +154,7 @@ async def get_experiment_assignments_impl(
     match experiment.experiment_type:
         case ExperimentsType.FREQ_ONLINE.value | ExperimentsType.FREQ_PREASSIGNED.value:
             strata_names = await _get_assignment_csv_strata_names_from_experiment(experiment)
-            select_query = _build_experiment_assignments_select_query(
+            select_query = _build_freq_experiment_assignments_select_query(
                 experiment.id,
                 experiment.experiment_type,
                 strata_names,
@@ -156,11 +176,15 @@ async def get_experiment_assignments_impl(
                     "context_values": None,
                 }
         case ExperimentsType.MAB_ONLINE.value | ExperimentsType.CMAB_ONLINE.value:
-            select_query = _build_bandit_experiment_assignments_json_select_query(
-                experiment.id, experiment.experiment_type
+            select_query = _build_bandit_experiment_assignments_select_query(
+                experiment.id,
+                experiment.experiment_type,
+                with_microseconds=True,
+                include_observed_at=True,
+                include_context_vals=True,
             )
             async for assignment in stream(xngin_session, select_query, JSON_STREAM_FETCH_SIZE_ROWS):
-                participant_id, arm_id, arm_name, created_at, observed_at, outcome, context_values = assignment
+                participant_id, arm_id, arm_name, created_at, outcome, observed_at, context_values = assignment
                 yield {
                     "participant_id": participant_id,
                     "arm_id": arm_id,

--- a/src/xngin/apiserver/routers/experiments/experiments_common_csv.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common_csv.py
@@ -24,7 +24,13 @@ async def _get_assignment_csv_strata_names_from_experiment(experiment: tables.Ex
     return sorted([ef.field_name for ef in await experiment.awaitable_attrs.experiment_fields if ef.is_strata])
 
 
-def _build_experiment_assignments_select_query(experiment_id: str, experiment_type: str, strata_names: list[str]):
+def _build_experiment_assignments_select_query(
+    experiment_id: str,
+    experiment_type: str,
+    strata_names: list[str],
+    *,
+    with_microseconds: bool = False,
+):
     match experiment_type:
         case ExperimentsType.FREQ_ONLINE.value | ExperimentsType.FREQ_PREASSIGNED.value:
             if strata_names:
@@ -47,12 +53,17 @@ def _build_experiment_assignments_select_query(experiment_id: str, experiment_ty
             else:
                 extra_columns = sql.SQL("")
                 lateral_join = sql.SQL("")
+            created_at_column = sql.SQL("aa.created_at AS created_at")
+            if not with_microseconds:
+                created_at_column = sql.SQL(
+                    """to_char(aa.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at"""
+                )
             return t"""
                 SELECT
                     aa.participant_id AS participant_id,
                     aa.arm_id AS arm_id,
                     a.name AS arm_name,
-                    to_char(aa.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at
+                    {created_at_column:q}
                     {extra_columns:q}
                 FROM arm_assignments AS aa
                 JOIN arms AS a
@@ -92,8 +103,8 @@ def _build_bandit_experiment_assignments_json_select_query(experiment_id: str, e
             draw.participant_id AS participant_id,
             draw.arm_id AS arm_id,
             a.name AS arm_name,
-            to_char(draw.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at,
-            to_char(draw.observed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS observed_at,
+            draw.created_at AS created_at,
+            draw.observed_at AS observed_at,
             draw.outcome AS outcome
             {extra_columns:q}
         FROM draws AS draw
@@ -124,7 +135,10 @@ async def get_experiment_assignments_impl(
         case ExperimentsType.FREQ_ONLINE.value | ExperimentsType.FREQ_PREASSIGNED.value:
             strata_names = await _get_assignment_csv_strata_names_from_experiment(experiment)
             select_query = _build_experiment_assignments_select_query(
-                experiment.id, experiment.experiment_type, strata_names
+                experiment.id,
+                experiment.experiment_type,
+                strata_names,
+                with_microseconds=True,
             )
             async for assignment in stream(xngin_session, select_query, JSON_STREAM_FETCH_SIZE_ROWS):
                 participant_id, arm_id, arm_name, created_at, *strata_values = assignment
@@ -152,7 +166,7 @@ async def get_experiment_assignments_impl(
                     "arm_id": arm_id,
                     "arm_name": arm_name,
                     "created_at": created_at,
-                    "strata": None,
+                    "strata": [],
                     "observed_at": observed_at,
                     "outcome": outcome,
                     "context_values": context_values,

--- a/src/xngin/apiserver/routers/experiments/test_experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_api.py
@@ -1,5 +1,7 @@
+import csv
 from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
+from io import StringIO
 from typing import TYPE_CHECKING
 
 import pytest
@@ -365,6 +367,53 @@ async def test_get_experiment_assignments_streams_preassigned_assignments(
         assert assignment.observed_at is None
         assert assignment.outcome is None
         assert assignment.context_values is None
+
+
+async def test_both_get_experiment_assignments_endpoints_have_matching_strata_ordering(
+    testing_datasource,
+    aclient: AdminAPIClient,
+    eclient: ExperimentsAPIClient,
+):
+    request = make_unvalidated_create_experiment_request(
+        experiment_type=ExperimentsType.FREQ_PREASSIGNED,
+        table_name="dwh",
+        primary_key="id",
+    )
+    request.design_spec = PreassignedFrequentistExperimentSpec(
+        **request.design_spec.model_dump(exclude={"strata"}),
+        strata=[Stratum(field_name="ethnicity"), Stratum(field_name="gender")],
+    )
+    created_experiment = aclient.create_experiment(
+        datasource_id=testing_datasource.ds.id,
+        body=request,
+        desired_n=2,
+    ).data
+    aclient.commit_experiment(
+        datasource_id=testing_datasource.datasource_id,
+        experiment_id=created_experiment.experiment_id,
+    )
+
+    data = eclient.get_experiment_assignments(
+        api_key=testing_datasource.key,
+        experiment_id=created_experiment.experiment_id,
+    ).data
+    csv_response = eclient.client.get(
+        f"/v1/experiments/{created_experiment.experiment_id}/assignments/csv",
+        headers={"X-API-Key": testing_datasource.key},
+    )
+    assert csv_response.status_code == HTTPStatus.OK, csv_response.content
+
+    csv_rows = {row["participant_id"]: row for row in csv.DictReader(StringIO(csv_response.text))}
+    assert set(csv_rows) == {assignment.participant_id for assignment in data.assignments}
+
+    for assignment in data.assignments:
+        csv_row = csv_rows[assignment.participant_id]
+        assert assignment.strata is not None
+        assert [stratum.field_name for stratum in assignment.strata] == ["ethnicity", "gender"]
+        assert {stratum.field_name: stratum.strata_value for stratum in assignment.strata} == {
+            "ethnicity": csv_row["ethnicity"] or None,
+            "gender": csv_row["gender"] or None,
+        }
 
 
 async def test_get_experiment_assignments_streams_bandit_assignments(

--- a/src/xngin/apiserver/routers/experiments/test_experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_api.py
@@ -348,11 +348,20 @@ async def test_get_experiment_assignments_streams_preassigned_assignments(
 
     assert len(data.assignments) == 2
     for assignment in data.assignments:
+        participant_assignment = eclient.get_assignment(
+            api_key=testing_datasource.key,
+            experiment_id=experiment.experiment_id,
+            participant_id=assignment.participant_id,
+            create_if_none=False,
+        ).data.assignment
+        assert participant_assignment is not None
         assert assignment.arm_name == arms_by_id[assignment.arm_id]
+        assert assignment.arm_id == participant_assignment.arm_id
+        assert assignment.arm_name == participant_assignment.arm_name
+        assert assignment.created_at == participant_assignment.created_at
         assert assignment.strata is not None and len(assignment.strata) == 1
         assert assignment.strata[0].field_name == "gender"
         assert assignment.strata[0].strata_value is not None
-        assert assignment.created_at is not None
         assert assignment.observed_at is None
         assert assignment.outcome is None
         assert assignment.context_values is None
@@ -390,6 +399,18 @@ async def test_get_experiment_assignments_streams_bandit_assignments(
         experiment_id=experiment.experiment_id,
         participant_id="p1",
     )
+    updated_first_assignment = eclient.get_assignment(
+        api_key=testing_datasource.key,
+        experiment_id=experiment.experiment_id,
+        participant_id="p1",
+        create_if_none=False,
+    ).data.assignment
+    updated_second_assignment = eclient.get_assignment(
+        api_key=testing_datasource.key,
+        experiment_id=experiment.experiment_id,
+        participant_id="p2",
+        create_if_none=False,
+    ).data.assignment
 
     data = eclient.get_experiment_assignments(
         api_key=testing_datasource.key,
@@ -403,6 +424,7 @@ async def test_get_experiment_assignments_streams_bandit_assignments(
     assert set(assignments_by_participant_id) == {"p1", "p2"}
 
     p1 = assignments_by_participant_id["p1"]
+    assert updated_first_assignment == p1
     assert p1.arm_name == arms_by_id[p1.arm_id]
     assert p1.created_at is not None
     assert p1.observed_at is not None
@@ -412,6 +434,7 @@ async def test_get_experiment_assignments_streams_bandit_assignments(
     assert p1.strata == []
 
     p2 = assignments_by_participant_id["p2"]
+    assert updated_second_assignment == p2
     assert p2.arm_name == arms_by_id[p2.arm_id]
     assert p2.created_at is not None
     assert p2.observed_at is None

--- a/src/xngin/apiserver/routers/experiments/test_experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_api.py
@@ -473,23 +473,25 @@ async def test_get_experiment_assignments_streams_bandit_assignments(
     assert set(assignments_by_participant_id) == {"p1", "p2"}
 
     p1 = assignments_by_participant_id["p1"]
-    assert updated_first_assignment == p1
+    assert updated_first_assignment is not None
+    assert updated_first_assignment.model_copy(update={"strata": None}) == p1
     assert p1.arm_name == arms_by_id[p1.arm_id]
     assert p1.created_at is not None
     assert p1.observed_at is not None
     assert p1.observed_at >= observed_at.replace(microsecond=0)
     assert p1.outcome == 1.5
     assert p1.context_values is None
-    assert p1.strata == []
+    assert p1.strata is None
 
     p2 = assignments_by_participant_id["p2"]
-    assert updated_second_assignment == p2
+    assert updated_second_assignment is not None
+    assert updated_second_assignment.model_copy(update={"strata": None}) == p2
     assert p2.arm_name == arms_by_id[p2.arm_id]
     assert p2.created_at is not None
     assert p2.observed_at is None
     assert p2.outcome is None
     assert p2.context_values is None
-    assert p2.strata == []
+    assert p2.strata is None
 
 
 async def test_get_experiment_assignments_streams_cmab_context_values(
@@ -569,17 +571,17 @@ async def test_get_experiment_assignments_streams_cmab_context_values(
     assert p1.created_at is not None
     assert p1.observed_at is not None
     assert p1.outcome == 1.5
-    assert p1.strata == []
+    assert p1.strata is None
     assert p1.context_values == [1.0, 1.0]
-    assert first_assignment == p1
+    assert first_assignment.model_copy(update={"strata": None}) == p1
 
     p2 = assignments_by_participant_id["p2"]
     assert p2.created_at is not None
     assert p2.observed_at is None
     assert p2.outcome is None
-    assert p2.strata == []
+    assert p2.strata is None
     assert p2.context_values == [2.0, 2.0]
-    assert second_assignment == p2
+    assert second_assignment.model_copy(update={"strata": None}) == p2
 
 
 async def test_get_experiment_assignments_as_csv_success(
@@ -727,6 +729,7 @@ async def test_get_assignment_mab_online(testing_datasource, aclient: AdminAPICl
     assert len(assignments.assignments) == 1
     assert assignments.assignments[0].participant_id == "1"
     assert str(assignments.assignments[0].arm_id) == str(parsed.assignment.arm_id)
+    assert assignments.assignments[0].strata is None
     assert assignments.assignments[0].observed_at is None
     assert assignments.assignments[0].outcome is None
     assert assignments.assignments[0].context_values is None
@@ -830,6 +833,7 @@ async def test_get_cmab_experiment_assignment_for_online_participant(
     assert len(assignments.assignments) == 1
     assert assignments.assignments[0].participant_id == "1"
     assert str(assignments.assignments[0].arm_id) == str(parsed.assignment.arm_id)
+    assert assignments.assignments[0].strata is None
     assert assignments.assignments[0].context_values == [1.0, 1.0]
 
     experiment = eclient.get_experiment(

--- a/src/xngin/apiserver/routers/experiments/test_experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_api.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from pydantic import TypeAdapter
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from xngin.apiserver.routers.common_api_types import (
     Arm,
@@ -18,6 +19,7 @@ from xngin.apiserver.routers.common_api_types import (
     ExperimentConfig,
     ExperimentsType,
     Filter,
+    GetExperimentAssignmentsResponse,
     GetParticipantAssignmentResponse,
     LikelihoodTypes,
     MABExperimentSpec,
@@ -30,6 +32,7 @@ from xngin.apiserver.routers.common_api_types import (
     UpdateBanditArmOutcomeRequest,
 )
 from xngin.apiserver.routers.common_enums import ContextType, ExperimentState, Relation, StopAssignmentReason
+from xngin.apiserver.routers.experiments.test_experiments_common import insert_experiment_and_arms
 from xngin.apiserver.sqla import tables
 from xngin.apiserver.testing.admin_api_client import AdminAPIClientHTTPValidationError
 from xngin.apiserver.testing.experiments_api_client import ExperimentsAPIClientNotDefaultStatusError
@@ -318,6 +321,139 @@ async def test_get_experiment_assignments_success(
     assert parsed.balance_check is None
     assert {assignment.participant_id for assignment in parsed.assignments} == {"participant_1", "participant_2"}
     assert {assignment.arm_name for assignment in parsed.assignments}.issubset({"control", "treatment"})
+
+
+async def test_get_experiment_assignments_streams_preassigned_assignments(
+    xngin_session: AsyncSession,
+    testing_datasource,
+    eclient: ExperimentsAPIClient,
+):
+    experiment = await insert_experiment_and_arms(xngin_session, testing_datasource.ds)
+    await xngin_session.commit()
+
+    arm1_id = experiment.arms[0].id
+    arm2_id = experiment.arms[1].id
+    xngin_session.add_all([
+        tables.ArmAssignment(
+            experiment_id=experiment.id,
+            participant_type="",
+            participant_id="p1",
+            arm_id=arm1_id,
+            strata=[{"field_name": "gender", "strata_value": "F"}],
+        ),
+        tables.ArmAssignment(
+            experiment_id=experiment.id,
+            participant_type="",
+            participant_id="p2",
+            arm_id=arm2_id,
+            strata=[{"field_name": "gender", "strata_value": "M"}],
+        ),
+        tables.ArmStats(arm_id=arm1_id, population=1),
+        tables.ArmStats(arm_id=arm2_id, population=1),
+    ])
+    await xngin_session.commit()
+
+    response = eclient.client.get(
+        f"/v1/experiments/{experiment.id}/assignments",
+        headers={"X-API-Key": testing_datasource.key},
+    )
+    assert response.status_code == HTTPStatus.OK, response.content
+    assert response.headers["content-type"].startswith("application/json")
+
+    data = TypeAdapter(GetExperimentAssignmentsResponse).validate_python(response.json())
+    assert data.experiment_id == experiment.id
+    assert data.sample_size == 2
+    assert data.balance_check is None
+
+    assignments_by_participant_id = {assignment.participant_id: assignment for assignment in data.assignments}
+    assert set(assignments_by_participant_id) == {"p1", "p2"}
+
+    p1 = assignments_by_participant_id["p1"]
+    assert str(p1.arm_id) == arm1_id
+    assert p1.arm_name == "control"
+    assert p1.strata is not None and len(p1.strata) == 1
+    assert p1.strata[0].field_name == "gender"
+    assert p1.strata[0].strata_value == "F"
+    assert p1.created_at is not None
+    assert p1.observed_at is None
+    assert p1.outcome is None
+    assert p1.context_values is None
+
+    p2 = assignments_by_participant_id["p2"]
+    assert str(p2.arm_id) == arm2_id
+    assert p2.arm_name == "treatment"
+    assert p2.strata is not None and len(p2.strata) == 1
+    assert p2.strata[0].field_name == "gender"
+    assert p2.strata[0].strata_value == "M"
+    assert p2.created_at is not None
+    assert p2.observed_at is None
+    assert p2.outcome is None
+    assert p2.context_values is None
+
+
+async def test_get_experiment_assignments_streams_bandit_assignments(
+    xngin_session: AsyncSession,
+    testing_datasource,
+    eclient: ExperimentsAPIClient,
+):
+    experiment = await insert_experiment_and_arms(
+        xngin_session, testing_datasource.ds, experiment_type=ExperimentsType.MAB_ONLINE
+    )
+    await xngin_session.commit()
+
+    observed_at = datetime.now(UTC)
+    arm1_id = experiment.arms[0].id
+    arm2_id = experiment.arms[1].id
+    xngin_session.add_all([
+        tables.Draw(
+            experiment_id=experiment.id,
+            participant_type="",
+            participant_id="p1",
+            arm_id=arm1_id,
+            current_mu=experiment.arms[0].mu,
+            current_covariance=experiment.arms[0].covariance,
+            outcome=1.5,
+            observed_at=observed_at,
+        ),
+        tables.Draw(
+            experiment_id=experiment.id,
+            participant_type="",
+            participant_id="p2",
+            arm_id=arm2_id,
+            current_mu=experiment.arms[1].mu,
+            current_covariance=experiment.arms[1].covariance,
+        ),
+    ])
+    await xngin_session.commit()
+
+    data = eclient.get_experiment_assignments(
+        api_key=testing_datasource.key,
+        experiment_id=experiment.id,
+    ).data
+    assert data.experiment_id == experiment.id
+    assert data.sample_size == 2
+    assert data.balance_check is None
+
+    assignments_by_participant_id = {assignment.participant_id: assignment for assignment in data.assignments}
+    assert set(assignments_by_participant_id) == {"p1", "p2"}
+
+    p1 = assignments_by_participant_id["p1"]
+    assert str(p1.arm_id) == arm1_id
+    assert p1.arm_name == experiment.arms[0].name
+    assert p1.created_at is not None
+    assert p1.observed_at == observed_at.replace(microsecond=0)
+    assert p1.outcome == 1.5
+    assert p1.context_values is None
+    assert p1.strata is None
+
+    p2 = assignments_by_participant_id["p2"]
+    assert str(p2.arm_id) == arm2_id
+    assert p2.arm_name == experiment.arms[1].name
+    assert p2.created_at is not None
+    assert p2.observed_at is None
+    assert p2.outcome is None
+    assert p2.context_values is None
+    assert p2.strata is None
 
 
 async def test_get_experiment_assignments_as_csv_success(

--- a/src/xngin/apiserver/routers/experiments/test_experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_api.py
@@ -431,27 +431,39 @@ async def test_get_experiment_assignments_streams_cmab_context_values(
         experiment_type=ExperimentsType.CMAB_ONLINE,
     )
 
-    context_inputs_p1 = [
-        ContextInput(context_id=context.context_id, context_value=1.0)
-        for context in sorted(experiment.design_spec.contexts, key=lambda c: c.context_id)
-    ]
-    context_inputs_p2 = [
-        ContextInput(context_id=context.context_id, context_value=2.0)
-        for context in sorted(experiment.design_spec.contexts, key=lambda c: c.context_id)
-    ]
-
+    # Create two draws
     _ = eclient.get_assignment_cmab(
         api_key=testing_datasource.key,
-        body=CMABContextInputRequest(context_inputs=context_inputs_p1),
+        body=CMABContextInputRequest(
+            context_inputs=[
+                ContextInput(context_id=context.context_id, context_value=1.0)
+                for context in sorted(experiment.design_spec.contexts, key=lambda c: c.context_id)
+            ]
+        ),
         experiment_id=experiment.experiment_id,
         participant_id="p1",
     ).data.assignment
     _ = eclient.get_assignment_cmab(
         api_key=testing_datasource.key,
-        body=CMABContextInputRequest(context_inputs=context_inputs_p2),
+        body=CMABContextInputRequest(
+            context_inputs=[
+                ContextInput(context_id=context.context_id, context_value=2.0)
+                for context in sorted(experiment.design_spec.contexts, key=lambda c: c.context_id)
+            ]
+        ),
         experiment_id=experiment.experiment_id,
         participant_id="p2",
     ).data.assignment
+
+    # One participant has an outcome
+    eclient.update_bandit_arm_with_participant_outcome(
+        api_key=testing_datasource.key,
+        body=UpdateBanditArmOutcomeRequest(outcome=1.5),
+        experiment_id=experiment.experiment_id,
+        participant_id="p1",
+    )
+
+    # Fetch assignments from single-assignment endpoint for later comparison.
     first_assignment = eclient.get_assignment_cmab(
         api_key=testing_datasource.key,
         body=CMABContextInputRequest(context_inputs=None),
@@ -469,6 +481,7 @@ async def test_get_experiment_assignments_streams_cmab_context_values(
     assert first_assignment is not None
     assert second_assignment is not None
 
+    # Get all assignments
     data = eclient.get_experiment_assignments(
         api_key=testing_datasource.key,
         experiment_id=experiment.experiment_id,
@@ -482,8 +495,8 @@ async def test_get_experiment_assignments_streams_cmab_context_values(
 
     p1 = assignments_by_participant_id["p1"]
     assert p1.created_at is not None
-    assert p1.observed_at is None
-    assert p1.outcome is None
+    assert p1.observed_at is not None
+    assert p1.outcome == 1.5
     assert p1.strata == []
     assert p1.context_values == [1.0, 1.0]
     assert first_assignment == p1

--- a/src/xngin/apiserver/routers/experiments/test_experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_api.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 from pydantic import TypeAdapter
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from xngin.apiserver.routers.common_api_types import (
     Arm,
@@ -14,12 +13,12 @@ from xngin.apiserver.routers.common_api_types import (
     CMABContextInputRequest,
     CMABExperimentSpec,
     Context,
+    ContextInput,
     CreateExperimentRequest,
     DesignSpecMetricRequest,
     ExperimentConfig,
     ExperimentsType,
     Filter,
-    GetExperimentAssignmentsResponse,
     GetParticipantAssignmentResponse,
     LikelihoodTypes,
     MABExperimentSpec,
@@ -32,7 +31,6 @@ from xngin.apiserver.routers.common_api_types import (
     UpdateBanditArmOutcomeRequest,
 )
 from xngin.apiserver.routers.common_enums import ContextType, ExperimentState, Relation, StopAssignmentReason
-from xngin.apiserver.routers.experiments.test_experiments_common import insert_experiment_and_arms
 from xngin.apiserver.sqla import tables
 from xngin.apiserver.testing.admin_api_client import AdminAPIClientHTTPValidationError
 from xngin.apiserver.testing.experiments_api_client import ExperimentsAPIClientNotDefaultStatusError
@@ -51,6 +49,7 @@ async def create_experiment(
     primary_key: str | None = None,
     end_date: datetime | None = None,
     filters: list[Filter] | None = None,
+    desired_n: int | None = None,
 ):
     """Creates an online experiment using the Admin API."""
     if experiment_type not in {
@@ -75,7 +74,9 @@ async def create_experiment(
     )
     request = CreateExperimentRequest.model_validate(request, from_attributes=True)
     if experiment_type == ExperimentsType.FREQ_PREASSIGNED:
-        result = aclient.create_experiment(datasource_id=datasource_metadata.ds.id, body=request, desired_n=1)
+        result = aclient.create_experiment(
+            datasource_id=datasource_metadata.ds.id, body=request, desired_n=desired_n or 1
+        )
     else:
         result = aclient.create_experiment(datasource_id=datasource_metadata.datasource_id, body=request)
     created_experiment = result.data
@@ -324,113 +325,77 @@ async def test_get_experiment_assignments_success(
 
 
 async def test_get_experiment_assignments_streams_preassigned_assignments(
-    xngin_session: AsyncSession,
     testing_datasource,
+    aclient: AdminAPIClient,
     eclient: ExperimentsAPIClient,
 ):
-    experiment = await insert_experiment_and_arms(xngin_session, testing_datasource.ds)
-    await xngin_session.commit()
-
-    arm1_id = experiment.arms[0].id
-    arm2_id = experiment.arms[1].id
-    xngin_session.add_all([
-        tables.ArmAssignment(
-            experiment_id=experiment.id,
-            participant_type="",
-            participant_id="p1",
-            arm_id=arm1_id,
-            strata=[{"field_name": "gender", "strata_value": "F"}],
-        ),
-        tables.ArmAssignment(
-            experiment_id=experiment.id,
-            participant_type="",
-            participant_id="p2",
-            arm_id=arm2_id,
-            strata=[{"field_name": "gender", "strata_value": "M"}],
-        ),
-        tables.ArmStats(arm_id=arm1_id, population=1),
-        tables.ArmStats(arm_id=arm2_id, population=1),
-    ])
-    await xngin_session.commit()
-
-    response = eclient.client.get(
-        f"/v1/experiments/{experiment.id}/assignments",
-        headers={"X-API-Key": testing_datasource.key},
+    experiment = await create_experiment(
+        testing_datasource,
+        aclient,
+        experiment_type=ExperimentsType.FREQ_PREASSIGNED,
+        desired_n=2,
     )
-    assert response.status_code == HTTPStatus.OK, response.content
-    assert response.headers["content-type"].startswith("application/json")
 
-    data = TypeAdapter(GetExperimentAssignmentsResponse).validate_python(response.json())
-    assert data.experiment_id == experiment.id
-    assert data.sample_size == 2
-    assert data.balance_check is None
-
-    assignments_by_participant_id = {assignment.participant_id: assignment for assignment in data.assignments}
-    assert set(assignments_by_participant_id) == {"p1", "p2"}
-
-    p1 = assignments_by_participant_id["p1"]
-    assert str(p1.arm_id) == arm1_id
-    assert p1.arm_name == "control"
-    assert p1.strata is not None and len(p1.strata) == 1
-    assert p1.strata[0].field_name == "gender"
-    assert p1.strata[0].strata_value == "F"
-    assert p1.created_at is not None
-    assert p1.observed_at is None
-    assert p1.outcome is None
-    assert p1.context_values is None
-
-    p2 = assignments_by_participant_id["p2"]
-    assert str(p2.arm_id) == arm2_id
-    assert p2.arm_name == "treatment"
-    assert p2.strata is not None and len(p2.strata) == 1
-    assert p2.strata[0].field_name == "gender"
-    assert p2.strata[0].strata_value == "M"
-    assert p2.created_at is not None
-    assert p2.observed_at is None
-    assert p2.outcome is None
-    assert p2.context_values is None
-
-
-async def test_get_experiment_assignments_streams_bandit_assignments(
-    xngin_session: AsyncSession,
-    testing_datasource,
-    eclient: ExperimentsAPIClient,
-):
-    experiment = await insert_experiment_and_arms(
-        xngin_session, testing_datasource.ds, experiment_type=ExperimentsType.MAB_ONLINE
-    )
-    await xngin_session.commit()
-
-    observed_at = datetime.now(UTC)
-    arm1_id = experiment.arms[0].id
-    arm2_id = experiment.arms[1].id
-    xngin_session.add_all([
-        tables.Draw(
-            experiment_id=experiment.id,
-            participant_type="",
-            participant_id="p1",
-            arm_id=arm1_id,
-            current_mu=experiment.arms[0].mu,
-            current_covariance=experiment.arms[0].covariance,
-            outcome=1.5,
-            observed_at=observed_at,
-        ),
-        tables.Draw(
-            experiment_id=experiment.id,
-            participant_type="",
-            participant_id="p2",
-            arm_id=arm2_id,
-            current_mu=experiment.arms[1].mu,
-            current_covariance=experiment.arms[1].covariance,
-        ),
-    ])
-    await xngin_session.commit()
+    arms_by_id = {arm.arm_id: arm.arm_name for arm in experiment.design_spec.arms}
 
     data = eclient.get_experiment_assignments(
         api_key=testing_datasource.key,
-        experiment_id=experiment.id,
+        experiment_id=experiment.experiment_id,
     ).data
-    assert data.experiment_id == experiment.id
+    assert data.experiment_id == experiment.experiment_id
+    assert data.sample_size == 2
+    assert data.balance_check is None
+
+    assert len(data.assignments) == 2
+    for assignment in data.assignments:
+        assert assignment.arm_name == arms_by_id[assignment.arm_id]
+        assert assignment.strata is not None and len(assignment.strata) == 1
+        assert assignment.strata[0].field_name == "gender"
+        assert assignment.strata[0].strata_value is not None
+        assert assignment.created_at is not None
+        assert assignment.observed_at is None
+        assert assignment.outcome is None
+        assert assignment.context_values is None
+
+
+async def test_get_experiment_assignments_streams_bandit_assignments(
+    testing_datasource,
+    aclient: AdminAPIClient,
+    eclient: ExperimentsAPIClient,
+):
+    experiment = await create_experiment(
+        testing_datasource,
+        aclient,
+        experiment_type=ExperimentsType.MAB_ONLINE,
+    )
+
+    observed_at = datetime.now(UTC)
+    arms_by_id = {arm.arm_id: arm.arm_name for arm in experiment.design_spec.arms}
+    first_assignment = eclient.get_assignment(
+        api_key=testing_datasource.key,
+        experiment_id=experiment.experiment_id,
+        participant_id="p1",
+    ).data.assignment
+    second_assignment = eclient.get_assignment(
+        api_key=testing_datasource.key,
+        experiment_id=experiment.experiment_id,
+        participant_id="p2",
+    ).data.assignment
+    assert first_assignment is not None
+    assert second_assignment is not None
+
+    eclient.update_bandit_arm_with_participant_outcome(
+        api_key=testing_datasource.key,
+        body=UpdateBanditArmOutcomeRequest(outcome=1.5),
+        experiment_id=experiment.experiment_id,
+        participant_id="p1",
+    )
+
+    data = eclient.get_experiment_assignments(
+        api_key=testing_datasource.key,
+        experiment_id=experiment.experiment_id,
+    ).data
+    assert data.experiment_id == experiment.experiment_id
     assert data.sample_size == 2
     assert data.balance_check is None
 
@@ -438,22 +403,98 @@ async def test_get_experiment_assignments_streams_bandit_assignments(
     assert set(assignments_by_participant_id) == {"p1", "p2"}
 
     p1 = assignments_by_participant_id["p1"]
-    assert str(p1.arm_id) == arm1_id
-    assert p1.arm_name == experiment.arms[0].name
+    assert p1.arm_name == arms_by_id[p1.arm_id]
     assert p1.created_at is not None
-    assert p1.observed_at == observed_at.replace(microsecond=0)
+    assert p1.observed_at is not None
+    assert p1.observed_at >= observed_at.replace(microsecond=0)
     assert p1.outcome == 1.5
     assert p1.context_values is None
-    assert p1.strata is None
+    assert p1.strata == []
 
     p2 = assignments_by_participant_id["p2"]
-    assert str(p2.arm_id) == arm2_id
-    assert p2.arm_name == experiment.arms[1].name
+    assert p2.arm_name == arms_by_id[p2.arm_id]
     assert p2.created_at is not None
     assert p2.observed_at is None
     assert p2.outcome is None
     assert p2.context_values is None
-    assert p2.strata is None
+    assert p2.strata == []
+
+
+async def test_get_experiment_assignments_streams_cmab_context_values(
+    testing_datasource,
+    aclient: AdminAPIClient,
+    eclient: ExperimentsAPIClient,
+):
+    experiment = await create_experiment(
+        testing_datasource,
+        aclient,
+        experiment_type=ExperimentsType.CMAB_ONLINE,
+    )
+
+    context_inputs_p1 = [
+        ContextInput(context_id=context.context_id, context_value=1.0)
+        for context in sorted(experiment.design_spec.contexts, key=lambda c: c.context_id)
+    ]
+    context_inputs_p2 = [
+        ContextInput(context_id=context.context_id, context_value=2.0)
+        for context in sorted(experiment.design_spec.contexts, key=lambda c: c.context_id)
+    ]
+
+    _ = eclient.get_assignment_cmab(
+        api_key=testing_datasource.key,
+        body=CMABContextInputRequest(context_inputs=context_inputs_p1),
+        experiment_id=experiment.experiment_id,
+        participant_id="p1",
+    ).data.assignment
+    _ = eclient.get_assignment_cmab(
+        api_key=testing_datasource.key,
+        body=CMABContextInputRequest(context_inputs=context_inputs_p2),
+        experiment_id=experiment.experiment_id,
+        participant_id="p2",
+    ).data.assignment
+    first_assignment = eclient.get_assignment_cmab(
+        api_key=testing_datasource.key,
+        body=CMABContextInputRequest(context_inputs=None),
+        experiment_id=experiment.experiment_id,
+        participant_id="p1",
+        create_if_none=False,
+    ).data.assignment
+    second_assignment = eclient.get_assignment_cmab(
+        api_key=testing_datasource.key,
+        body=CMABContextInputRequest(context_inputs=None),
+        experiment_id=experiment.experiment_id,
+        participant_id="p2",
+        create_if_none=False,
+    ).data.assignment
+    assert first_assignment is not None
+    assert second_assignment is not None
+
+    data = eclient.get_experiment_assignments(
+        api_key=testing_datasource.key,
+        experiment_id=experiment.experiment_id,
+    ).data
+    assert data.experiment_id == experiment.experiment_id
+    assert data.sample_size == 2
+    assert data.balance_check is None
+
+    assignments_by_participant_id = {assignment.participant_id: assignment for assignment in data.assignments}
+    assert set(assignments_by_participant_id) == {"p1", "p2"}
+
+    p1 = assignments_by_participant_id["p1"]
+    assert p1.created_at is not None
+    assert p1.observed_at is None
+    assert p1.outcome is None
+    assert p1.strata == []
+    assert p1.context_values == [1.0, 1.0]
+    assert first_assignment == p1
+
+    p2 = assignments_by_participant_id["p2"]
+    assert p2.created_at is not None
+    assert p2.observed_at is None
+    assert p2.outcome is None
+    assert p2.strata == []
+    assert p2.context_values == [2.0, 2.0]
+    assert second_assignment == p2
 
 
 async def test_get_experiment_assignments_as_csv_success(
@@ -668,7 +709,7 @@ async def test_get_cmab_experiment_assignment_for_online_participant(
     )
 
     context_inputs = [
-        {"context_id": context.context_id, "context_value": 1.0}
+        ContextInput(context_id=context.context_id, context_value=1.0)
         for context in sorted(online_experiment.design_spec.contexts, key=lambda c: c.context_id)
     ]
     parsed = eclient.get_assignment_cmab(
@@ -688,8 +729,9 @@ async def test_get_cmab_experiment_assignment_for_online_participant(
     assert parsed.assignment.context_values == [1.0, 1.0]
 
     # Test that we get the same assignment for the same participant.
-    parsed2 = eclient.get_assignment(
+    parsed2 = eclient.get_assignment_cmab(
         api_key=testing_datasource.key,
+        body=CMABContextInputRequest(context_inputs=None),
         experiment_id=online_experiment.experiment_id,
         participant_id="1",
     ).data

--- a/src/xngin/apiserver/routers/experiments/test_experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_common.py
@@ -54,7 +54,6 @@ from xngin.apiserver.routers.experiments.experiments_common import (
     fetch_fields_or_raise,
     get_assign_summary,
     get_existing_assignment_for_participant,
-    get_experiment_assignments_impl,
     get_experiment_impl,
     get_or_create_assignment_for_participant,
     make_participants_def_from_experiment,
@@ -1508,129 +1507,6 @@ async def test_get_experiment_impl_of_legacy_experiment(xngin_session, testing_d
     assert result.webhooks == ["wh1"]
     diff = DeepDiff(result.design_spec, expected_design_spec, exclude_regex_paths=[r"arms\[\d+\].arm_id"])
     assert not diff, f"Objects differ:\n{diff.pretty()}"
-
-
-async def test_get_experiment_assignments_impl(xngin_session, testing_datasource):
-    # First insert an experiment with assignments
-    experiment = await insert_experiment_and_arms(xngin_session, testing_datasource.ds)
-    await xngin_session.commit()
-
-    experiment_id = experiment.id
-    arm1_id = experiment.arms[0].id
-    arm2_id = experiment.arms[1].id
-    arm_assignments = [
-        tables.ArmAssignment(
-            experiment_id=experiment_id,
-            participant_type="",
-            participant_id="p1",
-            arm_id=arm1_id,
-            strata=[{"field_name": "gender", "strata_value": "F"}],
-        ),
-        tables.ArmAssignment(
-            experiment_id=experiment_id,
-            participant_type="",
-            participant_id="p2",
-            arm_id=arm2_id,
-            strata=[{"field_name": "gender", "strata_value": "M"}],
-        ),
-    ]
-    xngin_session.add_all(arm_assignments)
-    xngin_session.add_all([
-        tables.ArmStats(arm_id=arm1_id, population=1),
-        tables.ArmStats(arm_id=arm2_id, population=1),
-    ])
-    await xngin_session.commit()
-    await xngin_session.refresh(experiment, ["arms", "arm_assignments"])
-
-    data = await get_experiment_assignments_impl(xngin_session, experiment)
-
-    # Check the response structure
-    assert data.experiment_id == experiment.id
-    actual_assign_summary = await get_assign_summary(
-        xngin_session, experiment.id, None, ExperimentsType(experiment.experiment_type)
-    )
-    assert data.sample_size == actual_assign_summary.sample_size
-    assert data.balance_check == ExperimentStorageConverter(experiment).get_balance_check()
-
-    # Check assignments
-    assignments = data.assignments
-    assert len(assignments) == 2
-
-    # Verify first assignment
-    assert assignments[0].participant_id == "p1"
-    assert str(assignments[0].arm_id) == arm1_id
-    assert assignments[0].arm_name == "control"
-    assert assignments[0].strata is not None and len(assignments[0].strata) == 1
-    assert assignments[0].strata[0].field_name == "gender"
-    assert assignments[0].strata[0].strata_value == "F"
-    assert assignments[0].created_at is not None
-
-    # Verify second assignment
-    assert assignments[1].participant_id == "p2"
-    assert str(assignments[1].arm_id) == arm2_id
-    assert assignments[1].arm_name == "treatment"
-    assert assignments[1].strata is not None and len(assignments[1].strata) == 1
-    assert assignments[1].strata[0].field_name == "gender"
-    assert assignments[1].strata[0].strata_value == "M"
-    assert assignments[1].created_at is not None
-
-
-async def test_get_experiment_mab_assignments_impl(xngin_session, testing_datasource):
-    # First insert an experiment with assignments
-    experiment = await insert_experiment_and_arms(
-        xngin_session, testing_datasource.ds, experiment_type=ExperimentsType.MAB_ONLINE
-    )
-    await xngin_session.commit()
-
-    experiment_id = experiment.id
-    arm1_id = experiment.arms[0].id
-    arm2_id = experiment.arms[1].id
-    arm_assignments = [
-        tables.Draw(
-            experiment_id=experiment_id,
-            participant_type="",
-            participant_id="p1",
-            arm_id=arm1_id,
-            current_mu=experiment.arms[0].mu,
-            current_covariance=experiment.arms[0].covariance,
-        ),
-        tables.Draw(
-            experiment_id=experiment_id,
-            participant_type="",
-            participant_id="p2",
-            arm_id=arm2_id,
-            current_mu=experiment.arms[1].mu,
-            current_covariance=experiment.arms[1].covariance,
-        ),
-    ]
-    xngin_session.add_all(arm_assignments)
-    await xngin_session.commit()
-    await xngin_session.refresh(experiment, ["arms", "draws"])
-
-    data = await get_experiment_assignments_impl(xngin_session, experiment)
-
-    # Check the response structure
-    assert data.experiment_id == experiment.id
-
-    # Check assignments
-    assignments = data.assignments
-    assert len(assignments) == 2
-
-    # Verify first assignment
-    assert assignments[0].participant_id == "p1"
-    assert str(assignments[0].arm_id) == arm1_id
-    assert assignments[0].arm_name == "string"
-
-    # Verify second assignment
-    assert assignments[1].participant_id == "p2"
-    assert str(assignments[1].arm_id) == arm2_id
-    assert assignments[1].arm_name == "string"
-
-    for assignment in assignments:
-        assert assignment.outcome is None
-        assert assignment.context_values is None
-        assert assignment.observed_at is None
-        assert assignment.created_at is not None
 
 
 async def make_experiment_with_assignments(

--- a/src/xngin/apiserver/routers/experiments/test_experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_common.py
@@ -1542,7 +1542,7 @@ async def test_get_experiment_assignments_impl(xngin_session, testing_datasource
     await xngin_session.commit()
     await xngin_session.refresh(experiment, ["arms", "arm_assignments"])
 
-    data = get_experiment_assignments_impl(experiment)
+    data = await get_experiment_assignments_impl(xngin_session, experiment)
 
     # Check the response structure
     assert data.experiment_id == experiment.id
@@ -1607,7 +1607,7 @@ async def test_get_experiment_mab_assignments_impl(xngin_session, testing_dataso
     await xngin_session.commit()
     await xngin_session.refresh(experiment, ["arms", "draws"])
 
-    data = get_experiment_assignments_impl(experiment)
+    data = await get_experiment_assignments_impl(xngin_session, experiment)
 
     # Check the response structure
     assert data.experiment_id == experiment.id

--- a/src/xngin/apiserver/snapshots/snapshotter.py
+++ b/src/xngin/apiserver/snapshots/snapshotter.py
@@ -87,7 +87,6 @@ async def make_first_snapshot(experiment_id: str, snapshot_id: str):
                 .options(
                     selectinload(tables.Snapshot.experiment),
                     selectinload(tables.Snapshot.experiment).selectinload(tables.Experiment.arms),
-                    selectinload(tables.Snapshot.experiment).selectinload(tables.Experiment.arm_assignments),
                     selectinload(tables.Snapshot.experiment).selectinload(tables.Experiment.draws),
                     selectinload(tables.Snapshot.experiment).selectinload(tables.Experiment.contexts),
                     selectinload(tables.Snapshot.experiment).selectinload(tables.Experiment.datasource),

--- a/src/xngin/apiserver/sql/queries.py
+++ b/src/xngin/apiserver/sql/queries.py
@@ -1,8 +1,9 @@
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
 from loguru import logger
+from psycopg.rows import TupleRow
 
 from xngin.ops import performance
 
@@ -71,3 +72,10 @@ async def select_as_csv(
                 yield_count += 1
                 yield bytes(buffer)
     logger.info("select_as_csv streamed {} chunks in {}s", yield_count, timings.elapsed)
+
+
+async def stream(session: AsyncSession, select_query: Template, size: int) -> AsyncGenerator[TupleRow]:
+    """Streams the results of a query, asking libpq to buffer up to size rows at a time."""
+    async with with_driver_connection(session) as driver_conn, driver_conn.cursor() as cursor:
+        async for row in cursor.stream(select_query, size=size):
+            yield row


### PR DESCRIPTION
Previously, `experiments_api.get_experiment_assignments` would OOM on 1M
assignments. Now it completes in ~3s.

Also, the documented behavior of `experiments_api.get_assignment_cmab` differed
from reality. The two have now been aligned.

Also, moves a test from the common to the API level.