### PR TITLE
Data fix & reapplication of PR #213 (re: Make table_name and primary_key required for frequentist exps)

### DIFF
--- a/src/xngin/apiserver/conftest.py
+++ b/src/xngin/apiserver/conftest.py
@@ -519,8 +519,10 @@ def expect_status_code(
             f"Expected '{detail_eq}' to be one of the .msg fields in the response: {http_response.content}"
         )
     if detail_contains is not None:
-        assert any(detail_contains in msg for msg in match._detail_messages()), (
-            f"Expected '{detail_eq}' to be in one of the .msg fields in the response: {http_response.content}"
+        messages = match._detail_messages()
+        assert any(detail_contains in msg for msg in messages), (
+            f"Expected '{detail_contains}' to be in one of the .msg fields in the response: {http_response.content}"
+            f"\nmsg list (length {len(messages)}): \n\t{'\n\t'.join(messages)}"
         )
     if text is not None:
         assert match._has_text(text), f"Expected '{text}' to be in the response: {http_response.content}"

--- a/src/xngin/apiserver/routers/admin/admin_api.py
+++ b/src/xngin/apiserver/routers/admin/admin_api.py
@@ -109,9 +109,9 @@ from xngin.apiserver.routers.admin.generic_handlers import handle_delete
 from xngin.apiserver.routers.auth.auth_api_types import CallerIdentity
 from xngin.apiserver.routers.auth.auth_dependencies import require_user_from_token
 from xngin.apiserver.routers.common_api_types import (
-    BaseBanditExperimentSpec,
-    BaseFrequentistDesignSpec,
+    BayesABExperimentSpec,
     CMABContextInputRequest,
+    CMABExperimentSpec,
     ContextInput,
     ContextType,
     CreateExperimentRequest,
@@ -121,8 +121,11 @@ from xngin.apiserver.routers.common_api_types import (
     GetMetricsResponseElement,
     GetStrataResponseElement,
     ListExperimentsResponse,
+    MABExperimentSpec,
+    OnlineFrequentistExperimentSpec,
     PowerRequest,
     PowerResponse,
+    PreassignedFrequentistExperimentSpec,
 )
 from xngin.apiserver.routers.common_enums import ExperimentState, PreloadMethod
 from xngin.apiserver.routers.experiments import experiments_common, experiments_common_csv
@@ -1500,11 +1503,6 @@ async def create_experiment(
     if body.design_spec.ids_are_present():
         raise LateValidationError("Invalid DesignSpec: UUIDs must not be set.")
 
-    if (body.table_name is not None or body.primary_key is not None) and not isinstance(
-        body.design_spec, BaseFrequentistDesignSpec
-    ):
-        raise LateValidationError("table_name/primary_key is only supported for frequentist experiment types")
-
     # Validate webhook IDs exist and belong to organization
     organization_id = datasource.organization_id
     validated_webhooks = await validate_webhooks(
@@ -1558,20 +1556,19 @@ async def analyze_experiment(
 
     design_spec = await ExperimentStorageConverter(experiment).get_design_spec()
     match design_spec:
-        case BaseBanditExperimentSpec():
-            if experiment.experiment_type != ExperimentsType.MAB_ONLINE.value:
-                raise LateValidationError(
-                    """Invalid experiment type for bandit analysis; for CMAB experiments,
-                    use the corresponding POST endpoint.""",
-                )
-            return await experiments_common.analyze_experiment_bandit_impl(xngin_session, experiment)
-
-        case BaseFrequentistDesignSpec():
+        case PreassignedFrequentistExperimentSpec() | OnlineFrequentistExperimentSpec():
             # Always assume the first arm is the baseline; UI can override this.
             baseline_arm_id = baseline_arm_id or design_spec.arms[0].arm_id
             assert baseline_arm_id is not None
             return await experiments_common.analyze_experiment_freq_impl(
                 xngin_session, ds.get_config(), experiment, baseline_arm_id, design_spec.metrics
+            )
+        case MABExperimentSpec():
+            return await experiments_common.analyze_experiment_bandit_impl(xngin_session, experiment)
+        case CMABExperimentSpec() | BayesABExperimentSpec():
+            raise LateValidationError(
+                """Invalid experiment type for bandit analysis; for CMAB experiments,
+                use the corresponding POST endpoint.""",
             )
         case _:
             assert_never()
@@ -1876,11 +1873,6 @@ async def power_check(
 ) -> PowerResponse:
     """Performs a power check for the specified datasource."""
     design_spec = body.design_spec
-    if not isinstance(design_spec, BaseFrequentistDesignSpec):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Power checks are only supported for frequentist experiments",
-        )
     ds = await get_datasource_or_raise(session, user, datasource_id)
     if isinstance(ds.config, NoDwh):
         raise HTTPException(
@@ -1890,9 +1882,9 @@ async def power_check(
     dsconfig = ds.get_config()
 
     async with DwhSession(dsconfig.dwh) as dwh:
-        sa_table = await dwh.inspect_table(body.table_name)
+        sa_table = await dwh.inspect_table(design_spec.table_name)
         # Validate the fields used in the design spec are present in the table and that filter values are valid.
-        _ = await fetch_fields_from_table_or_raise(sa_table, design_spec, body.primary_key)
+        _ = await fetch_fields_from_table_or_raise(sa_table, design_spec)
         metric_stats = await asyncio.to_thread(
             get_stats_on_metrics,
             dwh.session,

--- a/src/xngin/apiserver/routers/admin/test_admin.py
+++ b/src/xngin/apiserver/routers/admin/test_admin.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse
 import numpy as np
 import pytest
 from deepdiff import DeepDiff
-from pydantic import HttpUrl, TypeAdapter
+from pydantic import HttpUrl
 from sqlalchemy import select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -140,12 +140,12 @@ async def make_freq_online_experiment(
     experiment_id = aclient.create_experiment(
         datasource_id=datasource_id,
         body=CreateExperimentRequest(
-            table_name="dwh",
-            primary_key="id",
             design_spec=OnlineFrequentistExperimentSpec(
                 experiment_type=ExperimentsType.FREQ_ONLINE,
                 experiment_name="test experiment",
                 description="test experiment",
+                table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
+                primary_key="id",
                 start_date=datetime(2024, 1, 1, tzinfo=UTC),
                 end_date=end_date,
                 arms=[Arm(arm_name="C", arm_description="C"), Arm(arm_name="T", arm_description="T")],
@@ -213,6 +213,8 @@ async def fixture_testing_experiment(xngin_session: AsyncSession, testing_dataso
         experiment_type=ExperimentsType.FREQ_PREASSIGNED,
         experiment_name="test experiment",
         description="test experiment",
+        table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
+        primary_key="id",
         start_date=datetime(2024, 1, 1, tzinfo=UTC),
         end_date=datetime.now(UTC) + timedelta(days=1),
         arms=[Arm(arm_name="C", arm_description="C"), Arm(arm_name="T", arm_description="T")],
@@ -220,9 +222,7 @@ async def fixture_testing_experiment(xngin_session: AsyncSession, testing_dataso
         strata=[],
         filters=[],
     )
-    table_name = TESTING_DWH_PARTICIPANT_DEF.table_name
-    primary_key = "id"
-    field_type_map = await fetch_fields_or_raise(datasource, design_spec, table_name, primary_key)
+    field_type_map = await fetch_fields_or_raise(datasource, design_spec)
 
     experiment_converter = ExperimentStorageConverter.init_from_components(
         datasource_id=datasource.id,
@@ -232,9 +232,9 @@ async def fixture_testing_experiment(xngin_session: AsyncSession, testing_dataso
         state=ExperimentState.COMMITTED,
         stopped_assignments_at=datetime.now(UTC),
         stopped_assignments_reason=StopAssignmentReason.PREASSIGNED,
-        table_name=table_name,
+        table_name=design_spec.table_name,
+        unique_id_name=design_spec.primary_key,
         field_type_map=field_type_map,
-        unique_id_name=primary_key,
     )
     experiment = experiment_converter.get_experiment()
     xngin_session.add(experiment)
@@ -1419,7 +1419,7 @@ async def test_lifecycle_with_db(testing_datasource, aclient: AdminAPIClient, ac
 
     # Create experiment using that participant type.
     create_exp_dict = make_createexperimentrequest_json()
-    create_exp_request = TypeAdapter(CreateExperimentRequest).validate_python(create_exp_dict)
+    create_exp_request = CreateExperimentRequest.model_validate(create_exp_dict)
     create_exp_request.design_spec.design_url = HttpUrl("https://example.com/design")
     assert isinstance(create_exp_request.design_spec, PreassignedFrequentistExperimentSpec)
     create_exp_request.design_spec.filters = [
@@ -1544,6 +1544,8 @@ async def test_abandon_experiment(testing_datasource, aclient: AdminAPIClient):
         experiment_type=ExperimentsType.FREQ_PREASSIGNED,
         experiment_name="test experiment",
         description="test experiment",
+        table_name="dwh",
+        primary_key="id",
         start_date=datetime(2024, 1, 1, tzinfo=UTC),
         end_date=datetime.now(UTC) + timedelta(days=1),
         arms=[Arm(arm_name="C", arm_description="C"), Arm(arm_name="T", arm_description="T")],
@@ -1553,7 +1555,7 @@ async def test_abandon_experiment(testing_datasource, aclient: AdminAPIClient):
     )
     parsed_response = aclient.create_experiment(
         datasource_id=datasource_id,
-        body=CreateExperimentRequest(design_spec=design_spec, table_name="dwh", primary_key="id"),
+        body=CreateExperimentRequest(design_spec=design_spec),
         desired_n=1,
     ).data
     assert parsed_response.state == ExperimentState.ASSIGNED
@@ -1567,10 +1569,13 @@ async def test_abandon_experiment(testing_datasource, aclient: AdminAPIClient):
 
 async def test_power_check_with_unbalanced_arms(testing_datasource, aclient: AdminAPIClient):
     """Test power check endpoint with balanced vs unbalanced arms."""
+    ds_id = testing_datasource.datasource_id
     design_spec = PreassignedFrequentistExperimentSpec(
         experiment_type=ExperimentsType.FREQ_PREASSIGNED,
         experiment_name="test power check",
         description="test power check with unbalanced arms",
+        table_name="dwh",
+        primary_key="id",
         start_date=datetime(2024, 1, 1, tzinfo=UTC),
         end_date=datetime.now(UTC) + timedelta(days=1),
         arms=[
@@ -1583,10 +1588,7 @@ async def test_power_check_with_unbalanced_arms(testing_datasource, aclient: Adm
     )
 
     # Call the power check endpoint
-    power_response = aclient.power_check(
-        datasource_id=testing_datasource.ds.id,
-        body=PowerRequest(design_spec=design_spec, table_name="dwh", primary_key="id"),
-    ).data
+    power_response = aclient.power_check(datasource_id=ds_id, body=PowerRequest(design_spec=design_spec)).data
     assert len(power_response.analyses) == 1
     metric_analysis = power_response.analyses[0]
     assert metric_analysis.metric_spec.field_name == "current_income"
@@ -1596,10 +1598,7 @@ async def test_power_check_with_unbalanced_arms(testing_datasource, aclient: Adm
     # Now check with unbalanced arms
     design_spec.arms[0].arm_weight = 20.0
     design_spec.arms[1].arm_weight = 80.0
-    power_response2 = aclient.power_check(
-        datasource_id=testing_datasource.ds.id,
-        body=PowerRequest(design_spec=design_spec, table_name="dwh", primary_key="id"),
-    ).data
+    power_response2 = aclient.power_check(datasource_id=ds_id, body=PowerRequest(design_spec=design_spec)).data
     assert len(power_response2.analyses) == 1
     metric_analysis2 = power_response2.analyses[0]
     assert metric_analysis2.metric_spec.field_name == "current_income"
@@ -1611,10 +1610,7 @@ async def test_power_check_with_unbalanced_arms(testing_datasource, aclient: Adm
     design_spec.arms[0].arm_weight = 10
     design_spec.arms[1].arm_weight = 50
     design_spec.arms[2].arm_weight = 40
-    power_response3 = aclient.power_check(
-        datasource_id=testing_datasource.ds.id,
-        body=PowerRequest(design_spec=design_spec, table_name="dwh", primary_key="id"),
-    ).data
+    power_response3 = aclient.power_check(datasource_id=ds_id, body=PowerRequest(design_spec=design_spec)).data
     assert len(power_response3.analyses) == 1
     metric_analysis3 = power_response3.analyses[0]
     assert metric_analysis3.metric_spec.field_name == "current_income"
@@ -1627,10 +1623,13 @@ async def test_power_check_with_unbalanced_arms(testing_datasource, aclient: Adm
 
 async def test_power_check_validations(testing_datasource, aclient: AdminAPIClient):
     """Test power check validations."""
+    ds_id = testing_datasource.datasource_id
     design_spec = PreassignedFrequentistExperimentSpec(
         experiment_type=ExperimentsType.FREQ_PREASSIGNED,
         experiment_name="test power check with synthesized schema",
         description="test power check using table_name and primary_key",
+        table_name="dwh",
+        primary_key="id",
         start_date=datetime(2024, 1, 1, tzinfo=UTC),
         end_date=datetime.now(UTC) + timedelta(days=1),
         arms=[
@@ -1643,26 +1642,21 @@ async def test_power_check_validations(testing_datasource, aclient: AdminAPIClie
     )
 
     # First check a valid power check
-    datasource_id = testing_datasource.ds.id
-    power_response = aclient.power_check(
-        datasource_id=datasource_id,
-        body=PowerRequest(design_spec=design_spec, table_name="dwh", primary_key="id"),
-    ).data
+    power_response = aclient.power_check(datasource_id=ds_id, body=PowerRequest(design_spec=design_spec)).data
     assert len(power_response.analyses) == 1
     assert power_response.analyses[0].metric_spec.field_name == "current_income"
     assert power_response.analyses[0].target_n is not None
 
     # Now check various failure scenarios
     with expect_status_code(404, message_contains="The table '' does not exist."):
-        aclient.power_check(
-            datasource_id=datasource_id, body=PowerRequest(design_spec=design_spec, table_name="", primary_key="")
-        )
+        bad_design_spec = design_spec.model_copy(deep=True)
+        bad_design_spec.table_name = ""
+        aclient.power_check(datasource_id=ds_id, body=PowerRequest(design_spec=bad_design_spec))
 
     with expect_status_code(422, detail_contains="columns that do not exist in the table: no_such_primary_key"):
-        aclient.power_check(
-            datasource_id=datasource_id,
-            body=PowerRequest(design_spec=design_spec, table_name="dwh", primary_key="no_such_primary_key"),
-        )
+        bad_design_spec = design_spec.model_copy(deep=True)
+        bad_design_spec.primary_key = "no_such_primary_key"
+        aclient.power_check(datasource_id=ds_id, body=PowerRequest(design_spec=bad_design_spec))
 
     with expect_status_code(
         422, detail_contains="columns that do not exist in the table: bad_filter, bad_metric, bad_stratum"
@@ -1671,18 +1665,12 @@ async def test_power_check_validations(testing_datasource, aclient: AdminAPIClie
         bad_design_spec.metrics = [DesignSpecMetricRequest(field_name="bad_metric", metric_pct_change=0.1)]
         bad_design_spec.strata = [Stratum(field_name="bad_stratum")]
         bad_design_spec.filters = [Filter(field_name="bad_filter", relation=Relation.INCLUDES, value=["value"])]
-        aclient.power_check(
-            datasource_id=datasource_id,
-            body=PowerRequest(design_spec=bad_design_spec, table_name="dwh", primary_key="id"),
-        )
+        aclient.power_check(datasource_id=ds_id, body=PowerRequest(design_spec=bad_design_spec))
 
     with expect_status_code(422, detail_contains="Invalid metric field(s): (gender). Only boolean or numeric"):
         bad_design_spec = design_spec.model_copy(deep=True)
         bad_design_spec.metrics = [DesignSpecMetricRequest(field_name="gender", metric_pct_change=0.1)]
-        aclient.power_check(
-            datasource_id=datasource_id,
-            body=PowerRequest(design_spec=bad_design_spec, table_name="dwh", primary_key="id"),
-        )
+        aclient.power_check(datasource_id=ds_id, body=PowerRequest(design_spec=bad_design_spec))
 
 
 async def test_create_experiment_with_invalid_design_url(testing_datasource, aclient: AdminAPIClient):
@@ -1702,6 +1690,15 @@ async def test_create_experiment_with_invalid_design_url(testing_datasource, acl
     # And we need a host.
     request["design_spec"]["design_url"] = "https://"
     with expect_status_code(422, detail_contains="Input should be a valid URL, empty host"):
+        aclient.create_experiment(datasource_id=datasource_id, body=request, desired_n=1)
+
+
+async def test_create_experiment_with_primary_key_as_strata_fails(testing_datasource, aclient: AdminAPIClient):
+    datasource_id = testing_datasource.ds.id
+    request = make_createexperimentrequest_json()
+    primary_key = request["design_spec"]["primary_key"]
+    request["design_spec"]["strata"] = [Stratum(field_name=primary_key)]
+    with expect_status_code(422, detail_contains=f"Primary key {primary_key} cannot be used in strata."):
         aclient.create_experiment(datasource_id=datasource_id, body=request, desired_n=1)
 
 
@@ -1810,12 +1807,12 @@ async def test_create_freq_preassigned_experiment_fields_use_roundtrip(
 ):
     datasource_id = testing_datasource.ds.id
     experiment_request = CreateExperimentRequest(
-        table_name="dwh",
-        primary_key="id",
         design_spec=PreassignedFrequentistExperimentSpec(
             experiment_type="freq_preassigned",
             experiment_name="Test Experiment with Filters",
             description="Testing filters roundtrip",
+            table_name="dwh",
+            primary_key="id",
             start_date=datetime(2024, 1, 1, tzinfo=UTC),
             end_date=datetime(2024, 1, 31, 23, 59, 59, tzinfo=UTC),
             arms=[
@@ -2797,12 +2794,12 @@ async def test_experiment_webhook_integration(testing_datasource, aclient: Admin
 
     # Create an experiment with only the first webhook using proper Pydantic models
     experiment_request = CreateExperimentRequest(
-        table_name="dwh",
-        primary_key="id",
         design_spec=PreassignedFrequentistExperimentSpec(
             experiment_type=ExperimentsType.FREQ_PREASSIGNED,
             experiment_name="Test Experiment with Webhook",
             description="Testing webhook integration",
+            table_name="dwh",
+            primary_key="id",
             start_date=datetime(2024, 1, 1, tzinfo=UTC),
             end_date=datetime(2024, 1, 31, 23, 59, 59, tzinfo=UTC),
             arms=[
@@ -2835,12 +2832,12 @@ async def test_experiment_webhook_integration(testing_datasource, aclient: Admin
 
     # Test creating an experiment with no webhooks using proper Pydantic models
     experiment_request_no_webhooks = CreateExperimentRequest(
-        table_name="dwh",
-        primary_key="id",
         design_spec=PreassignedFrequentistExperimentSpec(
             experiment_type=ExperimentsType.FREQ_PREASSIGNED,
             experiment_name="Test Experiment without Webhooks",
             description="Testing no webhook integration",
+            table_name="dwh",
+            primary_key="id",
             start_date=datetime(2024, 1, 1, tzinfo=UTC),
             end_date=datetime(2024, 1, 31, 23, 59, 59, tzinfo=UTC),
             arms=[
@@ -2896,10 +2893,10 @@ def test_snapshots(aclient: AdminAPIClient, aclient_unpriv: AdminAPIClient):
     experiment_id = aclient.create_experiment(
         datasource_id=create_datasource_response.id,
         body=CreateExperimentRequest(
-            table_name="dwh",
-            primary_key="id",
             design_spec=PreassignedFrequentistExperimentSpec(
                 experiment_type=ExperimentsType.FREQ_PREASSIGNED,
+                table_name="dwh",
+                primary_key="id",
                 experiment_name="test experiment",
                 description="test experiment",
                 start_date=datetime(2024, 1, 1, tzinfo=UTC),
@@ -3094,10 +3091,10 @@ def test_snapshot_on_ineligible_experiments(testing_datasource, aclient: AdminAP
     experiment_id = aclient.create_experiment(
         datasource_id=ds.id,
         body=CreateExperimentRequest(
-            table_name="dwh",
-            primary_key="id",
             design_spec=PreassignedFrequentistExperimentSpec(
                 experiment_type=ExperimentsType.FREQ_PREASSIGNED,
+                table_name="dwh",
+                primary_key="id",
                 experiment_name="test old experiment",
                 description="too old to be snapshotted",
                 start_date=datetime(2024, 1, 1, tzinfo=UTC),
@@ -3129,10 +3126,10 @@ def test_snapshot_on_ineligible_experiments(testing_datasource, aclient: AdminAP
     experiment_id = aclient.create_experiment(
         datasource_id=ds.id,
         body=CreateExperimentRequest(
-            table_name="dwh",
-            primary_key="id",
             design_spec=PreassignedFrequentistExperimentSpec(
                 experiment_type=ExperimentsType.FREQ_PREASSIGNED,
+                table_name="dwh",
+                primary_key="id",
                 experiment_name="test just ended experiment",
                 description="just ended within a day of now, so can be snapshotted",
                 start_date=datetime(2024, 1, 1, tzinfo=UTC),
@@ -3159,10 +3156,10 @@ def test_snapshot_with_nan(testing_datasource, aclient: AdminAPIClient):
     experiment_id = aclient.create_experiment(
         datasource_id=ds.id,
         body=CreateExperimentRequest(
-            table_name="dwh",
-            primary_key="id",
             design_spec=PreassignedFrequentistExperimentSpec(
                 experiment_type=ExperimentsType.FREQ_PREASSIGNED,
+                table_name="dwh",
+                primary_key="id",
                 experiment_name="test experiment",
                 description="test experiment",
                 start_date=datetime(2024, 1, 1, tzinfo=UTC),
@@ -3510,11 +3507,7 @@ async def test_create_experiment_with_table_name_and_primary_key(
 
     request_json = make_createexperimentrequest_json(experiment_type=ExperimentsType.FREQ_ONLINE)
     initial_participant_count = len(testing_datasource.ds.get_config().participants)
-    experiment_request = CreateExperimentRequest.model_validate({
-        **request_json,
-        "table_name": "dwh",  # The actual table name in test DWH
-        "primary_key": "id",
-    })
+    experiment_request = CreateExperimentRequest.model_validate(request_json)
 
     created = aclient.create_experiment(
         datasource_id=ds_id,
@@ -3535,40 +3528,28 @@ async def test_create_experiment_with_table_name_and_primary_key(
     assert experiment.datasource_table == "dwh"
 
 
-def test_create_experiment_table_name_requires_primary_key(testing_datasource, aclient: AdminAPIClient):
-    """Test that table_name requires primary_key."""
+def test_create_experiment_freq_design_spec_requires_primary_key(testing_datasource, aclient: AdminAPIClient):
     ds_id = testing_datasource.ds.id
     request_json = make_createexperimentrequest_json(experiment_type=ExperimentsType.FREQ_ONLINE)
-    constructed = CreateExperimentRequest.model_validate(request_json)
-    constructed.primary_key = None
-    constructed.table_name = "some_table"
-    with expect_status_code(422, text="table_name and primary_key must be provided together"):
-        aclient.create_experiment(datasource_id=ds_id, body=constructed)
+    del request_json["design_spec"]["primary_key"]
+    with expect_status_code(422, text="primary_key", detail_eq="Field required"):
+        aclient.create_experiment(datasource_id=ds_id, body=request_json)
 
 
-def test_create_experiment_primary_key_requires_table_name(testing_datasource, aclient: AdminAPIClient):
-    """Test that primary_key requires table_name."""
+def test_create_experiment_freq_design_spec_requires_table_name(testing_datasource, aclient: AdminAPIClient):
     ds_id = testing_datasource.ds.id
     request_json = make_createexperimentrequest_json(experiment_type=ExperimentsType.FREQ_ONLINE)
-    constructed = CreateExperimentRequest.model_validate(request_json)
-    constructed.primary_key = "id"
-    constructed.table_name = None
-    with expect_status_code(422, text="table_name and primary_key must be provided together"):
-        aclient.create_experiment(datasource_id=ds_id, body=constructed)
+    del request_json["design_spec"]["table_name"]
+    with expect_status_code(422, text="table_name", detail_eq="Field required"):
+        aclient.create_experiment(datasource_id=ds_id, body=request_json)
 
 
 async def test_create_preassigned_experiment_with_table_name_and_primary_key(
     xngin_session: AsyncSession, testing_datasource, aclient: AdminAPIClient
 ):
-    """Test creating a preassigned experiment with table_name and primary_key."""
     ds_id = testing_datasource.ds.id
-
     request_json = make_createexperimentrequest_json(experiment_type=ExperimentsType.FREQ_PREASSIGNED)
-    experiment_request = CreateExperimentRequest.model_validate({
-        **request_json,
-        "table_name": "dwh",
-        "primary_key": "id",
-    })
+    experiment_request = CreateExperimentRequest.model_validate(request_json)
 
     created = aclient.create_experiment(
         datasource_id=ds_id,
@@ -3620,10 +3601,10 @@ def test_list_snapshots_pagination(aclient: AdminAPIClient):
     experiment_id = aclient.create_experiment(
         datasource_id=ds.id,
         body=CreateExperimentRequest(
-            table_name="dwh",
-            primary_key="id",
             design_spec=PreassignedFrequentistExperimentSpec(
                 experiment_type=ExperimentsType.FREQ_PREASSIGNED,
+                table_name="dwh",
+                primary_key="id",
                 experiment_name="pagination test",
                 description="pagination test",
                 start_date=datetime(2024, 1, 1, tzinfo=UTC),
@@ -3717,11 +3698,11 @@ def test_list_organization_events_pagination(testing_datasource, aclient: AdminA
         experiment = aclient.create_experiment(
             datasource_id=ds_id,
             body=CreateExperimentRequest(
-                table_name="dwh",
-                primary_key="id",
                 webhooks=[webhook_id],
                 design_spec=PreassignedFrequentistExperimentSpec(
                     experiment_type=ExperimentsType.FREQ_PREASSIGNED,
+                    table_name="dwh",
+                    primary_key="id",
                     experiment_name=f"pagination event test {i}",
                     description=f"pagination event test {i}",
                     start_date=datetime(2024, 1, 1, tzinfo=UTC),
@@ -3796,10 +3777,10 @@ async def test_list_organization_events_pagination_with_same_timestamp_is_id_des
         experiment = aclient.create_experiment(
             datasource_id=ds_id,
             body=CreateExperimentRequest(
-                table_name="dwh",
-                primary_key="id",
                 design_spec=PreassignedFrequentistExperimentSpec(
                     experiment_type=ExperimentsType.FREQ_PREASSIGNED,
+                    table_name="dwh",
+                    primary_key="id",
                     experiment_name=f"same-ts event test {i}",
                     description=f"same-ts event test {i}",
                     start_date=datetime(2024, 1, 1, tzinfo=UTC),

--- a/src/xngin/apiserver/routers/common_api_types.py
+++ b/src/xngin/apiserver/routers/common_api_types.py
@@ -853,6 +853,18 @@ class BaseDesignSpec(ApiBaseModel):
 class BaseFrequentistDesignSpec(BaseDesignSpec):
     """Experiment design parameters for frequentist experiments."""
 
+    table_name: Annotated[
+        str,
+        Field(
+            max_length=MAX_LENGTH_OF_NAME_VALUE,
+            description="Datasource table used to resolve participant field metadata.",
+        ),
+    ]
+    primary_key: Annotated[
+        FieldName,
+        Field(description="Column name in table_name that uniquely identifies each participant."),
+    ]
+
     # Frequentist config params
     strata: Annotated[
         list[Stratum],
@@ -928,6 +940,13 @@ class BaseFrequentistDesignSpec(BaseDesignSpec):
     def serialize_dt(self, dt: datetime.datetime, _info):
         """Convert dates to iso strings in model_dump_json()/model_dump(mode='json')"""
         return dt.isoformat()
+
+    @model_validator(mode="after")
+    def validate_strata(self) -> Self:
+        """Validate that the strata are valid."""
+        if any(stratum.field_name == self.primary_key for stratum in self.strata):
+            raise ValueError(f"Primary key {self.primary_key} cannot be used in strata.")
+        return self
 
 
 class BaseBanditExperimentSpec(BaseDesignSpec):
@@ -1066,12 +1085,24 @@ class BayesABExperimentSpec(BaseBanditExperimentSpec):
     experiment_type: Literal[ExperimentsType.BAYESAB_ONLINE] = ExperimentsType.BAYESAB_ONLINE
 
 
+type AnyFrequentistDesignSpec = Annotated[
+    PreassignedFrequentistExperimentSpec | OnlineFrequentistExperimentSpec,
+    Field(
+        discriminator="experiment_type",
+        description="The specific type of frequentist experiment design.",
+    ),
+]
+
+type AnyBanditDesignSpec = Annotated[
+    MABExperimentSpec | CMABExperimentSpec | BayesABExperimentSpec,
+    Field(
+        discriminator="experiment_type",
+        description="The specific type of bandit experiment design.",
+    ),
+]
+
 type DesignSpec = Annotated[
-    PreassignedFrequentistExperimentSpec
-    | OnlineFrequentistExperimentSpec
-    | MABExperimentSpec
-    | CMABExperimentSpec
-    | BayesABExperimentSpec,
+    AnyFrequentistDesignSpec | AnyBanditDesignSpec,
     Field(
         discriminator="experiment_type",
         description="The type of assignment and experiment design.",
@@ -1080,18 +1111,7 @@ type DesignSpec = Annotated[
 
 
 class PowerRequest(ApiBaseModel):
-    design_spec: DesignSpec
-    table_name: Annotated[
-        str,
-        Field(description="Table name for ad-hoc power calculations. Fields are verified against the inspected table."),
-    ]
-    primary_key: Annotated[str, Field(description="Primary key field name.")]
-
-    @model_validator(mode="after")
-    def check_table_name_and_primary_key_together(self) -> Self:
-        if (self.table_name is None) != (self.primary_key is None):
-            raise ValueError("table_name and primary_key must be provided together or both omitted")
-        return self
+    design_spec: AnyFrequentistDesignSpec
 
 
 class PowerResponse(ApiBaseModel):
@@ -1249,21 +1269,6 @@ class CreateExperimentRequest(ApiBaseModel):
             ),
         ),
     ] = []
-    table_name: Annotated[
-        str | None,
-        Field(
-            default=None,
-            description="Optional table name for creating experiments without a pre-registered participant type. "
-            "When provided with primary_key, inspects the datasource table to derive experiment field metadata.",
-        ),
-    ] = None
-    primary_key: Annotated[
-        str | None,
-        Field(
-            default=None,
-            description="Optional primary key field name. Must be provided together with table_name.",
-        ),
-    ] = None
 
     @field_validator("webhooks")
     @classmethod
@@ -1272,15 +1277,6 @@ class CreateExperimentRequest(ApiBaseModel):
         if len(v) != len(set(v)):
             raise ValueError("Webhook IDs must be unique")
         return v
-
-    @model_validator(mode="after")
-    def check_table_name_and_primary_key_exist_for_frequentist_only(self) -> Self:
-        if self.design_spec.experiment_type in {ExperimentsType.FREQ_ONLINE, ExperimentsType.FREQ_PREASSIGNED}:
-            if self.table_name is None or self.primary_key is None:
-                raise ValueError("table_name and primary_key must be provided together for frequentist experiments.")
-        elif self.table_name is not None or self.primary_key is not None:
-            raise ValueError("table_name and primary_key are not supported for non-frequentist experiments.")
-        return self
 
 
 # TODO: make this class work with the Bayesian experiment types and their Draw records.

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -4,6 +4,7 @@ import io
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import assert_never
 
 import numpy as np
 import pandas as pd
@@ -27,6 +28,7 @@ from xngin.apiserver.routers.assignment_adapters import (
     make_balance_check,
 )
 from xngin.apiserver.routers.common_api_types import (
+    AnyFrequentistDesignSpec,
     Arm,
     ArmAnalysis,
     ArmSize,
@@ -34,7 +36,8 @@ from xngin.apiserver.routers.common_api_types import (
     AssignSummary,
     BalanceCheck,
     BanditExperimentAnalysisResponse,
-    BaseFrequentistDesignSpec,
+    BayesABExperimentSpec,
+    CMABExperimentSpec,
     CreateExperimentRequest,
     CreateExperimentResponse,
     DesignSpecMetricRequest,
@@ -42,8 +45,11 @@ from xngin.apiserver.routers.common_api_types import (
     GetExperimentResponse,
     GetParticipantAssignmentResponse,
     ListExperimentsResponse,
+    MABExperimentSpec,
     MetricAnalysis,
+    OnlineFrequentistExperimentSpec,
     ParticipantProperty,
+    PreassignedFrequentistExperimentSpec,
 )
 from xngin.apiserver.routers.common_enums import (
     DataType,
@@ -127,7 +133,8 @@ def make_participants_def_from_experiment(experiment: tables.Experiment) -> Part
 
 
 async def fetch_fields_or_raise(
-    datasource: tables.Datasource, design_spec: BaseFrequentistDesignSpec, table_name: str, primary_key: str
+    datasource: tables.Datasource,
+    design_spec: AnyFrequentistDesignSpec,
 ) -> dict[str, DataType]:
     """Inspect an explicit table/primary_key experiment request and return field metadata.
 
@@ -136,15 +143,11 @@ async def fetch_fields_or_raise(
     certain use, or if filter values are invalid for the field type.
     """
     async with DwhSession(datasource.get_config().dwh) as dwh:
-        sa_table = await dwh.inspect_table(table_name)
-        return await fetch_fields_from_table_or_raise(sa_table, design_spec, primary_key)
+        sa_table = await dwh.inspect_table(design_spec.table_name)
+        return await fetch_fields_from_table_or_raise(sa_table, design_spec)
 
 
-async def fetch_fields_from_table_or_raise(
-    table: Table,
-    design_spec: BaseFrequentistDesignSpec,
-    primary_key: str,
-) -> dict[str, DataType]:
+async def fetch_fields_from_table_or_raise(table: Table, design_spec: AnyFrequentistDesignSpec) -> dict[str, DataType]:
     """Helper to fetch_fields_or_raise that operates on a pre-inspected SQLAlchemy table."""
     schema_supported_fields_map: dict[str, DataType] = {}
     for column in table.columns.values():
@@ -156,7 +159,7 @@ async def fetch_fields_from_table_or_raise(
         *[metric.field_name for metric in design_spec.metrics],
         *[filter_.field_name for filter_ in design_spec.filters],
         *[stratum.field_name for stratum in design_spec.strata],
-        primary_key,
+        design_spec.primary_key,
     }
 
     referenced_fields_and_types = {
@@ -200,16 +203,15 @@ async def create_experiment_impl(
     random_state: int | None,
     validated_webhooks: list[tables.Webhook],
 ) -> CreateExperimentResponse:
-    match request.design_spec.experiment_type:
-        case ExperimentsType.FREQ_PREASSIGNED:
+    match request.design_spec:
+        case PreassignedFrequentistExperimentSpec():
             if desired_n is None:
                 raise LateValidationError("Preassigned experiments must have a desired_n.")
 
-            assert request.table_name is not None
-            assert request.primary_key is not None
-            table_name = request.table_name
-            primary_key = request.primary_key
-            field_type_map = await fetch_fields_or_raise(datasource, request.design_spec, table_name, primary_key)
+            preassigned_spec = request.design_spec
+            table_name = preassigned_spec.table_name
+            primary_key = preassigned_spec.primary_key
+            field_type_map = await fetch_fields_or_raise(datasource, preassigned_spec)
 
             # Get participants and their schema info from the client dwh.
             # Only fetch the columns we might need for stratified random assignment.
@@ -243,12 +245,9 @@ async def create_experiment_impl(
                 field_type_map=field_type_map,
             )
 
-        case ExperimentsType.FREQ_ONLINE:
-            assert request.table_name is not None
-            assert request.primary_key is not None
-            field_type_map = await fetch_fields_or_raise(
-                datasource, request.design_spec, request.table_name, request.primary_key
-            )
+        case OnlineFrequentistExperimentSpec():
+            online_spec = request.design_spec
+            field_type_map = await fetch_fields_or_raise(datasource, online_spec)
 
             return await create_freq_online_experiment_impl(
                 request=request,
@@ -259,7 +258,7 @@ async def create_experiment_impl(
                 field_type_map=field_type_map,
             )
 
-        case ExperimentsType.MAB_ONLINE | ExperimentsType.CMAB_ONLINE:
+        case MABExperimentSpec() | CMABExperimentSpec():
             return await create_bandit_online_experiment_impl(
                 xngin_session=xngin_session,
                 organization_id=datasource.organization_id,
@@ -292,12 +291,11 @@ async def create_preassigned_experiment_impl(
     """Create a frequentist preassigned experiment and persist it to the database."""
 
     design_spec = request.design_spec
-    table_name = request.table_name
-    unique_id_name = request.primary_key
-    assert table_name is not None and unique_id_name is not None
-
-    if design_spec.experiment_type != ExperimentsType.FREQ_PREASSIGNED:
+    if not isinstance(design_spec, PreassignedFrequentistExperimentSpec):
         raise MismatchedExperimentTypeError(f"can't create preassigned exp of type: {design_spec.experiment_type}")
+
+    table_name = design_spec.table_name
+    unique_id_name = design_spec.primary_key
 
     metric_names = [m.field_name for m in design_spec.metrics]
     strata_names = [s.field_name for s in design_spec.strata]
@@ -374,12 +372,11 @@ async def create_freq_online_experiment_impl(
 ) -> CreateExperimentResponse:
     """Create a frequentist online experiment and persist it to the database."""
     design_spec = request.design_spec
-    table_name = request.table_name
-    unique_id_name = request.primary_key
-    assert table_name is not None and unique_id_name is not None
-
-    if design_spec.experiment_type != ExperimentsType.FREQ_ONLINE:
+    if not isinstance(design_spec, OnlineFrequentistExperimentSpec):
         raise MismatchedExperimentTypeError(f"Can't create freq online exp of type: {design_spec.experiment_type}")
+
+    table_name = design_spec.table_name
+    unique_id_name = design_spec.primary_key
 
     experiment_converter = ExperimentStorageConverter.init_from_components(
         datasource_id=datasource_id,
@@ -419,8 +416,11 @@ async def create_bandit_online_experiment_impl(
     """Create a bandit experiment and persist it to the database."""
     design_spec = request.design_spec
 
-    if design_spec.experiment_type not in {ExperimentsType.MAB_ONLINE, ExperimentsType.CMAB_ONLINE}:
-        raise MismatchedExperimentTypeError(f"can't create bandit exp of type: {design_spec.experiment_type}")
+    match design_spec:
+        case MABExperimentSpec() | CMABExperimentSpec():
+            pass
+        case _:
+            raise MismatchedExperimentTypeError(f"can't create bandit exp of type: {design_spec.experiment_type}")
 
     experiment_converter = ExperimentStorageConverter.init_from_components(
         datasource_id=datasource_id,
@@ -863,10 +863,19 @@ async def update_bandit_arm_with_outcome_impl(
     # Not supported for frequentist experiments
     design_spec = await ExperimentStorageConverter(experiment).get_design_spec()
 
-    if isinstance(design_spec, BaseFrequentistDesignSpec):
-        raise LateValidationError(
-            "Cannot dynamically update arms for frequentist experiments.",
-        )
+    match design_spec:
+        case MABExperimentSpec() | CMABExperimentSpec():
+            pass
+        case PreassignedFrequentistExperimentSpec() | OnlineFrequentistExperimentSpec():
+            raise LateValidationError("Cannot dynamically update arms for frequentist experiments.")
+        case BayesABExperimentSpec():
+            # TODO: Add support for Bayesian A/B experiments.
+            raise LateValidationError(
+                f"Invalid experiment type for bandit outcome update: {design_spec.experiment_type.value}"
+            )
+        case _:
+            assert_never(design_spec)
+
     # Look up the participant's assignment if it exists
     assignment = await get_existing_assignment_for_participant(
         xngin_session, experiment.id, participant_id, experiment.experiment_type
@@ -878,12 +887,6 @@ async def update_bandit_arm_with_outcome_impl(
     if assignment.outcome is not None:
         raise ExperimentsAssignmentError(
             f"Participant {participant_id} already has an outcome recorded.",
-        )
-
-    # TODO: Add support for Bayesian A/B experiments.
-    if design_spec.experiment_type == ExperimentsType.BAYESAB_ONLINE:
-        raise LateValidationError(
-            f"Invalid experiment type for bandit outcome update: {design_spec.experiment_type.value}"
         )
 
     if design_spec.reward_type == LikelihoodTypes.BERNOULLI and outcome not in {

--- a/src/xngin/apiserver/routers/experiments/test_experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_api.py
@@ -8,10 +8,10 @@ import pytest
 from pydantic import TypeAdapter
 
 from xngin.apiserver.routers.common_api_types import (
+    AnyFrequentistDesignSpec,
     Arm,
     ArmBandit,
     BaseDesignSpec,
-    BaseFrequentistDesignSpec,
     CMABContextInputRequest,
     CMABExperimentSpec,
     Context,
@@ -116,30 +116,40 @@ def make_unvalidated_create_experiment_request(
         arms=[Arm(arm_name="overwritten1", arm_description=""), Arm(arm_name="overwritten2", arm_description="")],
     ).model_dump(exclude={"arms"})
 
-    design_spec: BaseFrequentistDesignSpec | MABExperimentSpec | CMABExperimentSpec
+    design_spec: AnyFrequentistDesignSpec | MABExperimentSpec | CMABExperimentSpec
     match experiment_type:
         case ExperimentsType.FREQ_PREASSIGNED:
-            design_spec = PreassignedFrequentistExperimentSpec(
+            props: dict = {
                 **base_kwargs,
-                arms=[
+                "arms": [
                     Arm(arm_name="control", arm_description="Control group"),
                     Arm(arm_name="treatment", arm_description="Treatment group"),
                 ],
-                metrics=[DesignSpecMetricRequest(field_name="is_onboarded", metric_pct_change=0.1)],
-                strata=[Stratum(field_name="gender")],
-                filters=filters,
-            )
+                "metrics": [DesignSpecMetricRequest(field_name="is_onboarded", metric_pct_change=0.1)],
+                "strata": [Stratum(field_name="gender")],
+                "filters": filters,
+            }
+            if table_name is not None:
+                props["table_name"] = table_name
+            if primary_key is not None:
+                props["primary_key"] = primary_key
+            design_spec = PreassignedFrequentistExperimentSpec.model_construct(**props)
         case ExperimentsType.FREQ_ONLINE:
-            design_spec = OnlineFrequentistExperimentSpec(
+            props_online: dict = {
                 **base_kwargs,
-                arms=[
+                "arms": [
                     Arm(arm_name="control", arm_description="Control group"),
                     Arm(arm_name="treatment", arm_description="Treatment group"),
                 ],
-                metrics=[DesignSpecMetricRequest(field_name="is_onboarded", metric_pct_change=0.1)],
-                strata=[Stratum(field_name="gender")],
-                filters=filters,
-            )
+                "metrics": [DesignSpecMetricRequest(field_name="is_onboarded", metric_pct_change=0.1)],
+                "strata": [Stratum(field_name="gender")],
+                "filters": filters,
+            }
+            if table_name is not None:
+                props_online["table_name"] = table_name
+            if primary_key is not None:
+                props_online["primary_key"] = primary_key
+            design_spec = OnlineFrequentistExperimentSpec.model_construct(**props_online)
         case ExperimentsType.MAB_ONLINE:
             design_spec = MABExperimentSpec(
                 **base_kwargs,
@@ -168,11 +178,7 @@ def make_unvalidated_create_experiment_request(
         case _:
             raise ValueError(f"Invalid experiment type: {experiment_type}")
 
-    return CreateExperimentRequest.model_construct(
-        design_spec=design_spec,
-        table_name=table_name,
-        primary_key=primary_key,
-    )
+    return CreateExperimentRequest.model_construct(design_spec=design_spec)
 
 
 @pytest.mark.parametrize(
@@ -232,30 +238,28 @@ async def test_get_experiment(testing_datasource, aclient: AdminAPIClient, eclie
 
 
 @pytest.mark.parametrize(
-    "experiment_type, table_name, primary_key, expected_status, expected_message",
+    "experiment_type, table_name, primary_key, expected_status, expected_in_loc",
     [
-        (ExperimentsType.FREQ_PREASSIGNED, None, None, 422, "table_name and primary_key must be provided"),
-        (ExperimentsType.FREQ_PREASSIGNED, "dwh", None, 422, "table_name and primary_key must be provided"),
-        (ExperimentsType.FREQ_PREASSIGNED, None, "id", 422, "table_name and primary_key must be provided"),
+        (ExperimentsType.FREQ_PREASSIGNED, None, None, 422, "table_name"),
+        (ExperimentsType.FREQ_PREASSIGNED, "dwh", None, 422, "primary_key"),
+        (ExperimentsType.FREQ_PREASSIGNED, None, "id", 422, "table_name"),
         (ExperimentsType.FREQ_PREASSIGNED, "dwh", "id", 200, None),
-        (ExperimentsType.FREQ_ONLINE, None, None, 422, "table_name and primary_key must be provided"),
-        (ExperimentsType.FREQ_ONLINE, "dwh", None, 422, "table_name and primary_key must be provided"),
-        (ExperimentsType.FREQ_ONLINE, None, "id", 422, "table_name and primary_key must be provided"),
+        (ExperimentsType.FREQ_ONLINE, None, None, 422, "table_name"),
+        (ExperimentsType.FREQ_ONLINE, "dwh", None, 422, "primary_key"),
+        (ExperimentsType.FREQ_ONLINE, None, "id", 422, "table_name"),
         (ExperimentsType.FREQ_ONLINE, "dwh", "id", 200, None),
-        (ExperimentsType.MAB_ONLINE, "dwh", "id", 422, "table_name and primary_key are not supported"),
-        (ExperimentsType.MAB_ONLINE, None, "id", 422, "table_name and primary_key are not supported"),
-        (ExperimentsType.CMAB_ONLINE, "dwh", "id", 422, "table_name and primary_key are not supported"),
-        (ExperimentsType.CMAB_ONLINE, "dwh", None, 422, "table_name and primary_key are not supported"),
     ],
 )
-async def test_create_experiment_api_table_name_and_primary_key_presence(
+# model_construct bypasses validation intentionally, so suppress expected PydanticSerializationUnexpectedValue noise
+@pytest.mark.filterwarnings("ignore:Pydantic serializer warnings:UserWarning:pydantic")
+async def test_create_experiment_api_table_name_and_primary_key_in_design_spec(
     testing_datasource,
     aclient: AdminAPIClient,
     experiment_type: ExperimentsType,
     table_name: str | None,
     primary_key: str | None,
     expected_status: HTTPStatus,
-    expected_message: str | None,
+    expected_in_loc: str | None,
 ):
     request = make_unvalidated_create_experiment_request(
         experiment_type=experiment_type,
@@ -270,10 +274,12 @@ async def test_create_experiment_api_table_name_and_primary_key_presence(
     )
 
     assert result.status == expected_status, result.data
-    if expected_message is not None:
+    if expected_in_loc is not None:
         assert isinstance(result.data, AdminAPIClientHTTPValidationError)
-        print(result.data.detail[0])
-        assert expected_message in result.data.detail[0].msg
+        msgs = [d.msg for d in result.data.detail]
+        assert any("Field required" in m for m in msgs), msgs
+        locs = [loc for d in result.data.detail for loc in d.loc]
+        assert any(expected_in_loc in str(loc) for loc in locs), locs
 
 
 def test_get_experiment_assignments_not_found(testing_datasource, eclient: ExperimentsAPIClient):

--- a/src/xngin/apiserver/routers/experiments/test_experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_common.py
@@ -19,7 +19,6 @@ from xngin.apiserver.exceptions_common import LateValidationError
 from xngin.apiserver.routers.common_api_types import (
     Arm,
     ArmBandit,
-    BaseFrequentistDesignSpec,
     CMABExperimentSpec,
     Context,
     ContextType,
@@ -68,9 +67,12 @@ from xngin.apiserver.testing.testing_dwh_def import TESTING_DWH_PARTICIPANT_DEF
 
 def make_createexperimentrequest_json(
     experiment_type: str = "freq_preassigned",
+    *,
     prior_type: PriorTypes = PriorTypes.NORMAL,
     reward_type: LikelihoodTypes = LikelihoodTypes.NORMAL,
     num_arms: int = 2,
+    table_name: str | None = None,
+    primary_key: str | None = None,
 ):
     """Make a basic CreateExperimentRequest JSON object.
 
@@ -79,10 +81,12 @@ def make_createexperimentrequest_json(
     experiment_type = ExperimentsType(experiment_type)
     match experiment_type:
         case ExperimentsType.FREQ_PREASSIGNED | ExperimentsType.FREQ_ONLINE:
+            table_name = table_name or TESTING_DWH_PARTICIPANT_DEF.table_name
+            primary_key = primary_key or "id"
             return {
-                "table_name": TESTING_DWH_PARTICIPANT_DEF.table_name,
-                "primary_key": "id",
                 "design_spec": {
+                    "table_name": table_name,
+                    "primary_key": primary_key,
                     "experiment_name": "test",
                     "description": "test",
                     "experiment_type": experiment_type,
@@ -197,12 +201,12 @@ def make_createexperimentrequest_json(
 
 def make_create_preassigned_experiment_request() -> CreateExperimentRequest:
     request = make_createexperimentrequest_json(experiment_type=ExperimentsType.FREQ_PREASSIGNED)
-    return TypeAdapter(CreateExperimentRequest).validate_python(request)
+    return CreateExperimentRequest.model_validate(request)
 
 
 def make_create_freq_online_experiment_request() -> CreateExperimentRequest:
     request = make_createexperimentrequest_json(experiment_type=ExperimentsType.FREQ_ONLINE)
-    return TypeAdapter(CreateExperimentRequest).validate_python(request)
+    return CreateExperimentRequest.model_validate(request)
 
 
 def make_create_online_bandit_experiment_request(
@@ -213,7 +217,7 @@ def make_create_online_bandit_experiment_request(
     request = make_createexperimentrequest_json(
         experiment_type=experiment_type, prior_type=prior_type, reward_type=reward_type
     )
-    return TypeAdapter(CreateExperimentRequest).validate_python(request)
+    return CreateExperimentRequest.model_validate(request)
 
 
 async def make_insertable_experiment(
@@ -223,20 +227,23 @@ async def make_insertable_experiment(
     experiment_type: ExperimentsType = ExperimentsType.FREQ_PREASSIGNED,
     prior_type: PriorTypes = PriorTypes.NORMAL,
     reward_type: LikelihoodTypes = LikelihoodTypes.NORMAL,
-    design_spec: DesignSpec | None = None,
     table_name: str | None = None,
     primary_key: str | None = None,
+    design_spec: DesignSpec | None = None,
 ) -> tuple[tables.Experiment, DesignSpec]:
     """Make a minimal experiment with arms ready for insertion into the database for tests.
 
-    If a design_spec is not provided, a new design_spec is created using the provided
-    experiment_type, prior_type, and reward_type. An experiment is then created using the spec and
-    any table_name and primary_key if provided.
-    This does not add any power analyses or balance checks.
+    If a design_spec is not provided, a new design_spec is created using the other arguments.
+    An experiment is then created using the spec.  This does not add any power analyses or balance
+    checks.
     """
     if design_spec is None:
         request = make_createexperimentrequest_json(
-            experiment_type=experiment_type, prior_type=prior_type, reward_type=reward_type
+            experiment_type=experiment_type,
+            prior_type=prior_type,
+            reward_type=reward_type,
+            table_name=table_name,
+            primary_key=primary_key,
         )
         design_spec = TypeAdapter(DesignSpec).validate_python(request["design_spec"])
 
@@ -250,11 +257,13 @@ async def make_insertable_experiment(
 
     # Get participants schema from datasource for frequentist experiments
     field_type_map = None
+    exp_table_name: str | None = None
+    exp_primary_key: str | None = None
     if experiment_type in {ExperimentsType.FREQ_PREASSIGNED, ExperimentsType.FREQ_ONLINE}:
         assert isinstance(design_spec, PreassignedFrequentistExperimentSpec | OnlineFrequentistExperimentSpec)
-        table_name = TESTING_DWH_PARTICIPANT_DEF.table_name if table_name is None else table_name
-        primary_key = "id" if primary_key is None else primary_key
-        field_type_map = await fetch_fields_or_raise(datasource, design_spec, table_name, primary_key)
+        exp_table_name = design_spec.table_name
+        exp_primary_key = design_spec.primary_key
+        field_type_map = await fetch_fields_or_raise(datasource, design_spec)
 
     experiment_converter = ExperimentStorageConverter.init_from_components(
         datasource_id=datasource.id,
@@ -264,9 +273,9 @@ async def make_insertable_experiment(
         state=state,
         stopped_assignments_at=stopped_assignments_at,
         stopped_assignments_reason=stopped_assignments_reason,
-        table_name=table_name,
+        table_name=exp_table_name,
+        unique_id_name=exp_primary_key,
         field_type_map=field_type_map,
-        unique_id_name=primary_key,
     )
     experiment = experiment_converter.get_experiment()
     return experiment, await experiment_converter.get_design_spec()
@@ -482,8 +491,7 @@ async def test_create_preassigned_experiment_impl(
         ]
     )
 
-    assert request.table_name is not None and request.primary_key is not None
-    field_type_map = await fetch_fields_or_raise(testing_datasource.ds, spec, request.table_name, request.primary_key)
+    field_type_map = await fetch_fields_or_raise(testing_datasource.ds, spec)
 
     response = await create_preassigned_experiment_impl(
         request=request.model_copy(deep=True),  # we'll use the original request for assertions
@@ -517,6 +525,8 @@ async def test_create_preassigned_experiment_impl(
     # original strata are not augmented with the metric names.
     assert response.design_spec.experiment_type == ExperimentsType.FREQ_PREASSIGNED
     assert isinstance(response.design_spec, PreassignedFrequentistExperimentSpec)
+    assert response.design_spec.table_name == spec.table_name
+    assert response.design_spec.primary_key == spec.primary_key
     assert response.design_spec.strata == [Stratum(field_name="gender")]
     # Verify assign_summary
     assert response.assign_summary is not None
@@ -542,7 +552,9 @@ async def test_create_preassigned_experiment_impl(
 
     assert experiment.experiment_type == ExperimentsType.FREQ_PREASSIGNED
     assert experiment.participant_type == ""
-    assert experiment.datasource_table == request.table_name
+    assert experiment.datasource_table == spec.table_name
+    unique_id_field = experiment.unique_id_field()
+    assert unique_id_field is not None and unique_id_field.field_name == spec.primary_key
     assert experiment.name == request.design_spec.experiment_name
     assert experiment.description == request.design_spec.description
     assert experiment.design_url == expected_design_url
@@ -641,9 +653,7 @@ async def test_create_preassigned_experiment_impl_raises_on_duplicate_ids(
     ]
 
     spec = cast(PreassignedFrequentistExperimentSpec, request.design_spec)
-    assert request.table_name is not None
-    assert request.primary_key is not None
-    field_type_map = await fetch_fields_or_raise(testing_datasource.ds, spec, request.table_name, request.primary_key)
+    field_type_map = await fetch_fields_or_raise(testing_datasource.ds, spec)
 
     with pytest.raises(LateValidationError, match="Duplicate participant ID found after filtering:"):
         await create_preassigned_experiment_impl(
@@ -672,9 +682,7 @@ async def test_create_preassigned_experiment_impl_with_unbalanced_arms(
     spec.arms[0].arm_weight = expected_weights[0]
     spec.arms[1].arm_weight = expected_weights[1]
 
-    assert request.table_name is not None
-    assert request.primary_key is not None
-    field_type_map = await fetch_fields_or_raise(testing_datasource.ds, spec, request.table_name, request.primary_key)
+    field_type_map = await fetch_fields_or_raise(testing_datasource.ds, spec)
 
     response = await create_preassigned_experiment_impl(
         request=request,
@@ -737,9 +745,7 @@ async def test_create_preassigned_experiment_impl_with_three_unbalanced_arms(
     spec.arms[1].arm_weight = expected_weights[1]
     spec.arms[2].arm_weight = expected_weights[2]
 
-    assert request.table_name is not None
-    assert request.primary_key is not None
-    field_type_map = await fetch_fields_or_raise(testing_datasource.ds, spec, request.table_name, request.primary_key)
+    field_type_map = await fetch_fields_or_raise(testing_datasource.ds, spec)
 
     response = await create_preassigned_experiment_impl(
         request=request,
@@ -797,14 +803,14 @@ async def test_create_freq_online_experiment_impl_experiments_fields_are_correct
 ):
     """Test creating a freq online experiment with filters, metrics, and strata are correctly stored."""
     experiment_request = CreateExperimentRequest(
-        table_name="dwh",
-        primary_key="id",
         design_spec=OnlineFrequentistExperimentSpec(
             experiment_type="freq_online",
             experiment_name="Test Experiment with Filters",
             description="Testing field storage",
             start_date=datetime(2024, 1, 1, tzinfo=UTC),
             end_date=datetime(2024, 1, 31, 23, 59, 59, tzinfo=UTC),
+            table_name="dwh",
+            primary_key="id",
             arms=[Arm(arm_name="control", arm_description=""), Arm(arm_name="treatment", arm_description="")],
             metrics=[
                 DesignSpecMetricRequest(field_name="current_income", metric_pct_change=5),
@@ -827,7 +833,6 @@ async def test_create_freq_online_experiment_impl_experiments_fields_are_correct
         ),
         webhooks=[],
     )
-    assert experiment_request.table_name is not None and experiment_request.primary_key is not None
 
     # Fake our field type map. Normally extracted from datasource schema.
     field_type_map: dict[str, DataType] = {
@@ -859,6 +864,8 @@ async def test_create_freq_online_experiment_impl_experiments_fields_are_correct
     assert response.participant_type_deprecated == ""
 
     assert isinstance(response.design_spec, OnlineFrequentistExperimentSpec)
+    assert response.design_spec.table_name == "dwh"
+    assert response.design_spec.primary_key == "id"
     assert response.design_spec.experiment_name == experiment_request.design_spec.experiment_name
     assert response.design_spec.description == experiment_request.design_spec.description
     assert response.design_spec.start_date == experiment_request.design_spec.start_date
@@ -968,7 +975,7 @@ async def test_create_experiment_impl_for_freq_online_with_unbalanced_arms(
     expected_weights = [100 * 1 / 3, 100 * 2 / 3]
     request["design_spec"]["arms"][0]["arm_weight"] = expected_weights[0]
     request["design_spec"]["arms"][1]["arm_weight"] = expected_weights[1]
-    request = TypeAdapter(CreateExperimentRequest).validate_python(request)
+    request = CreateExperimentRequest.model_validate(request)
 
     response = await create_experiment_impl(
         request=request,
@@ -1061,9 +1068,9 @@ async def test_create_experiment_impl_for_freq_raises_on_bad_filters(
 ):
     """Test that validate_filter_value is being called correctly during experiment creation."""
     request = make_createexperimentrequest_json(experiment_type=experiment_type)
-    request = TypeAdapter(CreateExperimentRequest).validate_python(request)
+    request = CreateExperimentRequest.model_validate(request)
     # Attach test filters
-    assert isinstance(request.design_spec, BaseFrequentistDesignSpec)
+    assert isinstance(request.design_spec, PreassignedFrequentistExperimentSpec | OnlineFrequentistExperimentSpec)
     request.design_spec.filters = filters
 
     with pytest.raises(LateValidationError, match=match):
@@ -1096,15 +1103,19 @@ async def test_create_experiment_impl_for_freq_online(xngin_session, testing_dat
     assert response.state == ExperimentState.ASSIGNED
 
     # Verify design_spec
+    req_online_spec = request.design_spec
+    assert isinstance(req_online_spec, OnlineFrequentistExperimentSpec)
     assert response.experiment_id is not None
     assert response.design_spec.arms[0].arm_id is not None
     assert response.design_spec.arms[1].arm_id is not None
-    assert response.design_spec.experiment_name == request.design_spec.experiment_name
-    assert response.design_spec.description == request.design_spec.description
+    assert response.design_spec.experiment_name == req_online_spec.experiment_name
+    assert response.design_spec.description == req_online_spec.description
     assert response.design_spec.design_url is None
-    assert response.design_spec.start_date == request.design_spec.start_date
-    assert response.design_spec.end_date == request.design_spec.end_date
+    assert response.design_spec.start_date == req_online_spec.start_date
+    assert response.design_spec.end_date == req_online_spec.end_date
     assert isinstance(response.design_spec, OnlineFrequentistExperimentSpec)
+    assert response.design_spec.table_name == req_online_spec.table_name
+    assert response.design_spec.primary_key == req_online_spec.primary_key
     assert response.design_spec.strata == [Stratum(field_name="gender")]
     # Online experiments don't have power analyses by default
     assert response.power_analyses is None
@@ -1121,20 +1132,19 @@ async def test_create_experiment_impl_for_freq_online(xngin_session, testing_dat
     assert experiment.experiment_type == ExperimentsType.FREQ_ONLINE
     assert experiment.participant_type == ""
     assert response.participant_type_deprecated == ""
-    assert experiment.datasource_table == TESTING_DWH_PARTICIPANT_DEF.table_name
-    assert experiment.name == request.design_spec.experiment_name
-    assert experiment.description == request.design_spec.description
+    assert experiment.datasource_table == req_online_spec.table_name
+    assert experiment.name == req_online_spec.experiment_name
+    assert experiment.description == req_online_spec.description
     assert experiment.design_url == ""
     # Online experiments still go through a review step before being committed
     assert experiment.state == ExperimentState.ASSIGNED
     assert experiment.datasource_id == testing_datasource.ds.id
-    assert_dates_equal(experiment.start_date, request.design_spec.start_date)
-    assert_dates_equal(experiment.end_date, request.design_spec.end_date)
+    assert_dates_equal(experiment.start_date, req_online_spec.start_date)
+    assert_dates_equal(experiment.end_date, req_online_spec.end_date)
     # Verify stats parameters were stored correctly
-    assert isinstance(request.design_spec, OnlineFrequentistExperimentSpec)
-    assert experiment.power == request.design_spec.power
-    assert experiment.alpha == request.design_spec.alpha
-    assert experiment.fstat_thresh == request.design_spec.fstat_thresh
+    assert experiment.power == req_online_spec.power
+    assert experiment.alpha == req_online_spec.alpha
+    assert experiment.fstat_thresh == req_online_spec.fstat_thresh
     # Verify design_spec was stored correctly
     converter = ExperimentStorageConverter(experiment)
     assert await converter.get_design_spec() == response.design_spec
@@ -1148,7 +1158,7 @@ async def test_create_experiment_impl_for_freq_online(xngin_session, testing_dat
     expected_arm_ids = {arm.arm_id for arm in response.design_spec.arms}
     assert arm_ids == expected_arm_ids
     # Verify arm positions were stored correctly
-    for i, (req_arm, db_arm) in enumerate(zip(request.design_spec.arms, arms, strict=True), start=1):
+    for i, (req_arm, db_arm) in enumerate(zip(req_online_spec.arms, arms, strict=True), start=1):
         assert db_arm.position == i
         assert req_arm.arm_name == db_arm.name
         assert req_arm.arm_weight is None
@@ -1624,11 +1634,11 @@ async def collect_streaming_response_body(response) -> bytes:
 async def test_get_experiment_assignments_as_csv_impl(xngin_session, testing_datasource):
     experiment, _ = await make_insertable_experiment(
         testing_datasource.ds,
-        table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
-        primary_key="id",
         design_spec=PreassignedFrequentistExperimentSpec(
             experiment_name="test experiment",
             description="test experiment",
+            table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
+            primary_key="id",
             start_date=datetime(2024, 1, 1, tzinfo=UTC),
             end_date=datetime.now(UTC) + timedelta(days=1),
             arms=[Arm(arm_name="control", arm_description=""), Arm(arm_name="treatment", arm_description="")],
@@ -1658,11 +1668,11 @@ async def test_get_experiment_assignments_as_csv_impl_emits_null_for_missing_met
 ):
     experiment, _ = await make_insertable_experiment(
         testing_datasource.ds,
-        table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
-        primary_key="id",
         design_spec=PreassignedFrequentistExperimentSpec(
             experiment_name="test experiment",
             description="test experiment",
+            table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
+            primary_key="id",
             start_date=datetime(2024, 1, 1, tzinfo=UTC),
             end_date=datetime.now(UTC) + timedelta(days=1),
             arms=[Arm(arm_name="control", arm_description=""), Arm(arm_name="treatment", arm_description="")],
@@ -1706,11 +1716,11 @@ async def test_get_experiment_assignments_as_csv_impl_uses_sorted_strata_header_
 ):
     experiment, _ = await make_insertable_experiment(
         testing_datasource.ds,
-        table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
-        primary_key="id",
         design_spec=PreassignedFrequentistExperimentSpec(
             experiment_name="test experiment",
             description="test experiment",
+            table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
+            primary_key="id",
             start_date=datetime(2024, 1, 1, tzinfo=UTC),
             end_date=datetime.now(UTC) + timedelta(days=1),
             arms=[Arm(arm_name="control", arm_description=""), Arm(arm_name="treatment", arm_description="")],
@@ -1732,11 +1742,11 @@ async def test_get_experiment_assignments_as_csv_impl_omits_strata_columns_when_
 ):
     experiment, _ = await make_insertable_experiment(
         testing_datasource.ds,
-        table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
-        primary_key="id",
         design_spec=PreassignedFrequentistExperimentSpec(
             experiment_name="test experiment",
             description="test experiment",
+            table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
+            primary_key="id",
             start_date=datetime(2024, 1, 1, tzinfo=UTC),
             end_date=datetime.now(UTC) + timedelta(days=1),
             arms=[Arm(arm_name="control", arm_description=""), Arm(arm_name="treatment", arm_description="")],
@@ -1854,8 +1864,6 @@ async def test_create_assignment_for_participant_errors(xngin_session, testing_d
         testing_datasource.ds,
         ExperimentState.ASSIGNED,
         experiment_type=ExperimentsType.FREQ_PREASSIGNED,
-        table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
-        primary_key="id",
     )
     experiment.arms = []
     response = await create_assignment_for_participant(xngin_session, experiment, "p1", None, random_state=66)
@@ -1866,8 +1874,6 @@ async def test_create_assignment_for_participant_errors(xngin_session, testing_d
         testing_datasource.ds,
         ExperimentState.ASSIGNED,
         experiment_type=ExperimentsType.FREQ_ONLINE,
-        table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
-        primary_key="id",
     )
     with pytest.raises(ExperimentsAssignmentError, match="Invalid experiment state: assigned"):
         await create_assignment_for_participant(xngin_session, experiment, "p1", None, random_state=66)
@@ -1877,8 +1883,6 @@ async def test_create_assignment_for_participant_errors(xngin_session, testing_d
         testing_datasource.ds,
         ExperimentState.COMMITTED,
         experiment_type=ExperimentsType.FREQ_ONLINE,
-        table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
-        primary_key="id",
     )
     experiment.arms = []
     with pytest.raises(ExperimentsAssignmentError, match="Experiment has no arms"):
@@ -1956,7 +1960,7 @@ async def test_create_assignment_for_participant_with_unbalanced_arms(xngin_sess
     request["design_spec"]["arms"][1]["arm_weight"] = expected_weights[1]
 
     response = await create_experiment_impl(
-        request=TypeAdapter(CreateExperimentRequest).validate_python(request),
+        request=CreateExperimentRequest.model_validate(request),
         datasource=testing_datasource.ds,
         xngin_session=xngin_session,
         desired_n=None,
@@ -2000,7 +2004,7 @@ async def test_create_assignment_for_participant_with_three_weighted_arms(xngin_
     request["design_spec"]["arms"][2]["arm_weight"] = expected_weights[2]
 
     response = await create_experiment_impl(
-        request=TypeAdapter(CreateExperimentRequest).validate_python(request),
+        request=CreateExperimentRequest.model_validate(request),
         datasource=testing_datasource.ds,
         xngin_session=xngin_session,
         desired_n=None,
@@ -2089,11 +2093,11 @@ async def test_get_or_create_assignment_for_participant_with_filters_in_online_f
 ):
     experiment, _ = await make_insertable_experiment(
         testing_datasource.ds,
-        table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
-        primary_key="id",
         design_spec=OnlineFrequentistExperimentSpec(
             experiment_name="test experiment",
             description="test experiment",
+            table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
+            primary_key="id",
             start_date=datetime(2024, 1, 1, tzinfo=UTC),
             end_date=datetime.now(UTC) + timedelta(days=1),
             arms=[Arm(arm_name="control", arm_description=""), Arm(arm_name="treatment", arm_description="")],
@@ -2243,8 +2247,6 @@ async def test_analyze_experiment_freq_impl_with_no_outcomes_for_any_arms(xngin_
         testing_datasource.ds,
         ExperimentState.ASSIGNED,
         experiment_type=ExperimentsType.FREQ_ONLINE,
-        table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
-        primary_key="id",
     )
     xngin_session.add(experiment)
     await xngin_session.commit()

--- a/src/xngin/apiserver/routers/test_common_api_types.py
+++ b/src/xngin/apiserver/routers/test_common_api_types.py
@@ -1,5 +1,5 @@
 import pytest
-from pydantic import TypeAdapter, ValidationError
+from pydantic import ValidationError
 
 from xngin.apiserver.routers.common_api_types import Filter, PreassignedFrequentistExperimentSpec
 from xngin.apiserver.routers.common_enums import Relation
@@ -125,12 +125,14 @@ def test_empty_value_list():
 
 
 def test_arm_weights_validation():
-    """Test validation of arm_weights in BaseFrequentistDesignSpec"""
+    """Test validation of arm_weights in PreassignedFrequentistExperimentSpec"""
     # Test: weights sum to 100 and match number of arms
     valid_spec = {
         "experiment_type": "freq_preassigned",
         "experiment_name": "test",
         "description": "test",
+        "table_name": "dwh",
+        "primary_key": "id",
         "start_date": "2024-01-01T00:00:00+00:00",
         "end_date": "2024-12-31T00:00:00+00:00",
         "arms": [
@@ -141,7 +143,7 @@ def test_arm_weights_validation():
         "metrics": [{"field_name": "metric1", "metric_pct_change": 0.1}],
         "filters": [],
     }
-    spec = TypeAdapter(PreassignedFrequentistExperimentSpec).validate_python(valid_spec)
+    spec = PreassignedFrequentistExperimentSpec.model_validate(valid_spec)
     assert [arm.arm_weight for arm in spec.arms] == [20.0, 80.0]
 
     # Test: three arms with weights summing to 100
@@ -151,7 +153,7 @@ def test_arm_weights_validation():
         {"arm_name": "T", "arm_description": "T", "arm_weight": 19.9},
         {"arm_name": "T2", "arm_description": "T2", "arm_weight": 60.0},
     ]
-    spec = TypeAdapter(PreassignedFrequentistExperimentSpec).validate_python(valid_spec_3arms)
+    spec = PreassignedFrequentistExperimentSpec.model_validate(valid_spec_3arms)
     assert spec.get_validated_arm_weights() == [20.1, 19.9, 60.0]
 
     # Invalid case: weights don't sum to 100
@@ -161,7 +163,7 @@ def test_arm_weights_validation():
         {"arm_name": "T", "arm_description": "T", "arm_weight": 80.0},
     ]
     with pytest.raises(ValidationError, match="arm_weights must sum to 100"):
-        TypeAdapter(PreassignedFrequentistExperimentSpec).validate_python(invalid_sum)
+        PreassignedFrequentistExperimentSpec.model_validate(invalid_sum)
 
     # Invalid case: number of weights doesn't match number of arms
     invalid_count = valid_spec.copy()
@@ -171,7 +173,7 @@ def test_arm_weights_validation():
         {"arm_name": "T2", "arm_description": "T2"},  # missing arm_weight
     ]
     with pytest.raises(ValidationError, match=r"Number of arm weights \(2\) must match number of arms \(3\)"):
-        TypeAdapter(PreassignedFrequentistExperimentSpec).validate_python(invalid_count)
+        PreassignedFrequentistExperimentSpec.model_validate(invalid_count)
 
     # Invalid case: weights too small and large
     invalid_negative = valid_spec.copy()
@@ -183,7 +185,7 @@ def test_arm_weights_validation():
         ValidationError,
         match=r"(?s)Input should be greater than 0.*Input should be less than 100",
     ):
-        TypeAdapter(PreassignedFrequentistExperimentSpec).validate_python(invalid_negative)
+        PreassignedFrequentistExperimentSpec.model_validate(invalid_negative)
 
     # Invalid case: zero weight
     invalid_zero = valid_spec.copy()
@@ -195,7 +197,7 @@ def test_arm_weights_validation():
         ValidationError,
         match=r"(?s)Input should be greater than 0.*Input should be less than 100",
     ):
-        TypeAdapter(PreassignedFrequentistExperimentSpec).validate_python(invalid_zero)
+        PreassignedFrequentistExperimentSpec.model_validate(invalid_zero)
 
     invalid_inf = valid_spec.copy()
     invalid_inf["arms"] = [
@@ -206,4 +208,4 @@ def test_arm_weights_validation():
         ValidationError,
         match=r"(?s)Input should be a finite number.*Input should be a finite number",
     ):
-        TypeAdapter(PreassignedFrequentistExperimentSpec).validate_python(invalid_inf)
+        PreassignedFrequentistExperimentSpec.model_validate(invalid_inf)

--- a/src/xngin/apiserver/snapshots/test_snapshotter.py
+++ b/src/xngin/apiserver/snapshots/test_snapshotter.py
@@ -2,6 +2,7 @@ import asyncio
 import math
 import warnings
 from datetime import UTC, datetime, timedelta
+from typing import assert_never
 
 import pytest
 from sqlalchemy import select
@@ -11,7 +12,7 @@ from xngin.apiserver.routers.common_api_types import (
     Arm,
     ArmBandit,
     BanditExperimentAnalysisResponse,
-    BaseFrequentistDesignSpec,
+    BayesABExperimentSpec,
     CMABContextInputRequest,
     CMABExperimentSpec,
     Context,
@@ -24,11 +25,12 @@ from xngin.apiserver.routers.common_api_types import (
     FreqExperimentAnalysisResponse,
     LikelihoodTypes,
     MABExperimentSpec,
+    OnlineFrequentistExperimentSpec,
     PreassignedFrequentistExperimentSpec,
     PriorTypes,
     UpdateBanditArmOutcomeRequest,
 )
-from xngin.apiserver.routers.common_enums import ExperimentState, StopAssignmentReason
+from xngin.apiserver.routers.common_enums import DataType, ExperimentState, StopAssignmentReason
 from xngin.apiserver.routers.experiments.experiments_common import fetch_fields_or_raise
 from xngin.apiserver.snapshots.snapshotter import (
     SNAPSHOT_TIMEOUT_SECS,
@@ -51,16 +53,21 @@ async def make_experiment(
     xngin_session,
     datasource: tables.Datasource,
     design_spec: DesignSpec,
-    *,
-    table_name: str | None = None,
-    primary_key: str | None = None,
 ) -> tables.Experiment:
-    field_type_map = None
-    if design_spec.experiment_type in {ExperimentsType.FREQ_PREASSIGNED, ExperimentsType.FREQ_ONLINE}:
-        assert isinstance(design_spec, BaseFrequentistDesignSpec)
-        assert table_name is not None
-        assert primary_key is not None
-        field_type_map = await fetch_fields_or_raise(datasource, design_spec, table_name, primary_key)
+    table_name: str | None
+    primary_key: str | None
+    field_type_map: dict[str, DataType] | None
+    match design_spec:
+        case PreassignedFrequentistExperimentSpec() | OnlineFrequentistExperimentSpec():
+            table_name = design_spec.table_name
+            primary_key = design_spec.primary_key
+            field_type_map = await fetch_fields_or_raise(datasource, design_spec)
+        case MABExperimentSpec() | CMABExperimentSpec() | BayesABExperimentSpec():
+            table_name = None
+            primary_key = None
+            field_type_map = None
+        case _:
+            assert_never(design_spec)
 
     experiment_converter = ExperimentStorageConverter.init_from_components(
         datasource_id=datasource.id,
@@ -71,8 +78,8 @@ async def make_experiment(
         stopped_assignments_at=datetime.now(UTC),
         stopped_assignments_reason=StopAssignmentReason.PREASSIGNED,
         table_name=table_name,
-        field_type_map=field_type_map,
         unique_id_name=primary_key,
+        field_type_map=field_type_map,
     )
     experiment = experiment_converter.get_experiment()
     xngin_session.add(experiment)
@@ -132,6 +139,8 @@ def make_snapshot_design_spec(
         metrics=[DesignSpecMetricRequest(field_name="is_engaged", metric_pct_change=0.1)],
         strata=[],
         filters=[],
+        table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
+        primary_key="id",
     )
 
 
@@ -145,11 +154,7 @@ def create_snapshot_experiment(
 ) -> str:
     experiment_id = aclient.create_experiment(
         datasource_id=testing_datasource.ds.id,
-        body=CreateExperimentRequest(
-            design_spec=make_snapshot_design_spec(name, end_date=end_date),
-            table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
-            primary_key="id",
-        ),
+        body=CreateExperimentRequest(design_spec=make_snapshot_design_spec(name, end_date=end_date)),
         desired_n=desired_n,
     ).data.experiment_id
     aclient.commit_experiment(datasource_id=testing_datasource.ds.id, experiment_id=experiment_id)
@@ -210,6 +215,8 @@ async def test_make_first_snapshot_of_freq_preassigned(xngin_session, testing_da
         experiment_type=ExperimentsType.FREQ_PREASSIGNED,
         experiment_name="test experiment",
         description="test experiment",
+        table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
+        primary_key="id",
         start_date=datetime(2024, 1, 1, tzinfo=UTC),
         end_date=datetime.now(UTC) + timedelta(days=1),
         arms=[
@@ -221,13 +228,7 @@ async def test_make_first_snapshot_of_freq_preassigned(xngin_session, testing_da
         filters=[],
     )
 
-    experiment = await make_experiment(
-        xngin_session,
-        datasource,
-        design_spec,
-        table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
-        primary_key="id",
-    )
+    experiment = await make_experiment(xngin_session, datasource, design_spec)
     # Arms' intial position should reflect design spec ordering
     arm1 = experiment.arms[0]
     assert arm1.position == 1

--- a/src/xngin/apiserver/storage/bootstrap.py
+++ b/src/xngin/apiserver/storage/bootstrap.py
@@ -101,11 +101,11 @@ async def _maybe_create_developer_samples(
         session,
         datasource,
         CreateExperimentRequest(
-            table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
-            primary_key="id",
             design_spec=PreassignedFrequentistExperimentSpec(
                 experiment_name="Preassigned steady gain",
                 description="Hypothesis",
+                table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
+                primary_key="id",
                 start_date=datetime.datetime.now() - datetime.timedelta(days=7),
                 end_date=datetime.datetime.now() + datetime.timedelta(days=7),
                 arms=[
@@ -125,11 +125,11 @@ async def _maybe_create_developer_samples(
         session,
         datasource,
         CreateExperimentRequest(
-            table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
-            primary_key="id",
             design_spec=PreassignedFrequentistExperimentSpec(
                 experiment_name="Preassigned 2.0",
                 description="Hypothesis",
+                table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
+                primary_key="id",
                 start_date=datetime.datetime.now() - datetime.timedelta(days=7),
                 end_date=datetime.datetime.now() + datetime.timedelta(days=7),
                 arms=[
@@ -148,11 +148,11 @@ async def _maybe_create_developer_samples(
         session,
         datasource,
         CreateExperimentRequest(
-            table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
-            primary_key="id",
             design_spec=OnlineFrequentistExperimentSpec(
                 experiment_name="Online",
                 description="Hypothesis",
+                table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
+                primary_key="id",
                 start_date=datetime.datetime.now() - datetime.timedelta(days=7),
                 end_date=datetime.datetime.now() + datetime.timedelta(days=7),
                 arms=[
@@ -172,11 +172,11 @@ async def _maybe_create_developer_samples(
         session,
         datasource,
         CreateExperimentRequest(
-            table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
-            primary_key="id",
             design_spec=OnlineFrequentistExperimentSpec(
                 experiment_name="Online 2.0",
                 description="Hypothesis",
+                table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
+                primary_key="id",
                 start_date=datetime.datetime.now() - datetime.timedelta(days=7),
                 end_date=datetime.datetime.now() + datetime.timedelta(days=7),
                 arms=[
@@ -242,11 +242,11 @@ async def _maybe_create_developer_samples(
         session,
         alt_datasource,
         CreateExperimentRequest(
-            table_name=WIDE_DWH_PARTICIPANT_DEF.table_name,
-            primary_key="id",
             design_spec=PreassignedFrequentistExperimentSpec(
                 experiment_name="Wide Preassigned",
                 description="Hypothesis",
+                table_name=WIDE_DWH_PARTICIPANT_DEF.table_name,
+                primary_key="id",
                 start_date=datetime.datetime.now() - datetime.timedelta(days=7),
                 end_date=datetime.datetime.now() + datetime.timedelta(days=7),
                 arms=[

--- a/src/xngin/apiserver/storage/storage_format_converters.py
+++ b/src/xngin/apiserver/storage/storage_format_converters.py
@@ -8,7 +8,7 @@ JSONB type columns for multi-value/complex types, use the converters to get/set 
 
 import operator
 from datetime import datetime
-from typing import Any, Self
+from typing import Any, Self, assert_never
 
 import numpy as np
 from pydantic import TypeAdapter
@@ -53,10 +53,15 @@ class ExperimentStorageConverter:
             field_type_map: Optional field name to data type mapping.
             unique_id_name: Optional unique ID field name.
         """
-        if not isinstance(design_spec, capi.BaseFrequentistDesignSpec):
-            self.experiment.design_spec_fields = None
-            self.experiment.experiment_fields = []
-            return self
+        match design_spec:
+            case capi.MABExperimentSpec() | capi.CMABExperimentSpec() | capi.BayesABExperimentSpec():
+                self.experiment.design_spec_fields = None
+                self.experiment.experiment_fields = []
+                return self
+            case capi.PreassignedFrequentistExperimentSpec() | capi.OnlineFrequentistExperimentSpec():
+                pass
+            case _:
+                assert_never(design_spec)
 
         field_type_map = field_type_map or {}
 
@@ -248,8 +253,15 @@ class ExperimentStorageConverter:
             ExperimentsType.FREQ_ONLINE.value,
             ExperimentsType.FREQ_PREASSIGNED.value,
         }:
+            await self.experiment.awaitable_attrs.experiment_fields
+            primary_key_field = self.experiment.unique_id_field()
+            if self.experiment.datasource_table is None or primary_key_field is None:
+                raise ValueError("Frequentist experiment is missing datasource_table or unique participant key field.")
+
             return TypeAdapter(capi.DesignSpec).validate_python({
                 **base_experiment_dict,
+                "table_name": self.experiment.datasource_table,
+                "primary_key": primary_key_field.field_name,
                 "arms": [
                     {
                         "arm_id": arm.id,
@@ -266,6 +278,7 @@ class ExperimentStorageConverter:
                 "alpha": self.experiment.alpha,
                 "fstat_thresh": self.experiment.fstat_thresh,
             })
+
         if self.experiment.experiment_type in {
             ExperimentsType.MAB_ONLINE.value,
             ExperimentsType.CMAB_ONLINE.value,
@@ -423,7 +436,7 @@ class ExperimentStorageConverter:
         )
 
         match design_spec:
-            case capi.BaseFrequentistDesignSpec():
+            case capi.PreassignedFrequentistExperimentSpec() | capi.OnlineFrequentistExperimentSpec():
                 # Set frequentist-specific fields
                 experiment.power = design_spec.power
                 experiment.alpha = design_spec.alpha
@@ -447,8 +460,8 @@ class ExperimentStorageConverter:
                     .set_power_response(power_analyses)
                 )
 
-            case capi.BaseBanditExperimentSpec():
-                if design_spec.experiment_type == ExperimentsType.CMAB_ONLINE and not design_spec.contexts:
+            case capi.MABExperimentSpec() | capi.CMABExperimentSpec():
+                if isinstance(design_spec, capi.CMABExperimentSpec) and not design_spec.contexts:
                     raise ValueError("Contexts are required for CMAB experiments.")
 
                 # Set bandit fields
@@ -506,5 +519,7 @@ class ExperimentStorageConverter:
                 ]
 
                 return cls(experiment)
-            case _:
+            case capi.BayesABExperimentSpec():
                 raise ValueError(f"Unsupported design_spec type: {type(design_spec)}.")
+            case _:
+                assert_never(design_spec)

--- a/src/xngin/apiserver/storage/storage_format_converters.py
+++ b/src/xngin/apiserver/storage/storage_format_converters.py
@@ -256,7 +256,10 @@ class ExperimentStorageConverter:
             await self.experiment.awaitable_attrs.experiment_fields
             primary_key_field = self.experiment.unique_id_field()
             if self.experiment.datasource_table is None or primary_key_field is None:
-                raise ValueError("Frequentist experiment is missing datasource_table or unique participant key field.")
+                raise ValueError(
+                    f"Frequentist experiment {self.experiment.id} "
+                    "is missing datasource_table or unique participant key field."
+                )
 
             return TypeAdapter(capi.DesignSpec).validate_python({
                 **base_experiment_dict,
@@ -284,7 +287,7 @@ class ExperimentStorageConverter:
             ExperimentsType.CMAB_ONLINE.value,
         }:
             if not self.experiment.prior_type or not self.experiment.reward_type:
-                raise ValueError("Bandit experiments must have prior_type and reward_type set.")
+                raise ValueError(f"Bandit experiment {self.experiment.id} must have prior_type and reward_type set.")
             contexts = None
             if self.experiment.experiment_type == ExperimentsType.CMAB_ONLINE.value:
                 contexts = [
@@ -462,7 +465,7 @@ class ExperimentStorageConverter:
 
             case capi.MABExperimentSpec() | capi.CMABExperimentSpec():
                 if isinstance(design_spec, capi.CMABExperimentSpec) and not design_spec.contexts:
-                    raise ValueError("Contexts are required for CMAB experiments.")
+                    raise ValueError(f"CMAB experiment {experiment.id} must have contexts set.")
 
                 # Set bandit fields
                 context_len = len(design_spec.contexts) if design_spec.contexts else 1


### PR DESCRIPTION
## Description

An update to the reverted #213. This reapplies PR 213 after I've cleaned up some stale test data in the db via API, and also makes it easier to see problematic ids in raised errors from caabd74d30097055512c43f4f9a53fdbb584776f.

Here's a diff with the previous merge commit: https://github.com/agency-fund/evidential-be/compare/a0f8f9b73d927346b54bf45a171eac5150c6c586...213_redo?expand=1

FE PR: https://github.com/agency-fund/evidential-fe/pull/240

## How has this been tested?

Identified problematic rows:
```
SELECT
    e.experiment_type,
    e.state,
    ef.field_name AS pk,
    e.datasource_table AS ds_table,
    e.created_at,
    e.id AS eid,
    o.name as oname,
    e.name as ename
FROM organizations o
JOIN datasources d on (d.organization_id = o.id)
JOIN experiments e on (e.datasource_id = d.id)
LEFT JOIN experiment_fields ef
    ON ef.experiment_id = e.id
    AND ef.is_unique_id = TRUE
WHERE
    experiment_type in ('freq_online', 'freq_preassigned')
    AND ef.field_name is NULL
ORDER BY created_at asc;
```

Re-confirmed that the following query hits only the 3 rows identified earlier as problematic:
```SELECT * FROM experiments e
WHERE e.experiment_type IN ('freq_online', 'freq_preassigned')
  AND e.state = 'assigned'
  AND e.created_at < '2026-01-01'
  AND datasource_table is NULL;
  ```
Data erased from the ds via API.