### PR TITLE
docs: add dashboard field mapping to BanditExperimentAnalysisResponse docstring

### DIFF
--- a/src/xngin/apiserver/routers/common_api_types.py
+++ b/src/xngin/apiserver/routers/common_api_types.py
@@ -550,7 +550,30 @@ class FreqExperimentAnalysisResponse(ApiBaseModel):
 
 
 class BanditExperimentAnalysisResponse(ApiBaseModel):
-    """Describes changes in arms for a bandit experiment"""
+    """Describes changes in arms for a bandit experiment.
+
+    ## Dashboard Field Mapping
+
+    When rendering this response in a UI, the following mapping applies:
+
+    | Response Field | Dashboard Section | Required | Notes |
+    |---|---|---|---|
+    | experiment_id | Header / audit link | Yes | Stable experiment identifier. |
+    | arm_analyses[].arm_name | Arm card title | Yes | Display name for each variant. |
+    | arm_analyses[].post_pred_mean | Primary metric value | Yes | Expected outcome; main decision cue. |
+    | arm_analyses[].post_pred_ci_lower | Uncertainty ribbon lower | Yes | 95% CI lower bound. |
+    | arm_analyses[].post_pred_ci_upper | Uncertainty ribbon upper | Yes | 95% CI upper bound. |
+    | arm_analyses[].prior_pred_mean | Prior expectation display | No | Useful for change-from-prior charts. |
+    | arm_analyses[].prior_pred_ci_lower | Prior uncertainty lower | No | Prior CI lower bound. |
+    | arm_analyses[].prior_pred_ci_upper | Prior uncertainty upper | No | Prior CI upper bound. |
+    | n_outcomes | Confidence / data-quality badge | Yes | Low n_outcomes (< 50) warrants a "needs more data" warning. |
+    | created_at | Analysis timestamp | Yes | When the analysis was generated. |
+    | contexts | Contextual analysis badge | No | Present when contextual bandit features are active. |
+
+    Fields requiring external aggregation (not in this response):
+    - assignment counts (allocation share) — from ArmAssignment logs
+    - reward counts (observed rate) — from Outcome events
+    """
 
     type: Literal[ExperimentAnalysisType.BANDIT] = ExperimentAnalysisType.BANDIT
 
@@ -560,7 +583,7 @@ class BanditExperimentAnalysisResponse(ApiBaseModel):
     ]
     arm_analyses: Annotated[
         list[BanditArmAnalysis],
-        Field(description="Contains one analysis per metric targeted by the experiment."),
+        Field(description="Contains one analysis per arm (variant) in the bandit experiment."),
     ]
     n_outcomes: Annotated[
         int,


### PR DESCRIPTION
## Summary

Adds a dashboard field mapping table to the `BanditExperimentAnalysisResponse` docstring so frontend consumers can see at a glance which response fields map to which dashboard sections.

## Motivation

The current docstring only says "Describes changes in arms for a bandit experiment" without guidance on how a UI should render these fields. This forces every downstream consumer (dashboard, replay system, audit tools) to reverse-engineer the response.

## Changes

- **`common_api_types.py`**: Expanded `BanditExperimentAnalysisResponse` docstring with:
  - A markdown table mapping each response field to its dashboard section (header, arm card, uncertainty ribbon, confidence badge, etc.)
  - Required vs. optional designation for each field
  - Notes on fields requiring external aggregation (assignment counts from logs, reward counts from outcomes)

## What This Does NOT Change

- No runtime logic changes
- No new fields or response model changes
- No breaking changes

## Related

Continues the bandit dashboard/replay documentation work discussed in the proof-of-concept at https://github.com/Ddhruv1108/c4gt-idinsight-766-bandit-proof
