### PR TITLE
Simplify experiment storage conversion

### DIFF
--- a/.cursor/rules/no-pr-without-explicit-request.mdc
+++ b/.cursor/rules/no-pr-without-explicit-request.mdc
@@ -1,0 +1,11 @@
+---
+description: Do not create or update pull requests without explicit user approval.
+alwaysApply: true
+---
+
+# Pull Request Creation
+
+Do not create, update, or otherwise manage GitHub pull requests unless the user explicitly asks for a PR action in the current conversation.
+
+When changes are complete, push the working branch and tell the user the branch name so they can pull it down locally for review and edits.
+

--- a/src/xngin/apiserver/routers/admin/admin_api.py
+++ b/src/xngin/apiserver/routers/admin/admin_api.py
@@ -142,7 +142,7 @@ from xngin.apiserver.settings import (
 )
 from xngin.apiserver.snapshots import snapshotter
 from xngin.apiserver.sqla import tables
-from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter
+from xngin.apiserver.storage.storage_format_converters import design_spec_from_experiment
 from xngin.stats import check_power
 
 GENERIC_SUCCESS = Response(status_code=status.HTTP_204_NO_CONTENT)
@@ -1554,7 +1554,7 @@ async def analyze_experiment(
         ],
     )
 
-    design_spec = await ExperimentStorageConverter(experiment).get_design_spec()
+    design_spec = await design_spec_from_experiment(experiment)
     match design_spec:
         case PreassignedFrequentistExperimentSpec() | OnlineFrequentistExperimentSpec():
             # Always assume the first arm is the baseline; UI can override this.

--- a/src/xngin/apiserver/routers/admin/test_admin.py
+++ b/src/xngin/apiserver/routers/admin/test_admin.py
@@ -98,7 +98,7 @@ from xngin.apiserver.routers.experiments.test_experiments_common import (
 )
 from xngin.apiserver.settings import ParticipantsDef, RemoteDatabaseConfig
 from xngin.apiserver.sqla import tables
-from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter
+from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter, experiment_from_design_spec
 from xngin.apiserver.testing.admin_api_client import AdminAPIClient
 from xngin.apiserver.testing.experiments_api_client import ExperimentsAPIClient
 from xngin.apiserver.testing.testing_dwh_def import TESTING_DWH_PARTICIPANT_DEF
@@ -224,7 +224,7 @@ async def fixture_testing_experiment(xngin_session: AsyncSession, testing_dataso
     )
     field_type_map = await fetch_fields_or_raise(datasource, design_spec)
 
-    experiment_converter = ExperimentStorageConverter.init_from_components(
+    experiment = experiment_from_design_spec(
         datasource_id=datasource.id,
         organization_id=datasource.organization_id,
         design_spec=design_spec,
@@ -233,7 +233,6 @@ async def fixture_testing_experiment(xngin_session: AsyncSession, testing_dataso
         stopped_assignments_reason=StopAssignmentReason.PREASSIGNED,
         field_type_map=field_type_map,
     )
-    experiment = experiment_converter.get_experiment()
     xngin_session.add(experiment)
     await xngin_session.commit()
 

--- a/src/xngin/apiserver/routers/admin/test_admin.py
+++ b/src/xngin/apiserver/routers/admin/test_admin.py
@@ -98,7 +98,7 @@ from xngin.apiserver.routers.experiments.test_experiments_common import (
 )
 from xngin.apiserver.settings import ParticipantsDef, RemoteDatabaseConfig
 from xngin.apiserver.sqla import tables
-from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter, experiment_from_design_spec
+from xngin.apiserver.storage.storage_format_converters import experiment_from_design_spec
 from xngin.apiserver.testing.admin_api_client import AdminAPIClient
 from xngin.apiserver.testing.experiments_api_client import ExperimentsAPIClient
 from xngin.apiserver.testing.testing_dwh_def import TESTING_DWH_PARTICIPANT_DEF

--- a/src/xngin/apiserver/routers/admin/test_admin.py
+++ b/src/xngin/apiserver/routers/admin/test_admin.py
@@ -227,13 +227,10 @@ async def fixture_testing_experiment(xngin_session: AsyncSession, testing_dataso
     experiment_converter = ExperimentStorageConverter.init_from_components(
         datasource_id=datasource.id,
         organization_id=datasource.organization_id,
-        experiment_type=design_spec.experiment_type,
         design_spec=design_spec,
         state=ExperimentState.COMMITTED,
         stopped_assignments_at=datetime.now(UTC),
         stopped_assignments_reason=StopAssignmentReason.PREASSIGNED,
-        table_name=design_spec.table_name,
-        unique_id_name=design_spec.primary_key,
         field_type_map=field_type_map,
     )
     experiment = experiment_converter.get_experiment()

--- a/src/xngin/apiserver/routers/experiments/experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_api.py
@@ -63,7 +63,7 @@ from xngin.apiserver.routers.experiments.experiments_common_csv import (
 )
 from xngin.apiserver.settings import Datasource
 from xngin.apiserver.sqla import tables
-from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter
+from xngin.apiserver.storage.storage_format_converters import balance_check_from_experiment
 
 JSON_STREAM_ROWS_PER_YIELD = 1_000
 
@@ -116,7 +116,7 @@ async def _stream_experiment_assignments_response(
     experiment: tables.Experiment, assignments: AsyncGenerator[AssignmentTypedDict]
 ) -> AsyncIterator[bytes]:
     """Efficiently streams Assignments to the client."""
-    balance_check = ExperimentStorageConverter(experiment).get_balance_check()
+    balance_check = balance_check_from_experiment(experiment)
     yield (
         b'{"balance_check":'
         + orjson.dumps(None if balance_check is None else balance_check.model_dump(mode="json"))

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -294,7 +294,6 @@ async def create_preassigned_experiment_impl(
     if not isinstance(design_spec, PreassignedFrequentistExperimentSpec):
         raise MismatchedExperimentTypeError(f"can't create preassigned exp of type: {design_spec.experiment_type}")
 
-    table_name = design_spec.table_name
     unique_id_name = design_spec.primary_key
 
     metric_names = [m.field_name for m in design_spec.metrics]
@@ -327,16 +326,13 @@ async def create_preassigned_experiment_impl(
     experiment_converter = ExperimentStorageConverter.init_from_components(
         datasource_id=datasource_id,
         organization_id=organization_id,
-        experiment_type=design_spec.experiment_type,
         design_spec=design_spec,
         state=ExperimentState.ASSIGNED,
         stopped_assignments_at=datetime.now(UTC),
         stopped_assignments_reason=StopAssignmentReason.PREASSIGNED,
         balance_check=balance_check,
         power_analyses=request.power_analyses,
-        table_name=table_name,
         field_type_map=field_type_map,
-        unique_id_name=unique_id_name,
     )
     experiment = experiment_converter.get_experiment()
     # Associate webhooks with the experiment
@@ -375,17 +371,11 @@ async def create_freq_online_experiment_impl(
     if not isinstance(design_spec, OnlineFrequentistExperimentSpec):
         raise MismatchedExperimentTypeError(f"Can't create freq online exp of type: {design_spec.experiment_type}")
 
-    table_name = design_spec.table_name
-    unique_id_name = design_spec.primary_key
-
     experiment_converter = ExperimentStorageConverter.init_from_components(
         datasource_id=datasource_id,
         organization_id=organization_id,
-        experiment_type=ExperimentsType.FREQ_ONLINE,
         design_spec=design_spec,
-        table_name=table_name,
         field_type_map=field_type_map,
-        unique_id_name=unique_id_name,
     )
     experiment = experiment_converter.get_experiment()
     # Associate webhooks with the experiment
@@ -425,7 +415,6 @@ async def create_bandit_online_experiment_impl(
     experiment_converter = ExperimentStorageConverter.init_from_components(
         datasource_id=datasource_id,
         organization_id=organization_id,
-        experiment_type=design_spec.experiment_type,
         design_spec=design_spec,
         n_trials=desired_n if desired_n is not None else 0,
     )

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -64,7 +64,7 @@ from xngin.apiserver.routers.experiments.property_filters import passes_filters,
 from xngin.apiserver.settings import DatasourceConfig, ParticipantsDef
 from xngin.apiserver.sql.queries import select_as_csv
 from xngin.apiserver.sqla import tables
-from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter
+from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter, experiment_from_design_spec
 from xngin.apiserver.webhooks.webhook_types import ExperimentCreatedWebhookBody
 from xngin.events.experiment_created import ExperimentCreatedEvent
 from xngin.stats.analysis import analyze_experiment as analyze_freq_experiment
@@ -323,7 +323,7 @@ async def create_preassigned_experiment_impl(
     )
     balance_check = make_balance_check(assignment_result.balance_result, design_spec.fstat_thresh)
 
-    experiment_converter = ExperimentStorageConverter.init_from_components(
+    experiment = experiment_from_design_spec(
         datasource_id=datasource_id,
         organization_id=organization_id,
         design_spec=design_spec,
@@ -334,7 +334,6 @@ async def create_preassigned_experiment_impl(
         power_analyses=request.power_analyses,
         field_type_map=field_type_map,
     )
-    experiment = experiment_converter.get_experiment()
     # Associate webhooks with the experiment
     for webhook in validated_webhooks:
         experiment.webhooks.append(webhook)
@@ -354,6 +353,7 @@ async def create_preassigned_experiment_impl(
 
     assign_summary = convert_assignment_results_to_assign_summary(experiment.arms, assignment_result, balance_check)
     webhook_ids = [webhook.id for webhook in validated_webhooks]
+    experiment_converter = ExperimentStorageConverter(experiment)
     return await experiment_converter.get_create_experiment_response(assign_summary, webhook_ids)
 
 
@@ -371,13 +371,12 @@ async def create_freq_online_experiment_impl(
     if not isinstance(design_spec, OnlineFrequentistExperimentSpec):
         raise MismatchedExperimentTypeError(f"Can't create freq online exp of type: {design_spec.experiment_type}")
 
-    experiment_converter = ExperimentStorageConverter.init_from_components(
+    experiment = experiment_from_design_spec(
         datasource_id=datasource_id,
         organization_id=organization_id,
         design_spec=design_spec,
         field_type_map=field_type_map,
     )
-    experiment = experiment_converter.get_experiment()
     # Associate webhooks with the experiment
     for webhook in validated_webhooks:
         experiment.webhooks.append(webhook)
@@ -392,6 +391,7 @@ async def create_freq_online_experiment_impl(
         arm_sizes=[ArmSize(arm=Arm(arm_id=arm.id, arm_name=arm.name), size=0) for arm in experiment.arms],
     )
     webhook_ids = [webhook.id for webhook in validated_webhooks]
+    experiment_converter = ExperimentStorageConverter(experiment)
     return await experiment_converter.get_create_experiment_response(empty_assign_summary, webhook_ids)
 
 
@@ -412,13 +412,12 @@ async def create_bandit_online_experiment_impl(
         case _:
             raise MismatchedExperimentTypeError(f"can't create bandit exp of type: {design_spec.experiment_type}")
 
-    experiment_converter = ExperimentStorageConverter.init_from_components(
+    experiment = experiment_from_design_spec(
         datasource_id=datasource_id,
         organization_id=organization_id,
         design_spec=design_spec,
         n_trials=desired_n if desired_n is not None else 0,
     )
-    experiment = experiment_converter.get_experiment()
     # Associate webhooks with the experiment
     for webhook in validated_webhooks:
         experiment.webhooks.append(webhook)
@@ -433,6 +432,7 @@ async def create_bandit_online_experiment_impl(
         arm_sizes=[ArmSize(arm=Arm(arm_id=arm.id, arm_name=arm.name), size=0) for arm in experiment.arms],
     )
     webhook_ids = [webhook.id for webhook in validated_webhooks]
+    experiment_converter = ExperimentStorageConverter(experiment)
     return await experiment_converter.get_create_experiment_response(empty_assign_summary, webhook_ids)
 
 

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -64,7 +64,16 @@ from xngin.apiserver.routers.experiments.property_filters import passes_filters,
 from xngin.apiserver.settings import DatasourceConfig, ParticipantsDef
 from xngin.apiserver.sql.queries import select_as_csv
 from xngin.apiserver.sqla import tables
-from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter, experiment_from_design_spec
+from xngin.apiserver.storage.storage_format_converters import (
+    balance_check_from_experiment,
+    create_experiment_response_from_experiment,
+    design_spec_filters_from_experiment,
+    design_spec_from_experiment,
+    experiment_config_from_experiment,
+    experiment_from_design_spec,
+    field_type_map_from_experiment,
+    get_experiment_response_from_experiment,
+)
 from xngin.apiserver.webhooks.webhook_types import ExperimentCreatedWebhookBody
 from xngin.events.experiment_created import ExperimentCreatedEvent
 from xngin.stats.analysis import analyze_experiment as analyze_freq_experiment
@@ -353,8 +362,7 @@ async def create_preassigned_experiment_impl(
 
     assign_summary = convert_assignment_results_to_assign_summary(experiment.arms, assignment_result, balance_check)
     webhook_ids = [webhook.id for webhook in validated_webhooks]
-    experiment_converter = ExperimentStorageConverter(experiment)
-    return await experiment_converter.get_create_experiment_response(assign_summary, webhook_ids)
+    return await create_experiment_response_from_experiment(experiment, assign_summary, webhook_ids)
 
 
 async def create_freq_online_experiment_impl(
@@ -391,8 +399,7 @@ async def create_freq_online_experiment_impl(
         arm_sizes=[ArmSize(arm=Arm(arm_id=arm.id, arm_name=arm.name), size=0) for arm in experiment.arms],
     )
     webhook_ids = [webhook.id for webhook in validated_webhooks]
-    experiment_converter = ExperimentStorageConverter(experiment)
-    return await experiment_converter.get_create_experiment_response(empty_assign_summary, webhook_ids)
+    return await create_experiment_response_from_experiment(experiment, empty_assign_summary, webhook_ids)
 
 
 async def create_bandit_online_experiment_impl(
@@ -432,8 +439,7 @@ async def create_bandit_online_experiment_impl(
         arm_sizes=[ArmSize(arm=Arm(arm_id=arm.id, arm_name=arm.name), size=0) for arm in experiment.arms],
     )
     webhook_ids = [webhook.id for webhook in validated_webhooks]
-    experiment_converter = ExperimentStorageConverter(experiment)
-    return await experiment_converter.get_create_experiment_response(empty_assign_summary, webhook_ids)
+    return await create_experiment_response_from_experiment(experiment, empty_assign_summary, webhook_ids)
 
 
 async def commit_experiment_impl(xngin_session: AsyncSession, experiment: tables.Experiment) -> CommitExperimentResult:
@@ -492,15 +498,14 @@ async def get_experiment_impl(
     xngin_session: AsyncSession,
     experiment: tables.Experiment,
 ) -> GetExperimentResponse:
-    converter = ExperimentStorageConverter(experiment)
     assign_summary = await get_assign_summary(
         xngin_session,
         experiment.id,
-        converter.get_balance_check(),
+        balance_check_from_experiment(experiment),
         experiment_type=ExperimentsType(experiment.experiment_type),
     )
     webhook_ids = [webhook.id for webhook in experiment.webhooks]
-    return await converter.get_experiment_response(assign_summary, webhook_ids)
+    return await get_experiment_response_from_experiment(experiment, assign_summary, webhook_ids)
 
 
 async def list_organization_or_datasource_experiments_impl(
@@ -545,13 +550,12 @@ async def list_organization_or_datasource_experiments_impl(
     experiments = await xngin_session.scalars(stmt)
     items = []
     for e in experiments:
-        converter = ExperimentStorageConverter(e)
-        balance_check = converter.get_balance_check()
+        balance_check = balance_check_from_experiment(e)
         assign_summary = await get_assign_summary(
             xngin_session, e.id, balance_check, experiment_type=ExperimentsType(e.experiment_type)
         )
         webhook_ids = [webhook.id for webhook in e.webhooks]
-        items.append(await converter.get_experiment_config(assign_summary, webhook_ids))
+        items.append(await experiment_config_from_experiment(e, assign_summary, webhook_ids))
     return ListExperimentsResponse(items=items)
 
 
@@ -644,9 +648,8 @@ def _participant_passes_filters(experiment: tables.Experiment, participant_props
         return True
 
     props_map = {p.field_name: p.value for p in participant_props}
-    experiment_converter = ExperimentStorageConverter(experiment)
-    field_map = experiment_converter.get_field_type_map()
-    return passes_filters(props_map, field_map, experiment_converter.get_design_spec_filters())
+    field_map = field_type_map_from_experiment(experiment)
+    return passes_filters(props_map, field_map, design_spec_filters_from_experiment(experiment))
 
 
 async def get_or_create_assignment_for_participant(
@@ -850,7 +853,7 @@ async def update_bandit_arm_with_outcome_impl(
 ) -> tables.Arm:
     """Update the Draw table with the outcome for a bandit experiment."""
     # Not supported for frequentist experiments
-    design_spec = await ExperimentStorageConverter(experiment).get_design_spec()
+    design_spec = await design_spec_from_experiment(experiment)
 
     match design_spec:
         case MABExperimentSpec() | CMABExperimentSpec():

--- a/src/xngin/apiserver/routers/experiments/test_experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_common.py
@@ -60,7 +60,7 @@ from xngin.apiserver.routers.experiments.experiments_common import (
 )
 from xngin.apiserver.routers.experiments.experiments_common_csv import get_experiment_assignments_as_csv_impl
 from xngin.apiserver.sqla import tables
-from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter
+from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter, experiment_from_design_spec
 from xngin.apiserver.testing.assertions import assert_dates_equal
 from xngin.apiserver.testing.testing_dwh_def import TESTING_DWH_PARTICIPANT_DEF
 
@@ -261,7 +261,7 @@ async def make_insertable_experiment(
         assert isinstance(design_spec, PreassignedFrequentistExperimentSpec | OnlineFrequentistExperimentSpec)
         field_type_map = await fetch_fields_or_raise(datasource, design_spec)
 
-    experiment_converter = ExperimentStorageConverter.init_from_components(
+    experiment = experiment_from_design_spec(
         datasource_id=datasource.id,
         organization_id=datasource.organization_id,
         design_spec=design_spec,
@@ -270,7 +270,7 @@ async def make_insertable_experiment(
         stopped_assignments_reason=stopped_assignments_reason,
         field_type_map=field_type_map,
     )
-    experiment = experiment_converter.get_experiment()
+    experiment_converter = ExperimentStorageConverter(experiment)
     return experiment, await experiment_converter.get_design_spec()
 
 

--- a/src/xngin/apiserver/routers/experiments/test_experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_common.py
@@ -60,7 +60,11 @@ from xngin.apiserver.routers.experiments.experiments_common import (
 )
 from xngin.apiserver.routers.experiments.experiments_common_csv import get_experiment_assignments_as_csv_impl
 from xngin.apiserver.sqla import tables
-from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter, experiment_from_design_spec
+from xngin.apiserver.storage.storage_format_converters import (
+    design_spec_from_experiment,
+    experiment_from_design_spec,
+    power_response_from_experiment,
+)
 from xngin.apiserver.testing.assertions import assert_dates_equal
 from xngin.apiserver.testing.testing_dwh_def import TESTING_DWH_PARTICIPANT_DEF
 
@@ -270,8 +274,7 @@ async def make_insertable_experiment(
         stopped_assignments_reason=stopped_assignments_reason,
         field_type_map=field_type_map,
     )
-    experiment_converter = ExperimentStorageConverter(experiment)
-    return experiment, await experiment_converter.get_design_spec()
+    return experiment, await design_spec_from_experiment(experiment)
 
 
 async def insert_experiment_and_arms(
@@ -577,10 +580,9 @@ async def test_create_preassigned_experiment_impl(
     assert experiment.power == request.design_spec.power
     assert experiment.alpha == request.design_spec.alpha
     assert experiment.fstat_thresh == request.design_spec.fstat_thresh
-    converter = ExperimentStorageConverter(experiment)
-    assert converter.get_power_response() == response.power_analyses
+    assert power_response_from_experiment(experiment) == response.power_analyses
     # Verify design_spec was stored correctly.
-    rehydrated_design_spec = await converter.get_design_spec()
+    rehydrated_design_spec = await design_spec_from_experiment(experiment)
     assert rehydrated_design_spec == response.design_spec
 
     # Verify assignments were created
@@ -1010,8 +1012,7 @@ async def test_create_experiment_impl_for_freq_online_with_unbalanced_arms(
         experiment = await get_experiment_preloaded(xngin_session, experiment.id)
 
     # and the rehydrated design spec
-    converter = ExperimentStorageConverter(experiment)
-    design_spec = await converter.get_design_spec()
+    design_spec = await design_spec_from_experiment(experiment)
     assert isinstance(design_spec, OnlineFrequentistExperimentSpec)
     assert design_spec.get_validated_arm_weights() == expected_weights
     # verify arm positions were stored correctly.
@@ -1139,8 +1140,7 @@ async def test_create_experiment_impl_for_freq_online(xngin_session, testing_dat
     assert experiment.alpha == req_online_spec.alpha
     assert experiment.fstat_thresh == req_online_spec.fstat_thresh
     # Verify design_spec was stored correctly
-    converter = ExperimentStorageConverter(experiment)
-    assert await converter.get_design_spec() == response.design_spec
+    assert await design_spec_from_experiment(experiment) == response.design_spec
     # Verify no power_analyses for online experiments
     assert experiment.power_analyses is None
 
@@ -1219,8 +1219,7 @@ async def test_create_experiment_impl_for_mab_online(xngin_session, testing_data
     assert_dates_equal(experiment.end_date, request.design_spec.end_date)
 
     # Verify design_spec was stored correctly
-    converter = ExperimentStorageConverter(experiment)
-    converted_design_spec = await converter.get_design_spec()
+    converted_design_spec = await design_spec_from_experiment(experiment)
     assert converted_design_spec == response.design_spec
     assert isinstance(converted_design_spec, MABExperimentSpec)
     for arms in converted_design_spec.arms:
@@ -1302,8 +1301,7 @@ async def test_create_experiment_impl_for_cmab_online(xngin_session, testing_dat
     assert_dates_equal(experiment.end_date, request.design_spec.end_date)
 
     # Verify design_spec was stored correctly
-    converter = ExperimentStorageConverter(experiment)
-    converted_design_spec = await converter.get_design_spec()
+    converted_design_spec = await design_spec_from_experiment(experiment)
     assert converted_design_spec == response.design_spec
     assert isinstance(converted_design_spec, CMABExperimentSpec)
     assert converted_design_spec.prior_type == PriorTypes.NORMAL

--- a/src/xngin/apiserver/routers/experiments/test_experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_common.py
@@ -257,24 +257,17 @@ async def make_insertable_experiment(
 
     # Get participants schema from datasource for frequentist experiments
     field_type_map = None
-    exp_table_name: str | None = None
-    exp_primary_key: str | None = None
     if experiment_type in {ExperimentsType.FREQ_PREASSIGNED, ExperimentsType.FREQ_ONLINE}:
         assert isinstance(design_spec, PreassignedFrequentistExperimentSpec | OnlineFrequentistExperimentSpec)
-        exp_table_name = design_spec.table_name
-        exp_primary_key = design_spec.primary_key
         field_type_map = await fetch_fields_or_raise(datasource, design_spec)
 
     experiment_converter = ExperimentStorageConverter.init_from_components(
         datasource_id=datasource.id,
         organization_id=datasource.organization_id,
-        experiment_type=experiment_type,
         design_spec=design_spec,
         state=state,
         stopped_assignments_at=stopped_assignments_at,
         stopped_assignments_reason=stopped_assignments_reason,
-        table_name=exp_table_name,
-        unique_id_name=exp_primary_key,
         field_type_map=field_type_map,
     )
     experiment = experiment_converter.get_experiment()

--- a/src/xngin/apiserver/snapshots/fake_data.py
+++ b/src/xngin/apiserver/snapshots/fake_data.py
@@ -18,7 +18,7 @@ from xngin.apiserver.routers.common_api_types import (
 )
 from xngin.apiserver.routers.common_enums import ExperimentsType
 from xngin.apiserver.sqla import tables
-from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter
+from xngin.apiserver.storage.storage_format_converters import design_spec_metrics_from_experiment
 
 VALID_SNAPSHOT_FIELDS = ["num_missing_values", "estimate", "std_error", "p_value", "t_stat"]
 
@@ -86,7 +86,7 @@ def validate_freq_experiment(experiment: tables.Experiment) -> None:
     if experiment.experiment_type not in {ExperimentsType.FREQ_ONLINE, ExperimentsType.FREQ_PREASSIGNED}:
         raise ValueError(f"Experiment type must be freq_online or freq_preassigned, got {experiment.experiment_type}")
 
-    if not ExperimentStorageConverter(experiment).get_design_spec_metrics():
+    if not design_spec_metrics_from_experiment(experiment):
         raise ValueError("Experiment has no metrics defined")
     if not experiment.arms:
         raise ValueError("Experiment has no arms defined")
@@ -94,7 +94,7 @@ def validate_freq_experiment(experiment: tables.Experiment) -> None:
 
 def get_metric_names(experiment: tables.Experiment) -> list[str]:
     """Return metric names defined on a frequentist experiment."""
-    return [m.field_name for m in ExperimentStorageConverter(experiment).get_design_spec_metrics()]
+    return [m.field_name for m in design_spec_metrics_from_experiment(experiment)]
 
 
 def get_arm_ids(experiment: tables.Experiment) -> list[str]:
@@ -163,7 +163,7 @@ def create_freq_experiment_analysis(
     metric_analyses = []
     baseline_arm_id = _get_baseline_arm_id(experiment)
 
-    for metric_index, metric_obj in enumerate(ExperimentStorageConverter(experiment).get_design_spec_metrics()):
+    for metric_index, metric_obj in enumerate(design_spec_metrics_from_experiment(experiment)):
         metric_field_name = metric_obj.field_name
         arm_analyses = []
 

--- a/src/xngin/apiserver/snapshots/snapshotter.py
+++ b/src/xngin/apiserver/snapshots/snapshotter.py
@@ -13,7 +13,7 @@ from xngin.apiserver.routers.common_api_types import ExperimentAnalysisResponse
 from xngin.apiserver.routers.common_enums import ContextType, ExperimentsType
 from xngin.apiserver.routers.experiments import experiments_common
 from xngin.apiserver.sqla import tables
-from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter
+from xngin.apiserver.storage.storage_format_converters import design_spec_metrics_from_experiment
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -191,7 +191,7 @@ async def _query_dwh_for_snapshot_data(
             dsconfig=datasource.get_config(),
             experiment=experiment,
             baseline_arm_id=baseline_arm.id,
-            metrics=ExperimentStorageConverter(experiment).get_design_spec_metrics(),
+            metrics=design_spec_metrics_from_experiment(experiment),
         )
     raise ValueError(f"Unsupported experiment type: {experiment_type}")
 

--- a/src/xngin/apiserver/snapshots/test_snapshotter.py
+++ b/src/xngin/apiserver/snapshots/test_snapshotter.py
@@ -39,7 +39,7 @@ from xngin.apiserver.snapshots.snapshotter import (
     process_pending_snapshots,
 )
 from xngin.apiserver.sqla import tables
-from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter, experiment_from_design_spec
+from xngin.apiserver.storage.storage_format_converters import experiment_from_design_spec
 from xngin.apiserver.testing.admin_api_client import AdminAPIClient
 from xngin.apiserver.testing.experiments_api_client import ExperimentsAPIClient
 from xngin.apiserver.testing.testing_dwh_def import TESTING_DWH_PARTICIPANT_DEF

--- a/src/xngin/apiserver/snapshots/test_snapshotter.py
+++ b/src/xngin/apiserver/snapshots/test_snapshotter.py
@@ -39,7 +39,7 @@ from xngin.apiserver.snapshots.snapshotter import (
     process_pending_snapshots,
 )
 from xngin.apiserver.sqla import tables
-from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter
+from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter, experiment_from_design_spec
 from xngin.apiserver.testing.admin_api_client import AdminAPIClient
 from xngin.apiserver.testing.experiments_api_client import ExperimentsAPIClient
 from xngin.apiserver.testing.testing_dwh_def import TESTING_DWH_PARTICIPANT_DEF
@@ -63,7 +63,7 @@ async def make_experiment(
         case _:
             assert_never(design_spec)
 
-    experiment_converter = ExperimentStorageConverter.init_from_components(
+    experiment = experiment_from_design_spec(
         datasource_id=datasource.id,
         organization_id=datasource.organization_id,
         design_spec=design_spec,
@@ -72,7 +72,6 @@ async def make_experiment(
         stopped_assignments_reason=StopAssignmentReason.PREASSIGNED,
         field_type_map=field_type_map,
     )
-    experiment = experiment_converter.get_experiment()
     xngin_session.add(experiment)
     await xngin_session.commit()
     # Add assignments to the experiment so analysis doesn't error.

--- a/src/xngin/apiserver/snapshots/test_snapshotter.py
+++ b/src/xngin/apiserver/snapshots/test_snapshotter.py
@@ -54,17 +54,11 @@ async def make_experiment(
     datasource: tables.Datasource,
     design_spec: DesignSpec,
 ) -> tables.Experiment:
-    table_name: str | None
-    primary_key: str | None
     field_type_map: dict[str, DataType] | None
     match design_spec:
         case PreassignedFrequentistExperimentSpec() | OnlineFrequentistExperimentSpec():
-            table_name = design_spec.table_name
-            primary_key = design_spec.primary_key
             field_type_map = await fetch_fields_or_raise(datasource, design_spec)
         case MABExperimentSpec() | CMABExperimentSpec() | BayesABExperimentSpec():
-            table_name = None
-            primary_key = None
             field_type_map = None
         case _:
             assert_never(design_spec)
@@ -72,13 +66,10 @@ async def make_experiment(
     experiment_converter = ExperimentStorageConverter.init_from_components(
         datasource_id=datasource.id,
         organization_id=datasource.organization_id,
-        experiment_type=design_spec.experiment_type,
         design_spec=design_spec,
         state=ExperimentState.COMMITTED,
         stopped_assignments_at=datetime.now(UTC),
         stopped_assignments_reason=StopAssignmentReason.PREASSIGNED,
-        table_name=table_name,
-        unique_id_name=primary_key,
         field_type_map=field_type_map,
     )
     experiment = experiment_converter.get_experiment()

--- a/src/xngin/apiserver/sqla/tables.py
+++ b/src/xngin/apiserver/sqla/tables.py
@@ -429,7 +429,7 @@ class ArmAssignment(Base):
 class Experiment(Base):
     """Stores experiment metadata.
 
-    Use the ExperimentStorageConverter to set/get the different JSONB columns with the appropriate
+    Use storage_format_converters helpers to set/get the different JSONB columns with the appropriate
     storage models, as well as derive other API types from the Experiment db record.
     """
 

--- a/src/xngin/apiserver/storage/storage_format_converters.py
+++ b/src/xngin/apiserver/storage/storage_format_converters.py
@@ -154,6 +154,135 @@ def _set_power_response_json(experiment: tables.Experiment, value: capi.PowerRes
         experiment.power_analyses = capi.PowerResponse.model_validate(value).model_dump()
 
 
+def experiment_from_design_spec(
+    *,
+    datasource_id: str,
+    organization_id: str,
+    design_spec: capi.DesignSpec,
+    state: ExperimentState = ExperimentState.ASSIGNED,
+    stopped_assignments_at: datetime | None = None,
+    stopped_assignments_reason: StopAssignmentReason | str | None = None,
+    balance_check: capi.BalanceCheck | None = None,
+    power_analyses: capi.PowerResponse | None = None,
+    n_trials: int = 0,
+    decision: str = "",
+    impact: str = "",
+    field_type_map: dict[str, DataType] | None = None,
+    participant_type: str = "",
+) -> tables.Experiment:
+    """Create an Experiment ORM object from a design spec and storage metadata."""
+    datasource_table = (
+        design_spec.table_name
+        if isinstance(design_spec, capi.PreassignedFrequentistExperimentSpec | capi.OnlineFrequentistExperimentSpec)
+        else None
+    )
+
+    # Initialize common fields
+    experiment = tables.Experiment(
+        datasource_id=datasource_id,
+        experiment_type=design_spec.experiment_type,
+        participant_type=participant_type,
+        datasource_table=datasource_table,
+        name=design_spec.experiment_name,
+        description=design_spec.description,
+        design_url=str(design_spec.design_url) if design_spec.design_url else None,
+        state=state.value,
+        start_date=design_spec.start_date,
+        end_date=design_spec.end_date,
+        stopped_assignments_at=stopped_assignments_at,
+        stopped_assignments_reason=stopped_assignments_reason,
+        decision=decision,
+        impact=impact,
+    )
+
+    match design_spec:
+        case capi.PreassignedFrequentistExperimentSpec() | capi.OnlineFrequentistExperimentSpec():
+            # Set frequentist-specific fields
+            experiment.power = design_spec.power
+            experiment.alpha = design_spec.alpha
+            experiment.fstat_thresh = design_spec.fstat_thresh
+
+            experiment.arms = [
+                tables.Arm(
+                    name=arm.arm_name,
+                    description=arm.arm_description,
+                    arm_weight=arm.arm_weight,
+                    position=i,
+                    experiment_id=experiment.id,
+                    organization_id=organization_id,
+                )
+                for i, arm in enumerate(design_spec.arms, start=1)
+            ]
+            _set_experiment_fields_from_design_spec(experiment, design_spec, field_type_map)
+            _set_balance_check_json(experiment, balance_check)
+            _set_power_response_json(experiment, power_analyses)
+            return experiment
+
+        case capi.MABExperimentSpec() | capi.CMABExperimentSpec():
+            if isinstance(design_spec, capi.CMABExperimentSpec) and not design_spec.contexts:
+                raise ValueError(f"CMAB experiment {experiment.id} must have contexts set.")
+
+            # Set bandit fields
+            context_len = len(design_spec.contexts) if design_spec.contexts else 1
+            if design_spec.contexts:
+                experiment.contexts = [
+                    tables.Context(
+                        name=context.context_name,
+                        description=context.context_description,
+                        value_type=context.value_type.value,
+                        experiment_id=experiment.id,
+                    )
+                    for context in design_spec.contexts
+                ]
+            experiment.reward_type = design_spec.reward_type.value
+            experiment.prior_type = design_spec.prior_type.value
+            experiment.n_trials = n_trials
+
+            arm_weights = design_spec.get_validated_arm_weights()
+            if arm_weights:
+                # TODO: this method can be expensive and should be on a thread.
+                param1, param2 = convert_arm_weights_to_prior_params(
+                    arm_weights=arm_weights,
+                    prior_type=design_spec.prior_type,
+                    num_contexts=context_len,
+                )
+                match design_spec.prior_type:
+                    case capi.PriorTypes.BETA:
+                        for arm, alpha, beta in zip(design_spec.arms, param1, param2, strict=True):
+                            arm.alpha_init = alpha
+                            arm.beta_init = beta
+                    case capi.PriorTypes.NORMAL:
+                        for arm, mu, sigma in zip(design_spec.arms, param1, param2, strict=True):
+                            arm.mu_init = mu
+                            arm.sigma_init = sigma
+
+            experiment.arms = [
+                tables.Arm(
+                    name=arm.arm_name,
+                    description=arm.arm_description,
+                    arm_weight=arm.arm_weight,
+                    position=i,
+                    experiment_id=experiment.id,
+                    organization_id=organization_id,
+                    mu_init=arm.mu_init,
+                    sigma_init=arm.sigma_init,
+                    mu=None if arm.mu_init is None else [arm.mu_init] * context_len,
+                    covariance=None if arm.sigma_init is None else np.diag([arm.sigma_init] * context_len).tolist(),
+                    alpha_init=arm.alpha_init,
+                    beta_init=arm.beta_init,
+                    alpha=arm.alpha_init,
+                    beta=arm.beta_init,
+                )
+                for i, arm in enumerate(design_spec.arms, start=1)
+            ]
+
+            return experiment
+        case capi.BayesABExperimentSpec():
+            raise ValueError(f"Unsupported design_spec type: {type(design_spec)}.")
+        case _:
+            assert_never(design_spec)
+
+
 class ExperimentStorageConverter:
     """Converts API components to storage components and vice versa for an Experiment."""
 
@@ -162,10 +291,6 @@ class ExperimentStorageConverter:
         Assemble a partial experiment with setters, and get the final object or derived API objects.
         """
         self.experiment = experiment
-
-    def get_experiment(self) -> tables.Experiment:
-        """When you're done assembling the experiment, use this to get the final object."""
-        return self.experiment
 
     def _convert_experiment_field_to_api_filters(
         self,
@@ -403,114 +528,21 @@ class ExperimentStorageConverter:
         field_type_map: dict[str, DataType] | None = None,
         participant_type: str = "",
     ) -> Self:
-        """Init experiment with arms from components. Get the final object with get_experiment()."""
-        datasource_table = (
-            design_spec.table_name
-            if isinstance(design_spec, capi.PreassignedFrequentistExperimentSpec | capi.OnlineFrequentistExperimentSpec)
-            else None
+        """Compatibility wrapper around experiment_from_design_spec."""
+        return cls(
+            experiment_from_design_spec(
+                datasource_id=datasource_id,
+                organization_id=organization_id,
+                design_spec=design_spec,
+                state=state,
+                stopped_assignments_at=stopped_assignments_at,
+                stopped_assignments_reason=stopped_assignments_reason,
+                balance_check=balance_check,
+                power_analyses=power_analyses,
+                n_trials=n_trials,
+                decision=decision,
+                impact=impact,
+                field_type_map=field_type_map,
+                participant_type=participant_type,
+            )
         )
-
-        # Initialize common fields
-        experiment = tables.Experiment(
-            datasource_id=datasource_id,
-            experiment_type=design_spec.experiment_type,
-            participant_type=participant_type,
-            datasource_table=datasource_table,
-            name=design_spec.experiment_name,
-            description=design_spec.description,
-            design_url=str(design_spec.design_url) if design_spec.design_url else None,
-            state=state.value,
-            start_date=design_spec.start_date,
-            end_date=design_spec.end_date,
-            stopped_assignments_at=stopped_assignments_at,
-            stopped_assignments_reason=stopped_assignments_reason,
-            decision=decision,
-            impact=impact,
-        )
-
-        match design_spec:
-            case capi.PreassignedFrequentistExperimentSpec() | capi.OnlineFrequentistExperimentSpec():
-                # Set frequentist-specific fields
-                experiment.power = design_spec.power
-                experiment.alpha = design_spec.alpha
-                experiment.fstat_thresh = design_spec.fstat_thresh
-
-                experiment.arms = [
-                    tables.Arm(
-                        name=arm.arm_name,
-                        description=arm.arm_description,
-                        arm_weight=arm.arm_weight,
-                        position=i,
-                        experiment_id=experiment.id,
-                        organization_id=organization_id,
-                    )
-                    for i, arm in enumerate(design_spec.arms, start=1)
-                ]
-                _set_experiment_fields_from_design_spec(experiment, design_spec, field_type_map)
-                _set_balance_check_json(experiment, balance_check)
-                _set_power_response_json(experiment, power_analyses)
-                return cls(experiment)
-
-            case capi.MABExperimentSpec() | capi.CMABExperimentSpec():
-                if isinstance(design_spec, capi.CMABExperimentSpec) and not design_spec.contexts:
-                    raise ValueError(f"CMAB experiment {experiment.id} must have contexts set.")
-
-                # Set bandit fields
-                context_len = len(design_spec.contexts) if design_spec.contexts else 1
-                if design_spec.contexts:
-                    experiment.contexts = [
-                        tables.Context(
-                            name=context.context_name,
-                            description=context.context_description,
-                            value_type=context.value_type.value,
-                            experiment_id=experiment.id,
-                        )
-                        for context in design_spec.contexts
-                    ]
-                experiment.reward_type = design_spec.reward_type.value
-                experiment.prior_type = design_spec.prior_type.value
-                experiment.n_trials = n_trials
-
-                arm_weights = design_spec.get_validated_arm_weights()
-                if arm_weights:
-                    # TODO: this method can be expensive and should be on a thread.
-                    param1, param2 = convert_arm_weights_to_prior_params(
-                        arm_weights=arm_weights,
-                        prior_type=design_spec.prior_type,
-                        num_contexts=context_len,
-                    )
-                    match design_spec.prior_type:
-                        case capi.PriorTypes.BETA:
-                            for arm, alpha, beta in zip(design_spec.arms, param1, param2, strict=True):
-                                arm.alpha_init = alpha
-                                arm.beta_init = beta
-                        case capi.PriorTypes.NORMAL:
-                            for arm, mu, sigma in zip(design_spec.arms, param1, param2, strict=True):
-                                arm.mu_init = mu
-                                arm.sigma_init = sigma
-
-                experiment.arms = [
-                    tables.Arm(
-                        name=arm.arm_name,
-                        description=arm.arm_description,
-                        arm_weight=arm.arm_weight,
-                        position=i,
-                        experiment_id=experiment.id,
-                        organization_id=organization_id,
-                        mu_init=arm.mu_init,
-                        sigma_init=arm.sigma_init,
-                        mu=None if arm.mu_init is None else [arm.mu_init] * context_len,
-                        covariance=None if arm.sigma_init is None else np.diag([arm.sigma_init] * context_len).tolist(),
-                        alpha_init=arm.alpha_init,
-                        beta_init=arm.beta_init,
-                        alpha=arm.alpha_init,
-                        beta=arm.beta_init,
-                    )
-                    for i, arm in enumerate(design_spec.arms, start=1)
-                ]
-
-                return cls(experiment)
-            case capi.BayesABExperimentSpec():
-                raise ValueError(f"Unsupported design_spec type: {type(design_spec)}.")
-            case _:
-                assert_never(design_spec)

--- a/src/xngin/apiserver/storage/storage_format_converters.py
+++ b/src/xngin/apiserver/storage/storage_format_converters.py
@@ -27,6 +27,133 @@ from xngin.stats.bandit_weights_to_prior import (
 )
 
 
+def _set_experiment_fields_from_design_spec(
+    experiment: tables.Experiment,
+    design_spec: capi.DesignSpec,
+    field_type_map: dict[str, DataType] | None = None,
+) -> None:
+    """Save the field-related components of a DesignSpec to an experiment."""
+    match design_spec:
+        case capi.MABExperimentSpec() | capi.CMABExperimentSpec() | capi.BayesABExperimentSpec():
+            experiment.design_spec_fields = None
+            experiment.experiment_fields = []
+            return
+        case capi.PreassignedFrequentistExperimentSpec() | capi.OnlineFrequentistExperimentSpec():
+            pass
+        case _:
+            assert_never(design_spec)
+
+    field_type_map = field_type_map or {}
+    unique_id_name = design_spec.primary_key
+
+    # Clear existing design fields
+    experiment.experiment_fields = []
+
+    # New fields used in the experiment. Each key is a field name and maps to a ExperimentField object.
+    fields_used_map: dict[str, tables.ExperimentField] = {}
+
+    fields_used_map[unique_id_name] = tables.ExperimentField(
+        field_name=unique_id_name,
+        data_type=field_type_map.get(unique_id_name, DataType.UNKNOWN).value,
+        is_unique_id=True,
+        experiment_filters=[],
+    )
+
+    # Add filters. Fields used as filters technically could be reused with different filter values.
+    for idx, filter_item in enumerate(design_spec.filters):
+        field = fields_used_map.get(filter_item.field_name)
+        datatype = field_type_map.get(filter_item.field_name, DataType.UNKNOWN)
+        # Create the new field if it doesn't exist
+        if field is None:
+            field = tables.ExperimentField(
+                field_name=filter_item.field_name,
+                data_type=datatype.value,
+                experiment_filters=[],
+            )
+            fields_used_map[filter_item.field_name] = field
+
+        # and associate new filter metadata with the field
+        filters = field.experiment_filters or []
+        values = filter_item.value
+        match datatype.storage_class():
+            case DataTypeStorageClass.BOOLEAN:
+                values = [None if v is None else bool(v) for v in values]
+                filters.append(
+                    tables.ExperimentFilter(
+                        position=idx + 1,
+                        relation=filter_item.relation,
+                        boolean_values=values,
+                    )
+                )
+            case DataTypeStorageClass.NUMERIC:
+                filters.append(
+                    tables.ExperimentFilter(
+                        position=idx + 1,
+                        relation=filter_item.relation,
+                        numeric_values=values,
+                    )
+                )
+            case _:
+                values = [None if v is None else str(v) for v in values]
+                filters.append(
+                    tables.ExperimentFilter(
+                        position=idx + 1,
+                        relation=filter_item.relation,
+                        string_values=values,
+                    )
+                )
+
+        field.experiment_filters = filters
+
+    # Add metrics
+    if design_spec.metrics:
+        for index, metric in enumerate(design_spec.metrics):
+            field = fields_used_map.get(metric.field_name)
+            if field is None:
+                field = tables.ExperimentField(
+                    field_name=metric.field_name,
+                    data_type=field_type_map.get(metric.field_name, DataType.UNKNOWN).value,
+                    experiment_filters=[],
+                )
+                fields_used_map[metric.field_name] = field
+
+            if index == 0:
+                field.is_primary_metric = True
+            field.metric_pct_change = metric.metric_pct_change
+            field.metric_target = metric.metric_target
+
+    # Add strata
+    if design_spec.strata:
+        for stratum in design_spec.strata:
+            field = fields_used_map.get(stratum.field_name)
+            if field is None:
+                field = tables.ExperimentField(
+                    field_name=stratum.field_name,
+                    data_type=field_type_map.get(stratum.field_name, DataType.UNKNOWN).value,
+                    experiment_filters=[],
+                )
+                fields_used_map[stratum.field_name] = field
+
+            field.is_strata = True
+
+    # add fields_used_map to experiment_fields
+    experiment.experiment_fields = list(fields_used_map.values())
+
+
+def _set_balance_check_json(experiment: tables.Experiment, value: capi.BalanceCheck | None) -> None:
+    if value is None:
+        experiment.balance_check = None
+    else:
+        experiment.balance_check = capi.BalanceCheck.model_validate(value).model_dump()
+
+
+def _set_power_response_json(experiment: tables.Experiment, value: capi.PowerResponse | None) -> None:
+    if value is None:
+        experiment.power_analyses = None
+    else:
+        experiment.power_analyses = capi.PowerResponse.model_validate(value).model_dump()
+
+
 class ExperimentStorageConverter:
     """Converts API components to storage components and vice versa for an Experiment."""
 
@@ -39,128 +166,6 @@ class ExperimentStorageConverter:
     def get_experiment(self) -> tables.Experiment:
         """When you're done assembling the experiment, use this to get the final object."""
         return self.experiment
-
-    def set_experiment_fields(
-        self,
-        design_spec: capi.DesignSpec,
-        field_type_map: dict[str, DataType] | None = None,
-        unique_id_name: str | None = None,
-    ) -> Self:
-        """Saves the components of a DesignSpec to the experiment.
-
-        Args:
-            design_spec: The design specification to save.
-            field_type_map: Optional field name to data type mapping.
-            unique_id_name: Optional unique ID field name.
-        """
-        match design_spec:
-            case capi.MABExperimentSpec() | capi.CMABExperimentSpec() | capi.BayesABExperimentSpec():
-                self.experiment.design_spec_fields = None
-                self.experiment.experiment_fields = []
-                return self
-            case capi.PreassignedFrequentistExperimentSpec() | capi.OnlineFrequentistExperimentSpec():
-                pass
-            case _:
-                assert_never(design_spec)
-
-        field_type_map = field_type_map or {}
-
-        # Clear existing design fields
-        self.experiment.experiment_fields = []
-
-        # New fields used in the experiment. Each key is a field name and maps to a ExperimentField object.
-        fields_used_map: dict[str, tables.ExperimentField] = {}
-
-        # Add unique ID
-        if unique_id_name:
-            fields_used_map[unique_id_name] = tables.ExperimentField(
-                field_name=unique_id_name,
-                data_type=field_type_map.get(unique_id_name, DataType.UNKNOWN).value,
-                is_unique_id=True,
-                experiment_filters=[],
-            )
-
-        # Add filters. Fields used as filters technically could be reused with different filter values.
-        for idx, filter_item in enumerate(design_spec.filters):
-            field = fields_used_map.get(filter_item.field_name)
-            datatype = field_type_map.get(filter_item.field_name, DataType.UNKNOWN)
-            # Create the new field if it doesn't exist
-            if field is None:
-                field = tables.ExperimentField(
-                    field_name=filter_item.field_name,
-                    data_type=datatype.value,
-                    experiment_filters=[],
-                )
-                fields_used_map[filter_item.field_name] = field
-
-            # and associate new filter metadata with the field
-            filters = field.experiment_filters or []
-            values = filter_item.value
-            match datatype.storage_class():
-                case DataTypeStorageClass.BOOLEAN:
-                    values = [None if v is None else bool(v) for v in values]
-                    filters.append(
-                        tables.ExperimentFilter(
-                            position=idx + 1,
-                            relation=filter_item.relation,
-                            boolean_values=values,
-                        )
-                    )
-                case DataTypeStorageClass.NUMERIC:
-                    filters.append(
-                        tables.ExperimentFilter(
-                            position=idx + 1,
-                            relation=filter_item.relation,
-                            numeric_values=values,
-                        )
-                    )
-                case _:
-                    values = [None if v is None else str(v) for v in values]
-                    filters.append(
-                        tables.ExperimentFilter(
-                            position=idx + 1,
-                            relation=filter_item.relation,
-                            string_values=values,
-                        )
-                    )
-
-            field.experiment_filters = filters
-
-        # Add metrics
-        if design_spec.metrics:
-            for index, metric in enumerate(design_spec.metrics):
-                field = fields_used_map.get(metric.field_name)
-                if field is None:
-                    field = tables.ExperimentField(
-                        field_name=metric.field_name,
-                        data_type=field_type_map.get(metric.field_name, DataType.UNKNOWN).value,
-                        experiment_filters=[],
-                    )
-                    fields_used_map[metric.field_name] = field
-
-                if index == 0:
-                    field.is_primary_metric = True
-                field.metric_pct_change = metric.metric_pct_change
-                field.metric_target = metric.metric_target
-
-        # Add strata
-        if design_spec.strata:
-            for stratum in design_spec.strata:
-                field = fields_used_map.get(stratum.field_name)
-                if field is None:
-                    field = tables.ExperimentField(
-                        field_name=stratum.field_name,
-                        data_type=field_type_map.get(stratum.field_name, DataType.UNKNOWN).value,
-                        experiment_filters=[],
-                    )
-                    fields_used_map[stratum.field_name] = field
-
-                field.is_strata = True
-
-        # add fields_used_map to experiment_fields
-        self.experiment.experiment_fields = list(fields_used_map.values())
-
-        return self
 
     def _convert_experiment_field_to_api_filters(
         self,
@@ -325,24 +330,10 @@ class ExperimentStorageConverter:
             })
         raise ValueError(f"Unsupported experiment type: {self.experiment.experiment_type}")
 
-    def set_balance_check(self, value: capi.BalanceCheck | None) -> Self:
-        if value is None:
-            self.experiment.balance_check = None
-        else:
-            self.experiment.balance_check = capi.BalanceCheck.model_validate(value).model_dump()
-        return self
-
     def get_balance_check(self) -> capi.BalanceCheck | None:
         if self.experiment.balance_check is not None:
             return capi.BalanceCheck.model_validate(self.experiment.balance_check)
         return None
-
-    def set_power_response(self, value: capi.PowerResponse | None) -> Self:
-        if value is None:
-            self.experiment.power_analyses = None
-        else:
-            self.experiment.power_analyses = capi.PowerResponse.model_validate(value).model_dump()
-        return self
 
     def get_power_response(
         self,
@@ -455,12 +446,10 @@ class ExperimentStorageConverter:
                     )
                     for i, arm in enumerate(design_spec.arms, start=1)
                 ]
-                return (
-                    cls(experiment)
-                    .set_experiment_fields(design_spec, field_type_map, design_spec.primary_key)
-                    .set_balance_check(balance_check)
-                    .set_power_response(power_analyses)
-                )
+                _set_experiment_fields_from_design_spec(experiment, design_spec, field_type_map)
+                _set_balance_check_json(experiment, balance_check)
+                _set_power_response_json(experiment, power_analyses)
+                return cls(experiment)
 
             case capi.MABExperimentSpec() | capi.CMABExperimentSpec():
                 if isinstance(design_spec, capi.CMABExperimentSpec) and not design_spec.contexts:

--- a/src/xngin/apiserver/storage/storage_format_converters.py
+++ b/src/xngin/apiserver/storage/storage_format_converters.py
@@ -400,7 +400,6 @@ class ExperimentStorageConverter:
         cls,
         datasource_id: str,
         organization_id: str,
-        experiment_type: capi.ExperimentsType,
         design_spec: capi.DesignSpec,
         state: ExperimentState = ExperimentState.ASSIGNED,
         stopped_assignments_at: datetime | None = None,
@@ -410,22 +409,22 @@ class ExperimentStorageConverter:
         n_trials: int = 0,
         decision: str = "",
         impact: str = "",
-        table_name: str | None = None,
         field_type_map: dict[str, DataType] | None = None,
-        unique_id_name: str | None = None,
         participant_type: str = "",
     ) -> Self:
-        """Init experiment with arms from components. Get the final object with get_experiment().
+        """Init experiment with arms from components. Get the final object with get_experiment()."""
+        datasource_table = (
+            design_spec.table_name
+            if isinstance(design_spec, capi.PreassignedFrequentistExperimentSpec | capi.OnlineFrequentistExperimentSpec)
+            else None
+        )
 
-        Raises:
-            ValueError: If the experiment_id is not set in the design_spec.
-        """
         # Initialize common fields
         experiment = tables.Experiment(
             datasource_id=datasource_id,
-            experiment_type=experiment_type,
+            experiment_type=design_spec.experiment_type,
             participant_type=participant_type,
-            datasource_table=table_name,
+            datasource_table=datasource_table,
             name=design_spec.experiment_name,
             description=design_spec.description,
             design_url=str(design_spec.design_url) if design_spec.design_url else None,
@@ -458,7 +457,7 @@ class ExperimentStorageConverter:
                 ]
                 return (
                     cls(experiment)
-                    .set_experiment_fields(design_spec, field_type_map, unique_id_name)
+                    .set_experiment_fields(design_spec, field_type_map, design_spec.primary_key)
                     .set_balance_check(balance_check)
                     .set_power_response(power_analyses)
                 )

--- a/src/xngin/apiserver/storage/storage_format_converters.py
+++ b/src/xngin/apiserver/storage/storage_format_converters.py
@@ -8,7 +8,7 @@ JSONB type columns for multi-value/complex types, use the converters to get/set 
 
 import operator
 from datetime import datetime
-from typing import Any, Self, assert_never
+from typing import Any, assert_never
 
 import numpy as np
 from pydantic import TypeAdapter
@@ -283,293 +283,183 @@ def experiment_from_design_spec(
             assert_never(design_spec)
 
 
-class ExperimentStorageConverter:
-    """Converts API components to storage components and vice versa for an Experiment."""
-
-    def __init__(self, experiment: tables.Experiment):
-        """
-        Assemble a partial experiment with setters, and get the final object or derived API objects.
-        """
-        self.experiment = experiment
-
-    def _convert_experiment_field_to_api_filters(
-        self,
-        experiment_field: tables.ExperimentField,
-    ) -> list[tuple[int, capi.Filter]]:
-        """Converts an ExperimentField to a list of (position, API filter) tuples, or empty list if not a filter."""
-        filters = []
-        for f in experiment_field.experiment_filters or []:
-            # Convert storage type to API type
-            values: list[Any]
-            if experiment_field.data_type == DataType.BIGINT:
-                values = [None if v is None else str(v) for v in (f.numeric_values or [])]
-            else:
-                values = f.string_values or f.numeric_values or f.boolean_values or []
-            filters.append((
-                f.position,
-                capi.Filter(
-                    field_name=experiment_field.field_name,
-                    relation=capi.Relation(f.relation),
-                    value=values,
-                ),
-            ))
-
-        return filters
-
-    def _convert_experiment_field_to_api_metric(
-        self,
-        experiment_field: tables.ExperimentField,
-    ) -> capi.DesignSpecMetricRequest | None:
-        """Converts an ExperimentField to an API metric, or None if the field is not a metric."""
-        if experiment_field.is_metric:
-            return capi.DesignSpecMetricRequest(
+def _convert_experiment_field_to_api_filters(
+    experiment_field: tables.ExperimentField,
+) -> list[tuple[int, capi.Filter]]:
+    """Convert an ExperimentField to (position, API filter) tuples, or an empty list if not a filter."""
+    filters = []
+    for f in experiment_field.experiment_filters or []:
+        values: list[Any]
+        if experiment_field.data_type == DataType.BIGINT:
+            values = [None if v is None else str(v) for v in (f.numeric_values or [])]
+        else:
+            values = f.string_values or f.numeric_values or f.boolean_values or []
+        filters.append((
+            f.position,
+            capi.Filter(
                 field_name=experiment_field.field_name,
-                metric_pct_change=experiment_field.metric_pct_change,
-                metric_target=experiment_field.metric_target,
-            )
-        return None
+                relation=capi.Relation(f.relation),
+                value=values,
+            ),
+        ))
 
-    def _convert_experiment_field_to_api_stratum(
-        self,
-        experiment_field: tables.ExperimentField,
-    ) -> capi.Stratum | None:
-        """Converts an ExperimentField to an API stratum, or None if the field is not a stratum."""
-        if experiment_field.is_strata:
-            return capi.Stratum(field_name=experiment_field.field_name)
-        return None
+    return filters
 
-    def get_design_spec_filters(self) -> list[capi.Filter]:
-        """Return design-spec filters from experiment_fields sorted by their position."""
-        position_filters: list[tuple[int, capi.Filter]] = []
-        for ef in self.experiment.experiment_fields:
-            if api_filters := self._convert_experiment_field_to_api_filters(ef):
-                position_filters.extend(api_filters)
 
-        return [f[1] for f in sorted(position_filters, key=operator.itemgetter(0))]
-
-    def get_design_spec_metrics(self) -> list[capi.DesignSpecMetricRequest]:
-        """Return design-spec metrics from experiment_fields."""
-        metrics = []
-        for ef in self.experiment.experiment_fields:
-            if api_metric := self._convert_experiment_field_to_api_metric(ef):
-                metrics.append(api_metric)
-        return metrics
-
-    def get_design_spec_strata(self) -> list[capi.Stratum]:
-        """Return design-spec strata from experiment_fields."""
-        strata = []
-        for ef in self.experiment.experiment_fields:
-            if api_stratum := self._convert_experiment_field_to_api_stratum(ef):
-                strata.append(api_stratum)
-        return strata
-
-    def get_field_type_map(self) -> dict[str, DataType]:
-        """Return a map of all the field names used in the experiment to their respective data types."""
-        return {ef.field_name: DataType(ef.data_type) for ef in self.experiment.experiment_fields}
-
-    async def get_design_spec(self) -> capi.DesignSpec:
-        """Converts stored experiment metadata to a DesignSpec object."""
-        base_experiment_dict = {
-            "experiment_type": self.experiment.experiment_type,
-            "experiment_name": self.experiment.name,
-            "description": self.experiment.description,
-            "design_url": self.experiment.design_url or None,
-            "start_date": self.experiment.start_date,
-            "end_date": self.experiment.end_date,
-        }
-        await self.experiment.awaitable_attrs.arms
-
-        if self.experiment.experiment_type in {
-            ExperimentsType.FREQ_ONLINE.value,
-            ExperimentsType.FREQ_PREASSIGNED.value,
-        }:
-            await self.experiment.awaitable_attrs.experiment_fields
-            primary_key_field = self.experiment.unique_id_field()
-            if self.experiment.datasource_table is None or primary_key_field is None:
-                raise ValueError(
-                    f"Frequentist experiment {self.experiment.id} "
-                    "is missing datasource_table or unique participant key field."
-                )
-
-            return TypeAdapter(capi.DesignSpec).validate_python({
-                **base_experiment_dict,
-                "table_name": self.experiment.datasource_table,
-                "primary_key": primary_key_field.field_name,
-                "arms": [
-                    {
-                        "arm_id": arm.id,
-                        "arm_name": arm.name,
-                        "arm_description": arm.description,
-                        "arm_weight": arm.arm_weight,
-                    }
-                    for arm in self.experiment.arms
-                ],
-                "strata": self.get_design_spec_strata(),
-                "metrics": self.get_design_spec_metrics(),
-                "filters": self.get_design_spec_filters(),
-                "power": self.experiment.power,
-                "alpha": self.experiment.alpha,
-                "fstat_thresh": self.experiment.fstat_thresh,
-            })
-
-        if self.experiment.experiment_type in {
-            ExperimentsType.MAB_ONLINE.value,
-            ExperimentsType.CMAB_ONLINE.value,
-        }:
-            if not self.experiment.prior_type or not self.experiment.reward_type:
-                raise ValueError(f"Bandit experiment {self.experiment.id} must have prior_type and reward_type set.")
-            contexts = None
-            if self.experiment.experiment_type == ExperimentsType.CMAB_ONLINE.value:
-                contexts = [
-                    capi.Context(
-                        context_id=context.id,
-                        context_name=context.name,
-                        context_description=context.description,
-                        value_type=capi.ContextType(context.value_type),
-                    )
-                    for context in self.experiment.contexts
-                ]
-
-            return TypeAdapter(capi.DesignSpec).validate_python({
-                **base_experiment_dict,
-                "arms": [
-                    {
-                        "arm_id": arm.id,
-                        "arm_name": arm.name,
-                        "arm_description": arm.description,
-                        "arm_weight": arm.arm_weight,
-                        "mu_init": arm.mu_init,
-                        "sigma_init": arm.sigma_init,
-                        "alpha_init": arm.alpha_init,
-                        "beta_init": arm.beta_init,
-                        "mu": arm.mu,
-                        "covariance": arm.covariance,
-                        "alpha": arm.alpha,
-                        "beta": arm.beta,
-                    }
-                    for arm in self.experiment.arms
-                ],
-                "prior_type": capi.PriorTypes(self.experiment.prior_type),
-                "reward_type": capi.LikelihoodTypes(self.experiment.reward_type),
-                "contexts": contexts,
-            })
-        raise ValueError(f"Unsupported experiment type: {self.experiment.experiment_type}")
-
-    def get_balance_check(self) -> capi.BalanceCheck | None:
-        if self.experiment.balance_check is not None:
-            return capi.BalanceCheck.model_validate(self.experiment.balance_check)
-        return None
-
-    def get_power_response(
-        self,
-    ) -> capi.PowerResponse | None:
-        if self.experiment.power_analyses is None:
-            return None
-        return capi.PowerResponse.model_validate(self.experiment.power_analyses)
-
-    async def get_experiment_config(
-        self,
-        assign_summary: capi.AssignSummary,
-        webhook_ids: list[str] | None = None,
-    ) -> capi.GetExperimentResponse:
-        """Construct an ExperimentConfig from the internal Experiment and an AssignSummary.
-
-        Expects assign_summary since that typically requires a db lookup."""
-        return capi.GetExperimentResponse(
-            experiment_id=(await self.experiment.awaitable_attrs.id),
-            datasource_id=self.experiment.datasource_id,
-            participant_type_deprecated=self.experiment.participant_type,
-            state=ExperimentState(self.experiment.state),
-            stopped_assignments_at=self.experiment.stopped_assignments_at,
-            stopped_assignments_reason=StopAssignmentReason.from_str(self.experiment.stopped_assignments_reason),
-            design_spec=await self.get_design_spec(),
-            power_analyses=self.get_power_response(),
-            assign_summary=assign_summary,
-            webhooks=webhook_ids or [],
-            decision=self.experiment.decision,
-            impact=self.experiment.impact,
+def _convert_experiment_field_to_api_metric(
+    experiment_field: tables.ExperimentField,
+) -> capi.DesignSpecMetricRequest | None:
+    """Convert an ExperimentField to an API metric, or None if the field is not a metric."""
+    if experiment_field.is_metric:
+        return capi.DesignSpecMetricRequest(
+            field_name=experiment_field.field_name,
+            metric_pct_change=experiment_field.metric_pct_change,
+            metric_target=experiment_field.metric_target,
         )
-
-    async def get_experiment_response(
-        self,
-        assign_summary: capi.AssignSummary,
-        webhook_ids: list[str] | None = None,
-    ) -> capi.GetExperimentResponse:
-        # Although GetExperimentResponse is a subclass of ExperimentConfig, we revalidate the
-        # response in case we ever change the API.
-        return capi.GetExperimentResponse.model_validate(
-            (await self.get_experiment_config(assign_summary, webhook_ids)).model_dump()
-        )
-
-    async def get_create_experiment_response(
-        self,
-        assign_summary: capi.AssignSummary,
-        webhook_ids: list[str] | None = None,
-    ) -> capi.CreateExperimentResponse:
-        # Revalidate the response in case we ever change the API.
-        return capi.CreateExperimentResponse.model_validate(
-            (await self.get_experiment_config(assign_summary, webhook_ids)).model_dump()
-        )
-
-    @classmethod
-    def init_from_components(
-        cls,
-        datasource_id: str,
-        organization_id: str,
-        design_spec: capi.DesignSpec,
-        state: ExperimentState = ExperimentState.ASSIGNED,
-        stopped_assignments_at: datetime | None = None,
-        stopped_assignments_reason: StopAssignmentReason | str | None = None,
-        balance_check: capi.BalanceCheck | None = None,
-        power_analyses: capi.PowerResponse | None = None,
-        n_trials: int = 0,
-        decision: str = "",
-        impact: str = "",
-        field_type_map: dict[str, DataType] | None = None,
-        participant_type: str = "",
-    ) -> Self:
-        """Compatibility wrapper around experiment_from_design_spec."""
-        return cls(
-            experiment_from_design_spec(
-                datasource_id=datasource_id,
-                organization_id=organization_id,
-                design_spec=design_spec,
-                state=state,
-                stopped_assignments_at=stopped_assignments_at,
-                stopped_assignments_reason=stopped_assignments_reason,
-                balance_check=balance_check,
-                power_analyses=power_analyses,
-                n_trials=n_trials,
-                decision=decision,
-                impact=impact,
-                field_type_map=field_type_map,
-                participant_type=participant_type,
-            )
-        )
+    return None
 
 
-async def design_spec_from_experiment(experiment: tables.Experiment) -> capi.DesignSpec:
-    return await ExperimentStorageConverter(experiment).get_design_spec()
+def _convert_experiment_field_to_api_stratum(
+    experiment_field: tables.ExperimentField,
+) -> capi.Stratum | None:
+    """Convert an ExperimentField to an API stratum, or None if the field is not a stratum."""
+    if experiment_field.is_strata:
+        return capi.Stratum(field_name=experiment_field.field_name)
+    return None
 
 
 def design_spec_filters_from_experiment(experiment: tables.Experiment) -> list[capi.Filter]:
-    return ExperimentStorageConverter(experiment).get_design_spec_filters()
+    """Return design-spec filters from experiment_fields sorted by their position."""
+    position_filters: list[tuple[int, capi.Filter]] = []
+    for ef in experiment.experiment_fields:
+        if api_filters := _convert_experiment_field_to_api_filters(ef):
+            position_filters.extend(api_filters)
+
+    return [f[1] for f in sorted(position_filters, key=operator.itemgetter(0))]
 
 
 def design_spec_metrics_from_experiment(experiment: tables.Experiment) -> list[capi.DesignSpecMetricRequest]:
-    return ExperimentStorageConverter(experiment).get_design_spec_metrics()
+    """Return design-spec metrics from experiment_fields."""
+    metrics = []
+    for ef in experiment.experiment_fields:
+        if api_metric := _convert_experiment_field_to_api_metric(ef):
+            metrics.append(api_metric)
+    return metrics
+
+
+def design_spec_strata_from_experiment(experiment: tables.Experiment) -> list[capi.Stratum]:
+    """Return design-spec strata from experiment_fields."""
+    strata = []
+    for ef in experiment.experiment_fields:
+        if api_stratum := _convert_experiment_field_to_api_stratum(ef):
+            strata.append(api_stratum)
+    return strata
 
 
 def field_type_map_from_experiment(experiment: tables.Experiment) -> dict[str, DataType]:
-    return ExperimentStorageConverter(experiment).get_field_type_map()
+    """Return a map of field names used in the experiment to their data types."""
+    return {ef.field_name: DataType(ef.data_type) for ef in experiment.experiment_fields}
+
+
+async def design_spec_from_experiment(experiment: tables.Experiment) -> capi.DesignSpec:
+    """Convert stored experiment metadata to a DesignSpec object."""
+    base_experiment_dict = {
+        "experiment_type": experiment.experiment_type,
+        "experiment_name": experiment.name,
+        "description": experiment.description,
+        "design_url": experiment.design_url or None,
+        "start_date": experiment.start_date,
+        "end_date": experiment.end_date,
+    }
+    await experiment.awaitable_attrs.arms
+
+    if experiment.experiment_type in {
+        ExperimentsType.FREQ_ONLINE.value,
+        ExperimentsType.FREQ_PREASSIGNED.value,
+    }:
+        await experiment.awaitable_attrs.experiment_fields
+        primary_key_field = experiment.unique_id_field()
+        if experiment.datasource_table is None or primary_key_field is None:
+            raise ValueError(
+                f"Frequentist experiment {experiment.id} "
+                "is missing datasource_table or unique participant key field."
+            )
+
+        return TypeAdapter(capi.DesignSpec).validate_python({
+            **base_experiment_dict,
+            "table_name": experiment.datasource_table,
+            "primary_key": primary_key_field.field_name,
+            "arms": [
+                {
+                    "arm_id": arm.id,
+                    "arm_name": arm.name,
+                    "arm_description": arm.description,
+                    "arm_weight": arm.arm_weight,
+                }
+                for arm in experiment.arms
+            ],
+            "strata": design_spec_strata_from_experiment(experiment),
+            "metrics": design_spec_metrics_from_experiment(experiment),
+            "filters": design_spec_filters_from_experiment(experiment),
+            "power": experiment.power,
+            "alpha": experiment.alpha,
+            "fstat_thresh": experiment.fstat_thresh,
+        })
+
+    if experiment.experiment_type in {
+        ExperimentsType.MAB_ONLINE.value,
+        ExperimentsType.CMAB_ONLINE.value,
+    }:
+        if not experiment.prior_type or not experiment.reward_type:
+            raise ValueError(f"Bandit experiment {experiment.id} must have prior_type and reward_type set.")
+        contexts = None
+        if experiment.experiment_type == ExperimentsType.CMAB_ONLINE.value:
+            contexts = [
+                capi.Context(
+                    context_id=context.id,
+                    context_name=context.name,
+                    context_description=context.description,
+                    value_type=capi.ContextType(context.value_type),
+                )
+                for context in experiment.contexts
+            ]
+
+        return TypeAdapter(capi.DesignSpec).validate_python({
+            **base_experiment_dict,
+            "arms": [
+                {
+                    "arm_id": arm.id,
+                    "arm_name": arm.name,
+                    "arm_description": arm.description,
+                    "arm_weight": arm.arm_weight,
+                    "mu_init": arm.mu_init,
+                    "sigma_init": arm.sigma_init,
+                    "alpha_init": arm.alpha_init,
+                    "beta_init": arm.beta_init,
+                    "mu": arm.mu,
+                    "covariance": arm.covariance,
+                    "alpha": arm.alpha,
+                    "beta": arm.beta,
+                }
+                for arm in experiment.arms
+            ],
+            "prior_type": capi.PriorTypes(experiment.prior_type),
+            "reward_type": capi.LikelihoodTypes(experiment.reward_type),
+            "contexts": contexts,
+        })
+    raise ValueError(f"Unsupported experiment type: {experiment.experiment_type}")
 
 
 def balance_check_from_experiment(experiment: tables.Experiment) -> capi.BalanceCheck | None:
-    return ExperimentStorageConverter(experiment).get_balance_check()
+    if experiment.balance_check is not None:
+        return capi.BalanceCheck.model_validate(experiment.balance_check)
+    return None
 
 
 def power_response_from_experiment(experiment: tables.Experiment) -> capi.PowerResponse | None:
-    return ExperimentStorageConverter(experiment).get_power_response()
+    if experiment.power_analyses is None:
+        return None
+    return capi.PowerResponse.model_validate(experiment.power_analyses)
 
 
 async def experiment_config_from_experiment(
@@ -577,7 +467,21 @@ async def experiment_config_from_experiment(
     assign_summary: capi.AssignSummary,
     webhook_ids: list[str] | None = None,
 ) -> capi.GetExperimentResponse:
-    return await ExperimentStorageConverter(experiment).get_experiment_config(assign_summary, webhook_ids)
+    """Construct an ExperimentConfig from the internal Experiment and an AssignSummary."""
+    return capi.GetExperimentResponse(
+        experiment_id=(await experiment.awaitable_attrs.id),
+        datasource_id=experiment.datasource_id,
+        participant_type_deprecated=experiment.participant_type,
+        state=ExperimentState(experiment.state),
+        stopped_assignments_at=experiment.stopped_assignments_at,
+        stopped_assignments_reason=StopAssignmentReason.from_str(experiment.stopped_assignments_reason),
+        design_spec=await design_spec_from_experiment(experiment),
+        power_analyses=power_response_from_experiment(experiment),
+        assign_summary=assign_summary,
+        webhooks=webhook_ids or [],
+        decision=experiment.decision,
+        impact=experiment.impact,
+    )
 
 
 async def get_experiment_response_from_experiment(
@@ -585,7 +489,10 @@ async def get_experiment_response_from_experiment(
     assign_summary: capi.AssignSummary,
     webhook_ids: list[str] | None = None,
 ) -> capi.GetExperimentResponse:
-    return await ExperimentStorageConverter(experiment).get_experiment_response(assign_summary, webhook_ids)
+    # Although GetExperimentResponse is a subclass of ExperimentConfig, revalidate in case the API diverges.
+    return capi.GetExperimentResponse.model_validate(
+        (await experiment_config_from_experiment(experiment, assign_summary, webhook_ids)).model_dump()
+    )
 
 
 async def create_experiment_response_from_experiment(
@@ -593,4 +500,7 @@ async def create_experiment_response_from_experiment(
     assign_summary: capi.AssignSummary,
     webhook_ids: list[str] | None = None,
 ) -> capi.CreateExperimentResponse:
-    return await ExperimentStorageConverter(experiment).get_create_experiment_response(assign_summary, webhook_ids)
+    # Revalidate in case CreateExperimentResponse diverges from ExperimentConfig.
+    return capi.CreateExperimentResponse.model_validate(
+        (await experiment_config_from_experiment(experiment, assign_summary, webhook_ids)).model_dump()
+    )

--- a/src/xngin/apiserver/storage/storage_format_converters.py
+++ b/src/xngin/apiserver/storage/storage_format_converters.py
@@ -546,3 +546,51 @@ class ExperimentStorageConverter:
                 participant_type=participant_type,
             )
         )
+
+
+async def design_spec_from_experiment(experiment: tables.Experiment) -> capi.DesignSpec:
+    return await ExperimentStorageConverter(experiment).get_design_spec()
+
+
+def design_spec_filters_from_experiment(experiment: tables.Experiment) -> list[capi.Filter]:
+    return ExperimentStorageConverter(experiment).get_design_spec_filters()
+
+
+def design_spec_metrics_from_experiment(experiment: tables.Experiment) -> list[capi.DesignSpecMetricRequest]:
+    return ExperimentStorageConverter(experiment).get_design_spec_metrics()
+
+
+def field_type_map_from_experiment(experiment: tables.Experiment) -> dict[str, DataType]:
+    return ExperimentStorageConverter(experiment).get_field_type_map()
+
+
+def balance_check_from_experiment(experiment: tables.Experiment) -> capi.BalanceCheck | None:
+    return ExperimentStorageConverter(experiment).get_balance_check()
+
+
+def power_response_from_experiment(experiment: tables.Experiment) -> capi.PowerResponse | None:
+    return ExperimentStorageConverter(experiment).get_power_response()
+
+
+async def experiment_config_from_experiment(
+    experiment: tables.Experiment,
+    assign_summary: capi.AssignSummary,
+    webhook_ids: list[str] | None = None,
+) -> capi.GetExperimentResponse:
+    return await ExperimentStorageConverter(experiment).get_experiment_config(assign_summary, webhook_ids)
+
+
+async def get_experiment_response_from_experiment(
+    experiment: tables.Experiment,
+    assign_summary: capi.AssignSummary,
+    webhook_ids: list[str] | None = None,
+) -> capi.GetExperimentResponse:
+    return await ExperimentStorageConverter(experiment).get_experiment_response(assign_summary, webhook_ids)
+
+
+async def create_experiment_response_from_experiment(
+    experiment: tables.Experiment,
+    assign_summary: capi.AssignSummary,
+    webhook_ids: list[str] | None = None,
+) -> capi.CreateExperimentResponse:
+    return await ExperimentStorageConverter(experiment).get_create_experiment_response(assign_summary, webhook_ids)

--- a/src/xngin/stats/test_bandit_sampling.py
+++ b/src/xngin/stats/test_bandit_sampling.py
@@ -26,7 +26,6 @@ def make_experiment_table(
     experiment_converter = ExperimentStorageConverter.init_from_components(
         datasource_id="ds_id",
         organization_id="org_id",
-        experiment_type=experiment_type,
         design_spec=design_spec,
         state=ExperimentState.COMMITTED,
         stopped_assignments_at=None,

--- a/src/xngin/stats/test_bandit_sampling.py
+++ b/src/xngin/stats/test_bandit_sampling.py
@@ -6,7 +6,7 @@ from xngin.apiserver.routers.common_api_types import DesignSpec
 from xngin.apiserver.routers.common_enums import ExperimentState, ExperimentsType, LikelihoodTypes, PriorTypes
 from xngin.apiserver.routers.experiments.test_experiments_common import make_createexperimentrequest_json
 from xngin.apiserver.sqla import tables
-from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter
+from xngin.apiserver.storage.storage_format_converters import experiment_from_design_spec
 from xngin.stats.bandit_sampling import choose_arm, update_arm
 
 
@@ -23,7 +23,7 @@ def make_experiment_table(
         num_arms=num_arms,
     )
     design_spec: DesignSpec = TypeAdapter(DesignSpec).validate_python(request["design_spec"])
-    experiment_converter = ExperimentStorageConverter.init_from_components(
+    fake_experiment = experiment_from_design_spec(
         datasource_id="ds_id",
         organization_id="org_id",
         design_spec=design_spec,
@@ -31,7 +31,6 @@ def make_experiment_table(
         stopped_assignments_at=None,
         stopped_assignments_reason=None,
     )
-    fake_experiment = experiment_converter.get_experiment()
     # Add fake ids to the arms
     for i, arm in enumerate(fake_experiment.arms):
         arm.id = f"arm_{i}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Ticket

N/A

## Related PRs

Frontend: N/A
Docs: N/A

## Description

Simplifies experiment storage conversion in reviewable commits:

1. Removes redundant factory inputs by deriving experiment type and frequentist table metadata from `design_spec`.
2. Demotes the fluent builder setters to private module helpers used only by the factory.
3. Adds `experiment_from_design_spec(...) -> tables.Experiment` and migrates construction call sites away from `init_from_components(...).get_experiment()`.
4. Adds module-level projection helpers and migrates external read call sites to them.
5. Removes the `ExperimentStorageConverter` class facade and keeps the functional storage-boundary API.

## Future Tasks (optional)

N/A

## How has this been tested?

- `git diff --check origin/main..HEAD`
- `rg "ExperimentStorageConverter|init_from_components\\(" src --glob "*.py"` returned no matches
- `python3 -m py_compile src/xngin/apiserver/storage/storage_format_converters.py src/xngin/apiserver/sqla/tables.py`
- Attempted focused tests with `task`, but this cloud image is missing `task`.
- Attempted focused tests with `uv run pytest`, but this cloud image is missing `uv`.
- Attempted broader `python3 -m compileall` on touched files, but the image has Python 3.12 while the project targets Python 3.14 syntax.

## To-do before merge (optional)

Run the focused tests in a Python 3.14 project environment:

- `task test-only -- src/xngin/apiserver/routers/experiments/test_experiments_common.py src/xngin/apiserver/routers/admin/test_admin.py src/xngin/apiserver/snapshots/test_snapshotter.py src/xngin/stats/test_bandit_sampling.py`

## Checklist

Fill with `x` for completed.

- [ ] I have updated the automated tests
- [ ] I have updated affected documentation
- [ ] I have updated the CI/CD scripts in `.github/workflows/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41b36850-6985-4d6a-8ebd-a131728053e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41b36850-6985-4d6a-8ebd-a131728053e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

