### PR TITLE
refactor: remove redundant context guard in `_update_arm_normal`

### DIFF
--- a/src/xngin/stats/bandit_sampling.py
+++ b/src/xngin/stats/bandit_sampling.py
@@ -131,8 +131,7 @@ def _update_arm_normal(
 
     # New mean
     llhood_term: np.ndarray | float = reward / llhood_sigma**2
-    if context is not None:
-        llhood_term = (context * llhood_term).squeeze()
+    llhood_term = (context * llhood_term).squeeze()
 
     new_mu = new_covariance @ ((prior_covariance_inv @ current_mu) + llhood_term)
     return UpdateTypeNormal(mu=new_mu.tolist(), covariance=new_covariance.tolist())


### PR DESCRIPTION
## Ticket

N/A (Code cleanup / Refactoring)

## Related PRs

Frontend: N/A
Docs: N/A

## Description

Removed the redundant `if context is not None:` guard in the `_update_arm_normal` function within `src/xngin/stats/bandit_sampling.py`. 

The `context` parameter is strictly typed as an `np.ndarray` and is guaranteed to not be `None` when called from `update_arm()` (where it defaults to `[1.0]` if missing). This change removes an unreachable branch and cleans up the code without altering any functionality.

## Future Tasks (optional)

- Make `llhood_sigma` configurable in `update_arm()` (currently hardcoded as a TODO).

## How has this been tested?

- Code compiles and existing unit tests in `src/xngin/stats/` pass.
- Verified type hints and call sites.


