### PR TITLE
raise error when the unique identifier is also used as a strata column

### DIFF
--- a/src/xngin/stats/assignment.py
+++ b/src/xngin/stats/assignment.py
@@ -11,7 +11,7 @@ from xngin.stats.balance import (
     preprocess_for_balance_and_stratification,
     restore_original_numeric_columns,
 )
-from xngin.stats.stats_errors import StatsError
+from xngin.stats.stats_errors import StatsAssignmentError
 
 STOCHATREAT_STRATUM_ID_NAME = "stratum_id"
 STOCHATREAT_TREAT_NAME = "treat"
@@ -66,6 +66,9 @@ def assign_treatment_and_check_balance(
             orig_stratum_cols - deduplicated and sorted list of stratum_cols.
                 May be useful for referencing original db values used in your df.
     """
+    if id_col in stratum_cols:
+        raise StatsAssignmentError(f"Columns with only unique values should not be used as strata: {id_col}")
+
     if len(stratum_cols) == 0:
         # No stratification, so use simple random assignment
         treatment_ids = simple_random_assignment(df, n_arms, random_state, arm_weights)
@@ -125,7 +128,7 @@ def assign_treatment_and_check_balance(
     treatment_ids = df_cleaned[STOCHATREAT_TREAT_NAME]
 
     if len(df) != len(df_cleaned):
-        raise StatsError(
+        raise StatsAssignmentError(
             f"Expected {len(df)} assignments but only have {len(df_cleaned)}. "
             f"Check if your {id_col} values could be causing problems."
         )

--- a/src/xngin/stats/stats_errors.py
+++ b/src/xngin/stats/stats_errors.py
@@ -21,5 +21,9 @@ class StatsBalanceError(StatsError):
     """Errors arising from steps in the balance check, e.g. not having usable covariates."""
 
 
+class StatsAssignmentError(StatsError):
+    """Errors arising from steps in the assignment, e.g. invalid strata."""
+
+
 class StatsAnalysisError(StatsError):
     """Errors arising from steps in the analysis, e.g. not having data."""

--- a/src/xngin/stats/test_assignment.py
+++ b/src/xngin/stats/test_assignment.py
@@ -12,6 +12,7 @@ from xngin.stats.assignment import (
     simple_random_assignment,
 )
 from xngin.stats.balance import BalanceResult
+from xngin.stats.stats_errors import StatsAssignmentError
 
 
 def make_sample_data_dict(n=1000):
@@ -253,6 +254,12 @@ def test_assign_treatment_with_no_valid_strata(sample_df):
     # Arm lengths should be equal
     assert set(result.treatment_ids) == {0, 1}
     assert result.treatment_ids.count(0) == result.treatment_ids.count(1)
+
+
+def test_assign_treatment_incorrectly_using_id_as_strata(sample_df):
+    """Test assignment when incorrectly uses the unique id column also as a strata column."""
+    with pytest.raises(StatsAssignmentError, match="Columns with only unique values should not be used as strata: id"):
+        assign_treatment_and_check_balance(df=sample_df, stratum_cols=["id"], id_col="id", n_arms=2, random_state=42)
 
 
 def test_simple_random_assignment(sample_df):


### PR DESCRIPTION
## Ticket

Quick fix to an error that can arise e.g. if someone clicks "Add All" under Strata in the FE, as we should not be allowing someone to include the primary key (unique identifier) to the list of strata.

## Description

This raises an error with a clearer message to the user as to why they are unable to move on beyond the power check.

## Future Tasks (optional)

Move the validation further up the chain into the design spec as part of #213.
FE can also explicitly exclude the known unique identifier column from the list. (More generally we could remove any other known unique id columns, if we knew of them in advance.)

## How has this been tested?

unittest and manual reproduction