### PR TITLE
Remove stratum_id_name from assignment behavior, and readability improvements.

### DIFF
--- a/src/xngin/apiserver/routers/assignment_adapters.py
+++ b/src/xngin/apiserver/routers/assignment_adapters.py
@@ -153,7 +153,7 @@ async def _bulk_insert_async(
     assignment_result: AssignmentResult,
 ) -> None:
     """Write arm assignments in bulk via COPY on the session's driver connection."""
-    orig_stratum_cols = assignment_result.orig_stratum_cols
+    stratum_cols = assignment_result.stratum_cols
 
     copy_sql = "COPY arm_assignments (experiment_id, participant_id, participant_type, arm_id, strata) FROM STDIN"
     async with (
@@ -166,7 +166,7 @@ async def _bulk_insert_async(
             row_mapping = row._mapping
 
             strata: list[StrataTypedDict]  # Use TypedDict to avoid runtime overhead of Pydantic.
-            if not orig_stratum_cols:
+            if not stratum_cols:
                 strata = []
             else:
                 # Output the participant's strata values as seen at this time of assignment.
@@ -175,7 +175,7 @@ async def _bulk_insert_async(
                         "field_name": column,
                         "strata_value": str(row_mapping[column]) if _is_present_scalar(row_mapping[column]) else "NA",
                     }
-                    for column in orig_stratum_cols
+                    for column in stratum_cols
                 ]
 
             arm_id = arm_ids[treatment_assignment]

--- a/src/xngin/apiserver/routers/assignment_adapters.py
+++ b/src/xngin/apiserver/routers/assignment_adapters.py
@@ -112,7 +112,6 @@ async def bulk_insert_arm_assignments(
     participant_id_col: str,
     data: Sequence[RowProtocol],
     assignment_result: AssignmentResult,
-    stratum_id_name: str | None = None,
 ) -> None:
     """Bulk insert arm assignments into the database via async COPY.
 
@@ -125,8 +124,6 @@ async def bulk_insert_arm_assignments(
         data: sqlalchemy result set of Rows representing units to be assigned
         assignment_result: AssignmentResult containing assignments and balance check results. AssignmentResult.arm_pop
           indexes are parallel to indexes on arm_ids.
-        stratum_id_name: If you want to output the strata group ids, provide a non-null name for
-                         the column to add to the assignment output as a Strata field.
     """
     with performance.timing("_bulk_insert_async"):
         await _bulk_insert_async(
@@ -137,7 +134,6 @@ async def bulk_insert_arm_assignments(
             participant_id_col=participant_id_col,
             data=data,
             assignment_result=assignment_result,
-            stratum_id_name=stratum_id_name,
         )
 
     arm_stats_rows = [
@@ -155,13 +151,8 @@ async def _bulk_insert_async(
     participant_id_col: str,
     data: Sequence[RowProtocol],
     assignment_result: AssignmentResult,
-    stratum_id_name: str | None,
 ) -> None:
     """Write arm assignments in bulk via COPY on the session's driver connection."""
-    # Track if we originally had valid strata
-    had_valid_strata = assignment_result.stratum_ids is not None
-    stratum_ids = assignment_result.stratum_ids or [0] * len(assignment_result.treatment_ids)
-    # These columns were the original columns to stratify on.
     orig_stratum_cols = assignment_result.orig_stratum_cols
 
     copy_sql = "COPY arm_assignments (experiment_id, participant_id, participant_type, arm_id, strata) FROM STDIN"
@@ -171,9 +162,7 @@ async def _bulk_insert_async(
         cur.copy(copy_sql) as copy,
     ):
         copy.set_types(["text", "text", "text", "text", "jsonb"])
-        for stratum_id, treatment_assignment, row in zip(
-            stratum_ids, assignment_result.treatment_ids, data, strict=True
-        ):
+        for treatment_assignment, row in zip(assignment_result.treatment_ids, data, strict=True):
             row_mapping = row._mapping
 
             strata: list[StrataTypedDict]  # Use TypedDict to avoid runtime overhead of Pydantic.
@@ -188,9 +177,6 @@ async def _bulk_insert_async(
                     }
                     for column in orig_stratum_cols
                 ]
-                # Only add stratum_id if we had valid strata and stratum_id_name is provided
-                if stratum_id_name is not None and had_valid_strata:
-                    strata.append({"field_name": stratum_id_name, "strata_value": str(stratum_id)})
 
             arm_id = arm_ids[treatment_assignment]
             await copy.write_row((

--- a/src/xngin/apiserver/routers/assignment_adapters.py
+++ b/src/xngin/apiserver/routers/assignment_adapters.py
@@ -111,7 +111,7 @@ async def bulk_insert_arm_assignments(
     participant_type: str,
     participant_id_col: str,
     data: Sequence[RowProtocol],
-    assignment_result: AssignmentResult,
+    assignments: AssignmentResult,
 ) -> None:
     """Bulk insert arm assignments into the database via async COPY.
 
@@ -122,7 +122,7 @@ async def bulk_insert_arm_assignments(
         participant_type: Type of participant in the experiment
         participant_id_col: Name of column in `data` containing participant identifiers
         data: sqlalchemy result set of Rows representing units to be assigned
-        assignment_result: AssignmentResult containing assignments and balance check results. AssignmentResult.arm_pop
+        assignments: AssignmentResult containing assignments and balance check results. AssignmentResult.arm_pop
           indexes are parallel to indexes on arm_ids.
     """
     with performance.timing("_bulk_insert_async"):
@@ -133,12 +133,10 @@ async def bulk_insert_arm_assignments(
             participant_type=participant_type,
             participant_id_col=participant_id_col,
             data=data,
-            assignment_result=assignment_result,
+            assignments=assignments,
         )
 
-    arm_stats_rows = [
-        {"arm_id": arm_id, "population": int(assignment_result.arm_pop[i])} for i, arm_id in enumerate(arm_ids)
-    ]
+    arm_stats_rows = [{"arm_id": arm_id, "population": int(assignments.arm_pop[i])} for i, arm_id in enumerate(arm_ids)]
     await xngin_session.execute(insert(tables.ArmStats).values(arm_stats_rows))
 
 
@@ -150,10 +148,10 @@ async def _bulk_insert_async(
     participant_type: str,
     participant_id_col: str,
     data: Sequence[RowProtocol],
-    assignment_result: AssignmentResult,
+    assignments: AssignmentResult,
 ) -> None:
     """Write arm assignments in bulk via COPY on the session's driver connection."""
-    stratum_cols = assignment_result.stratum_cols
+    stratum_cols = assignments.stratum_cols
 
     copy_sql = "COPY arm_assignments (experiment_id, participant_id, participant_type, arm_id, strata) FROM STDIN"
     async with (
@@ -162,7 +160,7 @@ async def _bulk_insert_async(
         cur.copy(copy_sql) as copy,
     ):
         copy.set_types(["text", "text", "text", "text", "jsonb"])
-        for treatment_assignment, row in zip(assignment_result.treatment_ids, data, strict=True):
+        for treatment_assignment, row in zip(assignments.treatment_ids, data, strict=True):
             row_mapping = row._mapping
 
             strata: list[StrataTypedDict]  # Use TypedDict to avoid runtime overhead of Pydantic.

--- a/src/xngin/apiserver/routers/assignment_adapters.py
+++ b/src/xngin/apiserver/routers/assignment_adapters.py
@@ -163,18 +163,15 @@ async def _bulk_insert_async(
         for treatment_assignment, row in zip(assignments.treatment_ids, data, strict=True):
             row_mapping = row._mapping
 
-            strata: list[StrataTypedDict]  # Use TypedDict to avoid runtime overhead of Pydantic.
-            if not stratum_cols:
-                strata = []
-            else:
-                # Output the participant's strata values as seen at this time of assignment.
-                strata = [
-                    {
-                        "field_name": column,
-                        "strata_value": str(row_mapping[column]) if _is_present_scalar(row_mapping[column]) else "NA",
-                    }
-                    for column in stratum_cols
-                ]
+            # Output the participant's strata values as seen at this time of assignment.
+            # StrataTypedDict avoids the runtime overhead of Pydantic.
+            strata: list[StrataTypedDict] = [
+                {
+                    "field_name": column,
+                    "strata_value": str(row_mapping[column]) if _is_present_scalar(row_mapping[column]) else "NA",
+                }
+                for column in stratum_cols
+            ]
 
             arm_id = arm_ids[treatment_assignment]
             await copy.write_row((

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -355,7 +355,7 @@ async def create_preassigned_experiment_impl(
         participant_type=experiment.participant_type,
         participant_id_col=unique_id_name,
         data=dwh_participants,
-        assignment_result=assignment_result,
+        assignments=assignment_result,
     )
 
     assign_summary = convert_assignment_results_to_assign_summary(experiment.arms, assignment_result, balance_check)

--- a/src/xngin/apiserver/routers/test_assignment_adapters.py
+++ b/src/xngin/apiserver/routers/test_assignment_adapters.py
@@ -198,7 +198,7 @@ def test_assign_treatments_with_balance_basic(sample_table, sample_rows):
     assert result.stratum_ids is not None
     assert len(result.stratum_ids) == len(sample_rows)
     assert len(result.treatment_ids) == len(sample_rows)
-    assert result.orig_stratum_cols == ["gender", "region"]
+    assert result.stratum_cols == ["gender", "region"]
     assert result.balance_result is not None
     # Use relative tolerance to accommodate BLAS/LAPACK differences between environments
     # (e.g. Apple Accelerate on macOS vs OpenBLAS on Linux)
@@ -228,7 +228,7 @@ async def test_bulk_insert_arm_assignments_basic(
         treatment_ids=[0, 1] * (len(sample_rows) // 2),
         stratum_ids=[int(s.is_male) for s in sample_rows],
         balance_result=None,
-        orig_stratum_cols=["gender"],
+        stratum_cols=["gender"],
         arm_pop=np.bincount([0, 1] * (len(sample_rows) // 2), minlength=len(arm_ids)),
     )
 
@@ -388,7 +388,7 @@ async def test_bulk_insert_renders_decimal_and_bool_strata_correctly(
         treatment_ids=[0, 1] * (len(sample_rows) // 2),
         stratum_ids=[0, 1] * (len(sample_rows) // 2),
         balance_result=None,
-        orig_stratum_cols=["income_dec", "is_male"],
+        stratum_cols=["income_dec", "is_male"],
         arm_pop=np.bincount([0, 1] * (len(sample_rows) // 2), minlength=len(arm_ids)),
     )
 
@@ -429,7 +429,7 @@ async def test_bulk_insert_with_no_stratification(xngin_session: AsyncSession, t
         treatment_ids=[0, 1] * (len(sample_rows) // 2),
         stratum_ids=None,
         balance_result=None,
-        orig_stratum_cols=[],
+        stratum_cols=[],
         arm_pop=np.bincount([0, 1] * (len(sample_rows) // 2), minlength=len(arm_ids)),
     )
 
@@ -471,7 +471,7 @@ async def test_bulk_insert_with_no_valid_strata(xngin_session: AsyncSession, tes
         treatment_ids=[0, 1] * (len(sample_rows) // 2),
         stratum_ids=None,
         balance_result=None,
-        orig_stratum_cols=["single_value"],
+        stratum_cols=["single_value"],
         arm_pop=np.bincount([0, 1] * (len(sample_rows) // 2), minlength=len(arm_ids)),
     )
 
@@ -510,7 +510,7 @@ async def test_bulk_insert_renders_missing_strata_values_as_na(
         treatment_ids=[0, 1] * (len(rows) // 2),
         stratum_ids=None,
         balance_result=None,
-        orig_stratum_cols=["nullable_value"],
+        stratum_cols=["nullable_value"],
         arm_pop=np.bincount([0, 1] * (len(rows) // 2), minlength=len(arm_ids)),
     )
 

--- a/src/xngin/apiserver/routers/test_assignment_adapters.py
+++ b/src/xngin/apiserver/routers/test_assignment_adapters.py
@@ -210,14 +210,12 @@ def test_assign_treatments_with_balance_basic(sample_table, sample_rows):
     assert result.balance_result.f_pvalue == pytest.approx(0.99990, abs=1e-4)
 
 
-@pytest.mark.parametrize("stratum_id_name", [None, "stratum_id"])
 async def test_bulk_insert_arm_assignments_basic(
     xngin_session: AsyncSession,
     testing_datasource: DatasourceMetadata,
     sample_rows,
-    stratum_id_name: str | None,
 ):
-    """Test bulk inserts of arm assignments, with and without strata group ids."""
+    """Test bulk inserts of arm assignments."""
     # First create an experiment and arms in db
     experiment = await insert_experiment_and_arms(xngin_session, testing_datasource.ds)
     arm_ids = [arm.id for arm in experiment.arms]
@@ -242,7 +240,6 @@ async def test_bulk_insert_arm_assignments_basic(
         participant_id_col=unique_id_field.field_name,
         data=sample_rows,
         assignment_result=fake_assignment_results,
-        stratum_id_name=stratum_id_name,
     )
 
     # Verify arm_stats populations were upserted
@@ -267,13 +264,9 @@ async def test_bulk_insert_arm_assignments_basic(
         assert assignment.arm_id in arm_ids
 
         # Verify strata are properly stored
+        assert len(assignment.strata) == 1
         assert assignment.strata[0]["field_name"] == "gender"
         assert assignment.strata[0]["strata_value"] in {"M", "F"}
-        assert len(assignment.strata) == 1 if stratum_id_name is None else 2
-        if stratum_id_name is not None:
-            assert assignment.strata[1]["field_name"] == stratum_id_name
-            # Note that all strata values are rendered as strings
-            assert assignment.strata[1]["strata_value"] in {"0", "1"}
 
 
 MAX_SAFE_INTEGER = (1 << 53) - 1  # 9007199254740991

--- a/src/xngin/apiserver/routers/test_assignment_adapters.py
+++ b/src/xngin/apiserver/routers/test_assignment_adapters.py
@@ -239,7 +239,7 @@ async def test_bulk_insert_arm_assignments_basic(
         participant_type=participant_type_name,
         participant_id_col=unique_id_field.field_name,
         data=sample_rows,
-        assignment_result=fake_assignment_results,
+        assignments=fake_assignment_results,
     )
 
     # Verify arm_stats populations were upserted
@@ -306,7 +306,7 @@ async def test_assign_and_bulk_insert_with_large_integers_as_participant_ids(
             participant_type=participant_type_name,
             participant_id_col=unique_id_field.field_name,
             data=rows,
-            assignment_result=assignment_result,
+            assignments=assignment_result,
         )
 
         # Get assignments for verification
@@ -399,7 +399,7 @@ async def test_bulk_insert_renders_decimal_and_bool_strata_correctly(
         participant_type=participant_type_name,
         participant_id_col=unique_id_field.field_name,
         data=sample_rows,
-        assignment_result=fake_assignment_results,
+        assignments=fake_assignment_results,
     )
 
     # Get assignments for verification
@@ -440,7 +440,7 @@ async def test_bulk_insert_with_no_stratification(xngin_session: AsyncSession, t
         participant_type=participant_type_name,
         participant_id_col=unique_id_field.field_name,
         data=sample_rows,
-        assignment_result=fake_assignment_results,
+        assignments=fake_assignment_results,
     )
 
     # Get assignments for verification
@@ -482,7 +482,7 @@ async def test_bulk_insert_with_no_valid_strata(xngin_session: AsyncSession, tes
         participant_type=participant_type_name,
         participant_id_col=unique_id_field.field_name,
         data=sample_rows,
-        assignment_result=fake_assignment_results,
+        assignments=fake_assignment_results,
     )
 
     # Get assignments for verification
@@ -521,7 +521,7 @@ async def test_bulk_insert_renders_missing_strata_values_as_na(
         participant_type=participant_type_name,
         participant_id_col=unique_id_field.field_name,
         data=rows,
-        assignment_result=fake_assignment_results,
+        assignments=fake_assignment_results,
     )
 
     assignments = (await xngin_session.scalars(select(tables.ArmAssignment))).all()

--- a/src/xngin/stats/assignment.py
+++ b/src/xngin/stats/assignment.py
@@ -29,7 +29,7 @@ class AssignmentResult:
 
     stratum_ids: list[int] | None
     balance_result: BalanceResult | None
-    orig_stratum_cols: list[str]
+    stratum_cols: list[str]
 
 
 def assign_treatment_and_check_balance(
@@ -63,7 +63,7 @@ def assign_treatment_and_check_balance(
             stratum_ids - list of stratum ids starting from 0, one per row in the dataframe.
                 May be useful if you wish to do any post-hoc analyses by stratum.
             balance_result - BalanceResult object containing the balance check results.
-            orig_stratum_cols - deduplicated and sorted list of stratum_cols.
+            stratum_cols - deduplicated and sorted list of stratum_cols.
                 May be useful for referencing original db values used in your df.
     """
     if id_col in stratum_cols:
@@ -76,7 +76,7 @@ def assign_treatment_and_check_balance(
             treatment_ids=treatment_ids,
             stratum_ids=None,
             balance_result=None,
-            orig_stratum_cols=[],
+            stratum_cols=[],
             arm_pop=np.bincount(treatment_ids, minlength=n_arms),
         )
 
@@ -102,7 +102,7 @@ def assign_treatment_and_check_balance(
             treatment_ids=treatment_ids,
             stratum_ids=None,
             balance_result=None,
-            orig_stratum_cols=orig_stratum_cols,
+            stratum_cols=orig_stratum_cols,
             arm_pop=np.bincount(treatment_ids, minlength=n_arms),
         )
 
@@ -156,7 +156,7 @@ def assign_treatment_and_check_balance(
         treatment_ids=list(treatment_ids),
         stratum_ids=list(stratum_ids),
         balance_result=balance_result,
-        orig_stratum_cols=orig_stratum_cols,
+        stratum_cols=orig_stratum_cols,
         arm_pop=np.bincount(treatment_ids, minlength=n_arms),
     )
 

--- a/src/xngin/stats/test_assignment.py
+++ b/src/xngin/stats/test_assignment.py
@@ -59,7 +59,7 @@ def test_assign_treatment_with_stratification(sample_df):
     assert len(result.stratum_ids) == len(sample_df)
     # 2 genders, 4 regions => 8 strata
     assert set(result.stratum_ids) == set(range(8))
-    assert set(result.orig_stratum_cols) == {"region", "gender"}
+    assert set(result.stratum_cols) == {"region", "gender"}
 
     # Check balance result structure
     assert isinstance(result.balance_result, BalanceResult)
@@ -83,7 +83,7 @@ def test_assign_treatment_multiple_arms(sample_df):
     assert len(result.treatment_ids) == len(sample_df)
     assert result.stratum_ids
     assert len(result.stratum_ids) == len(sample_df)
-    assert set(result.orig_stratum_cols) == {"gender", "region"}
+    assert set(result.stratum_cols) == {"gender", "region"}
     assert result.balance_result is not None
     assert isinstance(result.balance_result, BalanceResult)
 
@@ -109,7 +109,7 @@ def test_assign_treatment_reproducibility(sample_df):
     # Check that results are identical
     assert result1.treatment_ids == result2.treatment_ids
     assert result1.stratum_ids == result2.stratum_ids
-    assert result1.orig_stratum_cols == result2.orig_stratum_cols
+    assert result1.stratum_cols == result2.stratum_cols
     # Balance results should have same values
     assert result1.balance_result
     assert result2.balance_result
@@ -173,7 +173,7 @@ def test_assign_treatment_with_infer_objects():
     # Note: HC1 robust standard errors doesn't downweight by leverage, so p-value is quite low, i.e.
     # it's not a great estimator either in this scenario of singleton categories.
     assert result.balance_result.f_pvalue < 0.2
-    assert result.orig_stratum_cols == ["col1", "col2", "col3"]
+    assert result.stratum_cols == ["col1", "col2", "col3"]
 
 
 def test_assign_treatment_decimal_strata_columns_may_cause_problems(sample_df):
@@ -230,7 +230,7 @@ def test_assign_treatment_with_no_stratification(sample_df):
     assert len(result.treatment_ids) == len(sample_df)
     assert result.stratum_ids is None
     assert result.balance_result is None
-    assert result.orig_stratum_cols == []
+    assert result.stratum_cols == []
     # Arm lengths should be equal
     assert set(result.treatment_ids) == {0, 1}
     assert result.treatment_ids.count(0) == result.treatment_ids.count(1)
@@ -250,7 +250,7 @@ def test_assign_treatment_with_no_valid_strata(sample_df):
     assert len(result.treatment_ids) == len(sample_df)
     assert result.stratum_ids is None
     assert result.balance_result is None
-    assert result.orig_stratum_cols == ["single_value"]
+    assert result.stratum_cols == ["single_value"]
     # Arm lengths should be equal
     assert set(result.treatment_ids) == {0, 1}
     assert result.treatment_ids.count(0) == result.treatment_ids.count(1)
@@ -337,7 +337,7 @@ def test_assign_treatment_unbalanced_arms(sample_df):
     assert set(result.treatment_ids) == {0, 1}
     assert result.stratum_ids
     assert len(result.stratum_ids) == len(sample_df)
-    assert result.orig_stratum_cols == ["gender", "region"]
+    assert result.stratum_cols == ["gender", "region"]
     # Check proportions
     n_control = result.treatment_ids.count(0)
     n_treatment = result.treatment_ids.count(1)


### PR DESCRIPTION
- **Remove unused stratum_id_name parameter.**
- **Rename AssignmentResult.orig_stratum_cols to stratum_cols.**
- **Rename bulk_insert_arm_assignments parameter to assignments.**
- **Drop redundant empty-strata_cols branch in COPY loop.**
