### PR TITLE
Add a test-only task to taskfile

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -222,11 +222,19 @@ tasks:
       task test -- src/xngin/apiserver/routers/admin/test_admin.py # run a single test file
       task test -- -k tests_matching_some_string_expression -rA    # run subset of tests, show all output in summary
       task test -- -m integration                                  # run tests annotated with @pytest.mark.integration
+      task test -- --lf                                            # only re-run failed tests
     interactive: true
     env:
       DATABASE_URL: "{{.DATABASE_URL_FOR_TEST}}"
     deps:
       - bootstrap-dwh-database
+    cmds:
+      - uv run pytest {{.CLI_ARGS}}
+  test-only:
+    desc: "Runs unit tests without boostrapping the DWH database."
+    interactive: true
+    env:
+      DATABASE_URL: "{{.DATABASE_URL_FOR_TEST}}"
     cmds:
       - uv run pytest {{.CLI_ARGS}}
   test-psycopg2:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -237,15 +237,6 @@ tasks:
       DATABASE_URL: "{{.DATABASE_URL_FOR_TEST}}"
     cmds:
       - uv run pytest {{.CLI_ARGS}}
-  test-psycopg2:
-    desc: "Runs unit tests with the older psycopg2 driver"
-    interactive: true
-    env:
-      DATABASE_URL: "{{.DATABASE_URL_FOR_TEST}}"
-      XNGIN_DEVDWH_DSN: "{{regexReplaceAll `psycopg\\d*` .XNGIN_DEVDWH_DSN `psycopg2`}}"
-      XNGIN_QUERIES_TEST_URI: "{{regexReplaceAll `psycopg\\d*` .XNGIN_QUERIES_TEST_URI `psycopg2`}}"
-    cmds:
-      - uv run pytest {{.CLI_ARGS}}
   test-airplane:
     desc: "Run unit tests (in airplane mode)."
     interactive: true


### PR DESCRIPTION
`test-only` skips the `bootstrap-dwh-database` dependency. 
(Also makes it easier to run tests within a sandboxed agent, in conjunction with a rule that says  ``` Run tests with `UV_CACHE_DIR="${PWD}/.uv-cache" task test-only` ```, as it won't try to reach out of the current working dir to access a global uv cache nor require docker permissions to set up the db.)