### PR TITLE
Additional bandit analysis tests

### DIFF
--- a/src/xngin/apiserver/routers/admin/test_admin.py
+++ b/src/xngin/apiserver/routers/admin/test_admin.py
@@ -61,6 +61,7 @@ from xngin.apiserver.routers.common_api_types import (
     BanditExperimentAnalysisResponse,
     CMABContextInputRequest,
     CMABExperimentSpec,
+    ContextInput,
     CreateExperimentRequest,
     CreateExperimentResponse,
     DataType,
@@ -77,6 +78,7 @@ from xngin.apiserver.routers.common_api_types import (
     PreassignedFrequentistExperimentSpec,
     PriorTypes,
     Stratum,
+    UpdateBanditArmOutcomeRequest,
 )
 from xngin.apiserver.routers.common_enums import (
     ExperimentState,
@@ -131,9 +133,7 @@ def find_ds_with_name[DSType: HasName](datasources: list[DSType], name: str) -> 
 
 
 async def make_freq_online_experiment(
-    datasource_id: str,
-    aclient: AdminAPIClient,
-    end_date: datetime | None = None,
+    aclient: AdminAPIClient, datasource_id: str, end_date: datetime | None = None
 ) -> GetExperimentForUiResponse:
     """Create a frequentist online experiment using our API (rather than a fixture)."""
     end_date = end_date or datetime.now(UTC) + timedelta(days=1)
@@ -163,6 +163,45 @@ async def make_freq_online_experiment(
     data = aclient.get_experiment_for_ui(datasource_id=datasource_id, experiment_id=experiment_id).data
     assert isinstance(data, GetExperimentForUiResponse)
     return data
+
+
+def normalize_bandit_analysis(response: BanditExperimentAnalysisResponse) -> BanditExperimentAnalysisResponse:
+    return response.model_copy(update={"created_at": datetime(2000, 1, 1, tzinfo=UTC)})
+
+
+async def make_bandit_online_experiment(
+    aclient: AdminAPIClient,
+    datasource_id: str,
+    *,
+    experiment_type: ExperimentsType = ExperimentsType.MAB_ONLINE,
+    prior_type: PriorTypes = PriorTypes.BETA,
+    reward_type: LikelihoodTypes = LikelihoodTypes.BERNOULLI,
+) -> GetExperimentForUiResponse:
+    request_obj = make_create_online_bandit_experiment_request(
+        experiment_type=experiment_type,
+        reward_type=reward_type,
+        prior_type=prior_type,
+    )
+    experiment_id = aclient.create_experiment(datasource_id=datasource_id, body=request_obj, random_state=42).data
+    aclient.commit_experiment(datasource_id=datasource_id, experiment_id=experiment_id.experiment_id)
+    data = aclient.get_experiment_for_ui(datasource_id=datasource_id, experiment_id=experiment_id.experiment_id).data
+    assert isinstance(data, GetExperimentForUiResponse)
+    return data
+
+
+def make_cmab_context_inputs(
+    experiment: GetExperimentForUiResponse,
+    values: list[float],
+) -> list[ContextInput]:
+    design_spec = experiment.config.design_spec
+    assert isinstance(design_spec, CMABExperimentSpec)
+    assert design_spec.contexts is not None
+    sorted_contexts = sorted(design_spec.contexts, key=lambda c: c.context_id or "")
+    assert len(sorted_contexts) == len(values)
+    return [
+        ContextInput(context_id=context.context_id or "", context_value=value)
+        for context, value in zip(sorted_contexts, values, strict=True)
+    ]
 
 
 @pytest.fixture(name="testing_experiment")
@@ -2350,9 +2389,127 @@ def test_cmab_experiments_analyze(testing_bandit_experiment, aclient: AdminAPICl
         assert analysis.post_pred_stdev is not None
 
 
+async def test_mab_experiments_analyze_ignores_unobserved_draws_with_single_outcome(
+    testing_datasource,
+    aclient: AdminAPIClient,
+    eclient: ExperimentsAPIClient,
+):
+    experiment = await make_bandit_online_experiment(
+        aclient, testing_datasource.ds.id, prior_type=PriorTypes.NORMAL, reward_type=LikelihoodTypes.NORMAL
+    )
+
+    eclient.get_assignment(
+        api_key=testing_datasource.key,
+        experiment_id=experiment.config.experiment_id,
+        participant_id="p1",
+    )
+    eclient.update_bandit_arm_with_participant_outcome(
+        api_key=testing_datasource.key,
+        body=UpdateBanditArmOutcomeRequest(outcome=1.0),
+        experiment_id=experiment.config.experiment_id,
+        participant_id="p1",
+    )
+
+    analysis_before_unobserved_draw = aclient.analyze_experiment(
+        datasource_id=testing_datasource.ds.id,
+        experiment_id=experiment.config.experiment_id,
+    ).data
+    assert isinstance(analysis_before_unobserved_draw, BanditExperimentAnalysisResponse)
+
+    eclient.get_assignment(
+        api_key=testing_datasource.key,
+        experiment_id=experiment.config.experiment_id,
+        participant_id="p2",
+    )
+
+    analysis_after_unobserved_draw = aclient.analyze_experiment(
+        datasource_id=testing_datasource.ds.id,
+        experiment_id=experiment.config.experiment_id,
+    ).data
+    assert isinstance(analysis_after_unobserved_draw, BanditExperimentAnalysisResponse)
+
+    assert normalize_bandit_analysis(analysis_after_unobserved_draw) == normalize_bandit_analysis(
+        analysis_before_unobserved_draw
+    )
+
+
+async def test_mab_experiments_analyze_ignores_unobserved_draws_with_multiple_outcomes(
+    testing_datasource,
+    aclient: AdminAPIClient,
+    eclient: ExperimentsAPIClient,
+):
+    experiment = await make_bandit_online_experiment(
+        aclient, testing_datasource.ds.id, prior_type=PriorTypes.NORMAL, reward_type=LikelihoodTypes.NORMAL
+    )
+
+    for participant_id, outcome in [("p1", 1.0), ("p2", 0.0)]:
+        eclient.get_assignment(
+            api_key=testing_datasource.key,
+            experiment_id=experiment.config.experiment_id,
+            participant_id=participant_id,
+        )
+        eclient.update_bandit_arm_with_participant_outcome(
+            api_key=testing_datasource.key,
+            body=UpdateBanditArmOutcomeRequest(outcome=outcome),
+            experiment_id=experiment.config.experiment_id,
+            participant_id=participant_id,
+        )
+
+    analysis_before_unobserved_draw = aclient.analyze_experiment(
+        datasource_id=testing_datasource.ds.id,
+        experiment_id=experiment.config.experiment_id,
+    ).data
+    assert isinstance(analysis_before_unobserved_draw, BanditExperimentAnalysisResponse)
+
+    eclient.get_assignment(
+        api_key=testing_datasource.key,
+        experiment_id=experiment.config.experiment_id,
+        participant_id="p3",
+    )
+
+    analysis_after_unobserved_draw = aclient.analyze_experiment(
+        datasource_id=testing_datasource.ds.id,
+        experiment_id=experiment.config.experiment_id,
+    ).data
+    assert isinstance(analysis_after_unobserved_draw, BanditExperimentAnalysisResponse)
+
+    assert normalize_bandit_analysis(analysis_after_unobserved_draw) == normalize_bandit_analysis(
+        analysis_before_unobserved_draw
+    )
+
+
+async def test_mab_experiments_analyze_with_assigned_but_unobserved_participants_matches_prior(
+    testing_datasource,
+    aclient: AdminAPIClient,
+    eclient: ExperimentsAPIClient,
+):
+    experiment = await make_bandit_online_experiment(
+        aclient, testing_datasource.ds.id, prior_type=PriorTypes.NORMAL, reward_type=LikelihoodTypes.NORMAL
+    )
+
+    for participant_id in ["p1", "p2"]:
+        eclient.get_assignment(
+            api_key=testing_datasource.key,
+            experiment_id=experiment.config.experiment_id,
+            participant_id=participant_id,
+        )
+
+    experiment_analysis = aclient.analyze_experiment(
+        datasource_id=testing_datasource.ds.id,
+        experiment_id=experiment.config.experiment_id,
+    ).data
+    assert isinstance(experiment_analysis, BanditExperimentAnalysisResponse)
+
+    assert experiment_analysis.n_outcomes == 0
+    assert experiment_analysis.contexts is None
+    for analysis in experiment_analysis.arm_analyses:
+        assert analysis.post_pred_mean == analysis.prior_pred_mean
+        assert analysis.post_pred_stdev == analysis.prior_pred_stdev
+
+
 async def test_analyze_experiment_with_no_participants(testing_datasource, aclient: AdminAPIClient):
     datasource_id = testing_datasource.ds.id
-    experiment_id = (await make_freq_online_experiment(datasource_id, aclient)).config.experiment_id
+    experiment_id = (await make_freq_online_experiment(aclient, datasource_id)).config.experiment_id
 
     with expect_status_code(422, detail_eq="No participants found for experiment."):
         aclient.analyze_experiment(datasource_id=datasource_id, experiment_id=experiment_id)
@@ -2362,7 +2519,7 @@ async def test_analyze_experiment_whose_assignments_have_no_dwh_data(
     testing_datasource, aclient: AdminAPIClient, eclient: ExperimentsAPIClient
 ):
     datasource_id = testing_datasource.ds.id
-    experiment_id = (await make_freq_online_experiment(datasource_id, aclient)).config.experiment_id
+    experiment_id = (await make_freq_online_experiment(aclient, datasource_id)).config.experiment_id
 
     eclient.get_assignment(api_key=testing_datasource.key, experiment_id=experiment_id, participant_id="0")
 
@@ -2377,7 +2534,7 @@ async def test_analyze_experiment_with_no_assignments_in_one_arm_yet(
     xngin_session, testing_datasource, aclient: AdminAPIClient
 ):
     datasource_id = testing_datasource.ds.id
-    experiment_id = (await make_freq_online_experiment(datasource_id, aclient)).config.experiment_id
+    experiment_id = (await make_freq_online_experiment(aclient, datasource_id)).config.experiment_id
 
     # Setup: create artificial assignments directly in db to deterministically allocate them all to
     # one arm. Multiple are used for stable analysis calcs.

--- a/src/xngin/apiserver/snapshots/test_snapshotter.py
+++ b/src/xngin/apiserver/snapshots/test_snapshotter.py
@@ -1,4 +1,5 @@
 import asyncio
+import math
 import warnings
 from datetime import UTC, datetime, timedelta
 
@@ -700,7 +701,19 @@ async def test_create_snapshot_cmab_matches_admin_analysis_at_mean_contexts(
                 participant_id=participant_id,
             )
 
-    expected_contexts = [1.0 if context.value_type == ContextType.BINARY else 7.0 / 3.0 for context in sorted_contexts]
+    # BINARY context uses rounded mean of values; REAL_VALUED maps values < 0.5 to 0, else 1.
+    expected_real_context = sum(
+        participant_context_values[ContextType.REAL_VALUED] for _, participant_context_values, _ in participant_specs
+    ) / len(participant_specs)
+    mean_binary_context = sum(
+        participant_context_values[ContextType.BINARY] for _, participant_context_values, _ in participant_specs
+    ) / len(participant_specs)
+    # See snapshotter for details on thresholding behavior.
+    expected_binary_context = abs(float(math.ceil(mean_binary_context - 0.5)))
+    expected_contexts = [
+        expected_binary_context if context.value_type == ContextType.BINARY else expected_real_context
+        for context in sorted_contexts
+    ]
     admin_analysis = aclient.analyze_cmab_experiment(
         datasource_id=testing_datasource.ds.id,
         experiment_id=experiment_id,

--- a/src/xngin/apiserver/snapshots/test_snapshotter.py
+++ b/src/xngin/apiserver/snapshots/test_snapshotter.py
@@ -42,6 +42,10 @@ from xngin.apiserver.testing.experiments_api_client import ExperimentsAPIClient
 from xngin.apiserver.testing.testing_dwh_def import TESTING_DWH_PARTICIPANT_DEF
 
 
+def normalize_bandit_analysis(response: BanditExperimentAnalysisResponse) -> BanditExperimentAnalysisResponse:
+    return response.model_copy(update={"created_at": datetime(2000, 1, 1, tzinfo=UTC)})
+
+
 async def make_experiment(
     xngin_session,
     datasource: tables.Datasource,
@@ -149,6 +153,52 @@ def create_snapshot_experiment(
     ).data.experiment_id
     aclient.commit_experiment(datasource_id=testing_datasource.ds.id, experiment_id=experiment_id)
     return experiment_id
+
+
+def get_bandit_snapshot_analysis(
+    aclient: AdminAPIClient,
+    testing_datasource,
+    experiment_id: str,
+    snapshot_id: str,
+) -> BanditExperimentAnalysisResponse:
+    snapshot = aclient.get_snapshot(
+        organization_id=testing_datasource.org.id,
+        datasource_id=testing_datasource.ds.id,
+        experiment_id=experiment_id,
+        snapshot_id=snapshot_id,
+    ).data.snapshot
+    assert snapshot.status == SnapshotStatus.SUCCESS
+    data = snapshot.data
+    assert isinstance(data, BanditExperimentAnalysisResponse)
+    return data
+
+
+def get_sorted_cmab_context_inputs(
+    aclient: AdminAPIClient,
+    testing_datasource,
+    experiment_id: str,
+    values: list[float],
+) -> list[ContextInput]:
+    sorted_contexts = get_sorted_cmab_contexts(aclient, testing_datasource, experiment_id)
+    assert len(sorted_contexts) == len(values)
+    return [
+        ContextInput(context_id=context.context_id or "", context_value=value)
+        for context, value in zip(sorted_contexts, values, strict=True)
+    ]
+
+
+def get_sorted_cmab_contexts(
+    aclient: AdminAPIClient,
+    testing_datasource,
+    experiment_id: str,
+) -> list[Context]:
+    config = aclient.get_experiment_for_ui(
+        datasource_id=testing_datasource.ds.id,
+        experiment_id=experiment_id,
+    ).data.config
+    assert isinstance(config.design_spec, CMABExperimentSpec)
+    assert config.design_spec.contexts is not None
+    return sorted(config.design_spec.contexts, key=lambda c: c.context_id or "")
 
 
 async def test_make_first_snapshot_of_freq_preassigned(xngin_session, testing_datasource):
@@ -466,6 +516,9 @@ async def create_bandit_snapshot_experiment(
     *,
     experiment_type: ExperimentsType,
     with_draws: bool = True,
+    desired_n: int = 2,
+    prior_type: PriorTypes = PriorTypes.NORMAL,
+    reward_type: LikelihoodTypes = LikelihoodTypes.BERNOULLI,
 ) -> str:
     """Helper to create a bandit experiment for the test_create_snapshot_bandit_succeeds test."""
     design_spec: MABExperimentSpec | CMABExperimentSpec
@@ -478,11 +531,25 @@ async def create_bandit_snapshot_experiment(
                 start_date=datetime(2024, 1, 1, tzinfo=UTC),
                 end_date=datetime.now(UTC) + timedelta(days=1),
                 arms=[
-                    ArmBandit(arm_name="control", arm_description="", alpha_init=1, beta_init=1),
-                    ArmBandit(arm_name="treatment", arm_description="", alpha_init=1, beta_init=1),
+                    ArmBandit(
+                        arm_name="control",
+                        arm_description="",
+                        alpha_init=1 if prior_type == PriorTypes.BETA else None,
+                        beta_init=1 if prior_type == PriorTypes.BETA else None,
+                        mu_init=0 if prior_type == PriorTypes.NORMAL else None,
+                        sigma_init=1 if prior_type == PriorTypes.NORMAL else None,
+                    ),
+                    ArmBandit(
+                        arm_name="treatment",
+                        arm_description="",
+                        alpha_init=1 if prior_type == PriorTypes.BETA else None,
+                        beta_init=1 if prior_type == PriorTypes.BETA else None,
+                        mu_init=0 if prior_type == PriorTypes.NORMAL else None,
+                        sigma_init=1 if prior_type == PriorTypes.NORMAL else None,
+                    ),
                 ],
-                prior_type=PriorTypes.BETA,
-                reward_type=LikelihoodTypes.BERNOULLI,
+                prior_type=prior_type,
+                reward_type=reward_type,
             )
         case ExperimentsType.CMAB_ONLINE:
             design_spec = CMABExperimentSpec(
@@ -499,8 +566,8 @@ async def create_bandit_snapshot_experiment(
                     Context(context_name="context1", context_description="", value_type=ContextType.BINARY),
                     Context(context_name="context2", context_description="", value_type=ContextType.REAL_VALUED),
                 ],
-                prior_type=PriorTypes.NORMAL,
-                reward_type=LikelihoodTypes.BERNOULLI,
+                prior_type=prior_type,
+                reward_type=reward_type,
             )
         case _:
             raise ValueError(f"Unsupported experiment type: {experiment_type}")
@@ -508,7 +575,7 @@ async def create_bandit_snapshot_experiment(
     experiment_id = aclient.create_experiment(
         datasource_id=testing_datasource.ds.id,
         body=CreateExperimentRequest(design_spec=design_spec),
-        desired_n=2,
+        desired_n=desired_n,
         random_state=42,
     ).data.experiment_id
     aclient.commit_experiment(datasource_id=testing_datasource.ds.id, experiment_id=experiment_id)
@@ -588,7 +655,84 @@ async def test_create_snapshot_bandit_succeeds(
     assert data.n_outcomes == 2
 
 
-async def test_create_snapshot_cmab_with_zero_draws_succeeds(
+async def test_create_snapshot_cmab_matches_admin_analysis_at_mean_contexts(
+    testing_datasource,
+    aclient: AdminAPIClient,
+    eclient: ExperimentsAPIClient,
+):
+    experiment_id = await create_bandit_snapshot_experiment(
+        aclient,
+        eclient,
+        testing_datasource,
+        experiment_type=ExperimentsType.CMAB_ONLINE,
+        with_draws=False,
+        desired_n=3,
+        reward_type=LikelihoodTypes.NORMAL,
+    )
+    sorted_contexts = get_sorted_cmab_contexts(aclient, testing_datasource, experiment_id)
+
+    participant_specs = [
+        ("p1", {ContextType.BINARY: 1.0, ContextType.REAL_VALUED: 1.0}, 0.0),
+        ("p2", {ContextType.BINARY: 0.0, ContextType.REAL_VALUED: 2.0}, 1.0),
+        ("p3", {ContextType.BINARY: 1.0, ContextType.REAL_VALUED: 4.0}, None),
+    ]
+    for participant_id, context_values_by_type, outcome in participant_specs:
+        context_inputs = [
+            ContextInput(
+                context_id=context.context_id or "",
+                context_value=context_values_by_type[context.value_type],
+            )
+            for context in sorted_contexts
+        ]
+        assignment_response = eclient.get_assignment_cmab(
+            api_key=testing_datasource.key,
+            body=CMABContextInputRequest(context_inputs=context_inputs),
+            experiment_id=experiment_id,
+            participant_id=participant_id,
+            raise_if_not_default_status=False,
+        )
+        assert assignment_response.status == 200, assignment_response.data
+        if outcome is not None:
+            eclient.update_bandit_arm_with_participant_outcome(
+                api_key=testing_datasource.key,
+                body=UpdateBanditArmOutcomeRequest(outcome=outcome),
+                experiment_id=experiment_id,
+                participant_id=participant_id,
+            )
+
+    expected_contexts = [1.0 if context.value_type == ContextType.BINARY else 7.0 / 3.0 for context in sorted_contexts]
+    admin_analysis = aclient.analyze_cmab_experiment(
+        datasource_id=testing_datasource.ds.id,
+        experiment_id=experiment_id,
+        body=CMABContextInputRequest(
+            context_inputs=get_sorted_cmab_context_inputs(
+                aclient,
+                testing_datasource,
+                experiment_id,
+                expected_contexts,
+            )
+        ),
+    ).data
+    assert isinstance(admin_analysis, BanditExperimentAnalysisResponse)
+
+    create_snapshot_response = aclient.create_snapshot(
+        organization_id=testing_datasource.org.id,
+        datasource_id=testing_datasource.ds.id,
+        experiment_id=experiment_id,
+    ).data
+    snapshot_analysis = get_bandit_snapshot_analysis(
+        aclient,
+        testing_datasource,
+        experiment_id,
+        create_snapshot_response.id,
+    )
+
+    assert snapshot_analysis.n_outcomes == 2
+    assert snapshot_analysis.contexts == expected_contexts
+    assert normalize_bandit_analysis(snapshot_analysis) == normalize_bandit_analysis(admin_analysis)
+
+
+async def test_create_snapshot_cmab_with_zero_draws_matches_zero_context_admin_analysis(
     testing_datasource,
     aclient: AdminAPIClient,
     eclient: ExperimentsAPIClient,
@@ -601,19 +745,33 @@ async def test_create_snapshot_cmab_with_zero_draws_succeeds(
         with_draws=False,
     )
 
-    aclient.create_snapshot(
+    expected_contexts = [0.0, 0.0]
+    admin_analysis = aclient.analyze_cmab_experiment(
+        datasource_id=testing_datasource.ds.id,
+        experiment_id=experiment_id,
+        body=CMABContextInputRequest(
+            context_inputs=get_sorted_cmab_context_inputs(
+                aclient,
+                testing_datasource,
+                experiment_id,
+                expected_contexts,
+            )
+        ),
+    ).data
+    assert isinstance(admin_analysis, BanditExperimentAnalysisResponse)
+
+    create_snapshot_response = aclient.create_snapshot(
         organization_id=testing_datasource.org.id,
         datasource_id=testing_datasource.ds.id,
         experiment_id=experiment_id,
+    ).data
+    snapshot_analysis = get_bandit_snapshot_analysis(
+        aclient,
+        testing_datasource,
+        experiment_id,
+        create_snapshot_response.id,
     )
 
-    snapshots = aclient.list_snapshots(
-        organization_id=testing_datasource.org.id,
-        datasource_id=testing_datasource.ds.id,
-        experiment_id=experiment_id,
-    ).data.items
-    assert len(snapshots) == 1
-    assert snapshots[0].status == SnapshotStatus.SUCCESS
-    data = snapshots[0].data
-    assert isinstance(data, BanditExperimentAnalysisResponse)
-    assert data.n_outcomes == 0
+    assert snapshot_analysis.n_outcomes == 0
+    assert snapshot_analysis.contexts == expected_contexts
+    assert normalize_bandit_analysis(snapshot_analysis) == normalize_bandit_analysis(admin_analysis)


### PR DESCRIPTION
These tests improve coverage of corner cases in bandit analysis and will serve to ensure that upcoming performance-related changes do not alter user-visible behavior of the API.
