### PR TITLE
Remove ptype experiment from bootstrapped experiments.

### DIFF
--- a/src/xngin/apiserver/routers/auth/test_auth_dependencies.py
+++ b/src/xngin/apiserver/routers/auth/test_auth_dependencies.py
@@ -273,7 +273,7 @@ async def test_initial_user_setup_matches_testing_dwh(xngin_session: AsyncSessio
         .select_from(tables.Experiment)
         .where(tables.Experiment.datasource_id.in_([datasource.id for datasource in datasources]))
     )
-    assert experiment_count == 7
+    assert experiment_count == 6
 
     snapshot_count_rows = (
         await xngin_session.execute(

--- a/src/xngin/apiserver/storage/bootstrap.py
+++ b/src/xngin/apiserver/storage/bootstrap.py
@@ -38,8 +38,6 @@ async def _create_and_commit_experiment(
     session: AsyncSession,
     datasource: tables.Datasource,
     create_experiment_request: CreateExperimentRequest,
-    *,
-    participant_type_deprecated: str | None = None,
 ):
     result = await experiments_common.create_experiment_impl(
         create_experiment_request,
@@ -52,11 +50,6 @@ async def _create_and_commit_experiment(
     )
     experiment = await session.get_one(tables.Experiment, result.experiment_id)
     await experiments_common.commit_experiment_impl(session, experiment)
-    # We can't use the API anymore to simulate a user setting the participant type, so do it manually.
-    if participant_type_deprecated is not None:
-        experiment.participant_type = participant_type_deprecated
-        await session.commit()
-
     return experiment
 
 
@@ -104,7 +97,7 @@ async def _maybe_create_developer_samples(
             table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
             primary_key="id",
             design_spec=PreassignedFrequentistExperimentSpec(
-                experiment_name="Preassigned steady gain",
+                experiment_name="Preassigned - steady gain",
                 description="Hypothesis",
                 start_date=datetime.datetime.now() - datetime.timedelta(days=7),
                 end_date=datetime.datetime.now() + datetime.timedelta(days=7),
@@ -117,7 +110,6 @@ async def _maybe_create_developer_samples(
                 metrics=[DesignSpecMetricRequest(field_name="current_income", metric_pct_change=0.10)],
             ),
         ),
-        participant_type_deprecated="test_participant_type",
     )
     await seed_historical_snapshots(session, preassigned, STEADY_GAIN)
 
@@ -128,7 +120,7 @@ async def _maybe_create_developer_samples(
             table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
             primary_key="id",
             design_spec=PreassignedFrequentistExperimentSpec(
-                experiment_name="Preassigned 2.0",
+                experiment_name="Preassigned - late breakout",
                 description="Hypothesis",
                 start_date=datetime.datetime.now() - datetime.timedelta(days=7),
                 end_date=datetime.datetime.now() + datetime.timedelta(days=7),
@@ -152,30 +144,6 @@ async def _maybe_create_developer_samples(
             primary_key="id",
             design_spec=OnlineFrequentistExperimentSpec(
                 experiment_name="Online",
-                description="Hypothesis",
-                start_date=datetime.datetime.now() - datetime.timedelta(days=7),
-                end_date=datetime.datetime.now() + datetime.timedelta(days=7),
-                arms=[
-                    Arm(arm_name="Control", arm_description="First arm"),
-                    Arm(arm_name="Treatment", arm_description="Second arm"),
-                ],
-                filters=[],
-                strata=[],
-                metrics=[DesignSpecMetricRequest(field_name="current_income", metric_pct_change=0.10)],
-            ),
-        ),
-        participant_type_deprecated="test_participant_type",
-    )
-
-    # Create an online frequentist experiment with table name and primary key instead of a participant type
-    await _create_and_commit_experiment(
-        session,
-        datasource,
-        CreateExperimentRequest(
-            table_name=TESTING_DWH_PARTICIPANT_DEF.table_name,
-            primary_key="id",
-            design_spec=OnlineFrequentistExperimentSpec(
-                experiment_name="Online 2.0",
                 description="Hypothesis",
                 start_date=datetime.datetime.now() - datetime.timedelta(days=7),
                 end_date=datetime.datetime.now() + datetime.timedelta(days=7),
@@ -245,7 +213,7 @@ async def _maybe_create_developer_samples(
             table_name=WIDE_DWH_PARTICIPANT_DEF.table_name,
             primary_key="id",
             design_spec=PreassignedFrequentistExperimentSpec(
-                experiment_name="Wide Preassigned",
+                experiment_name="Preassigned - wide",
                 description="Hypothesis",
                 start_date=datetime.datetime.now() - datetime.timedelta(days=7),
                 end_date=datetime.datetime.now() + datetime.timedelta(days=7),


### PR DESCRIPTION
Developer environments are bootstrapped with various experiment types to ease
development. This PR removes the creation of an experiment using the old
participant-type fields, and updates the names of the other experiments to be
more descriptive of what they do.

Tested by bootstrapping a new dev environment.
