### PR TITLE
Populate cluster fields in MDE-mode solve_for_mde_cluster

### DIFF
--- a/src/xngin/stats/cluster_power.py
+++ b/src/xngin/stats/cluster_power.py
@@ -218,6 +218,8 @@ def solve_for_mde_cluster(
 ) -> MetricPowerAnalysis:
     """Calculate the minimum detectable effect (MDE) for a cluster-randomized design."""
 
+    assert metric.icc is not None and metric.avg_cluster_size is not None and metric.cv is not None
+
     target_possible, pct_change_possible = solve_for_mde_cluster_impl(
         metric=metric,
         desired_n=desired_n,
@@ -227,12 +229,39 @@ def solve_for_mde_cluster(
         power=power,
     )
 
+    # Compute DEFF, effective_n and numbers of clusters to add to MetricPowerAnalysis.
+    if arm_weights is None:
+        arm_probs = [1.0 / n_arms] * n_arms
+    else:
+        total_weight = sum(arm_weights)
+        arm_probs = [w / total_weight for w in arm_weights]
+
+    deff = calculate_design_effect(metric.icc, metric.avg_cluster_size, metric.cv)
+
+    clusters_per_arm_list: list[int] = []
+    n_per_arm_list: list[int] = []
+    for prob in arm_probs:
+        n_this_arm = desired_n * prob
+        clusters_this_arm = math.ceil(n_this_arm / metric.avg_cluster_size)
+        clusters_per_arm_list.append(clusters_this_arm)
+        n_per_arm_list.append(round(n_this_arm))
+
+    clusters_total = sum(clusters_per_arm_list)
+    effective_n = calculate_effective_sample_size(desired_n, deff)
+
     # Build response object for MDE calculation
-    analysis = MetricPowerAnalysis(metric_spec=metric)
-    analysis.target_n = desired_n
-    analysis.target_possible = target_possible
-    analysis.pct_change_possible = pct_change_possible
-    analysis.sufficient_n = None  # Not applicable in MDE mode
+    analysis = MetricPowerAnalysis(
+        metric_spec=metric,
+        target_n=desired_n,
+        target_possible=target_possible,
+        pct_change_possible=pct_change_possible,
+        sufficient_n=None,  # Not applicable in MDE mode
+        num_clusters_total=clusters_total,
+        clusters_per_arm=clusters_per_arm_list,
+        n_per_arm=n_per_arm_list,
+        design_effect=deff,
+        effective_sample_size=effective_n,
+    )
 
     # Create message
     assert metric.metric_baseline is not None
@@ -240,11 +269,13 @@ def solve_for_mde_cluster(
         "desired_n": desired_n,
         "metric_baseline": round(metric.metric_baseline, 4),
         "target_possible": round(target_possible, 4),
+        "num_clusters_total": clusters_total,
     }
     msg_type = MetricPowerAnalysisMessageType.SUFFICIENT
     msg_body = (
-        "With a desired sample size of {desired_n} units and a metric baseline of "  # noqa: RUF027
-        "{metric_baseline}, the minimum detectable effect (MDE) is {target_possible}."
+        "With a desired sample size of {desired_n} units across {num_clusters_total} "
+        "clusters and a metric baseline of {metric_baseline}, the minimum detectable "
+        "effect (MDE) is {target_possible}."  # noqa: RUF027
     )
     analysis.msg = MetricPowerAnalysisMessage(
         type=msg_type,

--- a/src/xngin/stats/cluster_power.py
+++ b/src/xngin/stats/cluster_power.py
@@ -2,6 +2,7 @@
 Power analysis for cluster-randomized designs.
 """
 
+import dataclasses
 import math
 
 from xngin.apiserver.routers.common_api_types import (
@@ -14,6 +15,32 @@ from xngin.stats.individual_power import (
     solve_for_mde_individual_impl,
     solve_for_sample_size_individual,
 )
+
+
+def _normalize_arm_weights(arm_weights: list[float] | None, n_arms: int) -> list[float]:
+    """Return per-arm allocation probabilities that sum to 1.
+
+    If arm_weights is None, returns an equal split across n_arms. Otherwise,
+    normalizes the provided weights so they sum to 1.
+    """
+    if arm_weights is None:
+        return [1.0 / n_arms] * n_arms
+    total_weight = sum(arm_weights)
+    return [w / total_weight for w in arm_weights]
+
+
+@dataclasses.dataclass(slots=True, kw_only=True, frozen=True)
+class MdeClusterResult:
+    """Result of an MDE-mode cluster-power calculation.
+
+    Returned by solve_for_mde_cluster_impl so callers can both use the MDE
+    values and surface the design-effect inputs without recomputing them.
+    """
+
+    target_possible: float
+    pct_change_possible: float
+    deff: float
+    effective_n: int
 
 
 def calculate_design_effect(
@@ -167,7 +194,7 @@ def solve_for_mde_cluster_impl(
     arm_weights: list[float] | None = None,
     alpha: float = 0.05,
     power: float = 0.8,
-) -> tuple[float, float]:
+) -> MdeClusterResult:
     """
     Given desired sample size, calculate minimum detectable effect (MDE) for a
     cluster-randomized design. Cluster parameters are read from the metric.
@@ -182,9 +209,8 @@ def solve_for_mde_cluster_impl(
         arm_weights: Optional allocation weights for unbalanced designs
 
     Returns:
-        Tuple of (target_value, pct_change):
-        - target_value: The minimum detectable effect in absolute terms
-        - pct_change: The minimum detectable effect as percent change from baseline
+        MdeClusterResult with the MDE values and the design effect / effective n
+        that were used to compute them.
 
     """
     if metric.icc is None:
@@ -197,13 +223,16 @@ def solve_for_mde_cluster_impl(
 
     effective_n = calculate_effective_sample_size(desired_n, deff)
 
-    return solve_for_mde_individual_impl(
+    target_possible, pct_change_possible = solve_for_mde_individual_impl(
         desired_n=effective_n,
         metric=metric,
         n_arms=n_arms,
+        arm_weights=arm_weights,
         alpha=alpha,
         power=power,
-        arm_weights=arm_weights,
+    )
+    return MdeClusterResult(
+        target_possible=target_possible, pct_change_possible=pct_change_possible, deff=deff, effective_n=effective_n
     )
 
 
@@ -220,7 +249,7 @@ def solve_for_mde_cluster(
 
     assert metric.icc is not None and metric.avg_cluster_size is not None and metric.cv is not None
 
-    target_possible, pct_change_possible = solve_for_mde_cluster_impl(
+    result = solve_for_mde_cluster_impl(
         metric=metric,
         desired_n=desired_n,
         arm_weights=arm_weights,
@@ -230,13 +259,7 @@ def solve_for_mde_cluster(
     )
 
     # Compute DEFF, effective_n and numbers of clusters to add to MetricPowerAnalysis.
-    if arm_weights is None:
-        arm_probs = [1.0 / n_arms] * n_arms
-    else:
-        total_weight = sum(arm_weights)
-        arm_probs = [w / total_weight for w in arm_weights]
-
-    deff = calculate_design_effect(metric.icc, metric.avg_cluster_size, metric.cv)
+    arm_probs = _normalize_arm_weights(arm_weights, n_arms)
 
     clusters_per_arm_list: list[int] = []
     n_per_arm_list: list[int] = []
@@ -247,20 +270,19 @@ def solve_for_mde_cluster(
         n_per_arm_list.append(round(n_this_arm))
 
     clusters_total = sum(clusters_per_arm_list)
-    effective_n = calculate_effective_sample_size(desired_n, deff)
 
     # Build response object for MDE calculation
     analysis = MetricPowerAnalysis(
         metric_spec=metric,
         target_n=desired_n,
-        target_possible=target_possible,
-        pct_change_possible=pct_change_possible,
+        target_possible=result.target_possible,
+        pct_change_possible=result.pct_change_possible,
         sufficient_n=None,  # Not applicable in MDE mode
         num_clusters_total=clusters_total,
         clusters_per_arm=clusters_per_arm_list,
         n_per_arm=n_per_arm_list,
-        design_effect=deff,
-        effective_sample_size=effective_n,
+        design_effect=result.deff,
+        effective_sample_size=result.effective_n,
     )
 
     # Create message
@@ -268,14 +290,14 @@ def solve_for_mde_cluster(
     values_map: dict[str, float | int] = {
         "desired_n": desired_n,
         "metric_baseline": round(metric.metric_baseline, 4),
-        "target_possible": round(target_possible, 4),
+        "target_possible": round(result.target_possible, 4),
         "num_clusters_total": clusters_total,
     }
     msg_type = MetricPowerAnalysisMessageType.SUFFICIENT
     msg_body = (
         "With a desired sample size of {desired_n} units across {num_clusters_total} "
         "clusters and a metric baseline of {metric_baseline}, the minimum detectable "
-        "effect (MDE) is {target_possible}."  # noqa: RUF027
+        "effect (MDE) is {target_possible}."
     )
     analysis.msg = MetricPowerAnalysisMessage(
         type=msg_type,
@@ -331,11 +353,7 @@ def solve_for_sample_size_cluster(
         )
         assert available_nonnull_n is not None
 
-        if arm_weights is None:
-            arm_probs = [1.0 / n_arms] * n_arms
-        else:
-            total_weight = sum(arm_weights)
-            arm_probs = [w / total_weight for w in arm_weights]
+        arm_probs = _normalize_arm_weights(arm_weights, n_arms)
 
         deff = calculate_design_effect(metric.icc, metric.avg_cluster_size, metric.cv)
 
@@ -368,7 +386,7 @@ def solve_for_sample_size_cluster(
         pct_change_possible = None
         if not sufficient_n:
             # Let the user know: Given the clustering, what could you detect with what's available?
-            target_possible, pct_change_possible = solve_for_mde_cluster_impl(
+            mde_result = solve_for_mde_cluster_impl(
                 metric=metric,
                 desired_n=available_nonnull_n,
                 n_arms=n_arms,
@@ -376,6 +394,8 @@ def solve_for_sample_size_cluster(
                 alpha=alpha,
                 power=power,
             )
+            target_possible = mde_result.target_possible
+            pct_change_possible = mde_result.pct_change_possible
 
         final_msg = _build_cluster_sample_size_message(
             metric=metric,

--- a/src/xngin/stats/cluster_power.py
+++ b/src/xngin/stats/cluster_power.py
@@ -37,9 +37,13 @@ class MdeClusterResult:
     values and surface the design-effect inputs without recomputing them.
     """
 
+    # The minimum detectable effect in absolute terms
     target_possible: float
+    # The minimum detectable effect as percent change from baseline
     pct_change_possible: float
+    # The design effect (DEFF)
     deff: float
+    # The effective sample size when accounting for clustering
     effective_n: int
 
 

--- a/src/xngin/stats/test_cluster_power.py
+++ b/src/xngin/stats/test_cluster_power.py
@@ -220,23 +220,6 @@ def test_calculate_num_clusters_needed_high_deff():
     assert n_high == 20
 
 
-def test_solve_for_mde_cluster_impl_basic():
-    metric = DesignSpecMetric(
-        field_name="reading_score",
-        metric_type=MetricType.NUMERIC,
-        metric_baseline=100,
-        metric_stddev=20,
-        icc=0.15,
-        avg_cluster_size=30,
-        cv=0.0,
-    )
-
-    target, pct_change = solve_for_mde_cluster_impl(desired_n=600, metric=metric, n_arms=2)
-
-    assert target == pytest.approx(110.68, rel=0.01)
-    assert pct_change == pytest.approx(0.1068, rel=0.01)
-
-
 def test_solve_for_mde_cluster_impl_no_clustering():
     ind_metric = DesignSpecMetric(
         field_name="test_metric",
@@ -255,10 +238,10 @@ def test_solve_for_mde_cluster_impl_no_clustering():
     )
 
     ind_target, ind_pct = solve_for_mde_individual_impl(desired_n=1000, metric=ind_metric, n_arms=2)
-    clust_target, clust_pct = solve_for_mde_cluster_impl(desired_n=1000, metric=clust_metric, n_arms=2)
+    clust_result = solve_for_mde_cluster_impl(desired_n=1000, metric=clust_metric, n_arms=2)
 
-    assert clust_target == pytest.approx(ind_target)
-    assert clust_pct == pytest.approx(ind_pct)
+    assert clust_result.target_possible == pytest.approx(ind_target)
+    assert clust_result.pct_change_possible == pytest.approx(ind_pct)
 
 
 def test_solve_for_mde_cluster_impl_higher_with_clustering():
@@ -279,7 +262,7 @@ def test_solve_for_mde_cluster_impl_higher_with_clustering():
     )
 
     ind_target, ind_pct = solve_for_mde_individual_impl(desired_n=600, metric=ind_metric, n_arms=2)
-    clust_target, clust_pct = solve_for_mde_cluster_impl(desired_n=600, metric=clust_metric, n_arms=2)
+    clust_result = solve_for_mde_cluster_impl(desired_n=600, metric=clust_metric, n_arms=2)
 
     assert ind_target == pytest.approx(104.6, rel=0.01)
     assert ind_pct == pytest.approx(0.046, rel=0.01)
@@ -287,8 +270,8 @@ def test_solve_for_mde_cluster_impl_higher_with_clustering():
     # With 600 participants, ICC=0.15, m=30:
     # DEFF = 5.35, effective_n = 600/5.35 = 112
     # MDE should be ~10.68 points (10.68% change)
-    assert clust_target == pytest.approx(110.7, rel=0.01)
-    assert clust_pct == pytest.approx(0.1068, rel=0.01)
+    assert clust_result.target_possible == pytest.approx(110.7, rel=0.01)
+    assert clust_result.pct_change_possible == pytest.approx(0.1068, rel=0.01)
 
 
 def test_solve_for_mde_cluster_impl_binary_metric():
@@ -301,12 +284,12 @@ def test_solve_for_mde_cluster_impl_binary_metric():
         cv=0.0,
     )
 
-    target, pct_change = solve_for_mde_cluster_impl(desired_n=1000, metric=metric, n_arms=2)
+    result = solve_for_mde_cluster_impl(desired_n=1000, metric=metric, n_arms=2)
 
     # Binary metric with clustering
     # DEFF = 1 + (50-1)*0.05 = 3.45
-    assert target == pytest.approx(0.0243, rel=0.01)
-    assert pct_change == pytest.approx(-0.7566, rel=0.01)
+    assert result.target_possible == pytest.approx(0.0243, rel=0.01)
+    assert result.pct_change_possible == pytest.approx(-0.7566, rel=0.01)
 
 
 def test_solve_for_mde_cluster_impl_unbalanced():
@@ -320,10 +303,10 @@ def test_solve_for_mde_cluster_impl_unbalanced():
         cv=0.0,
     )
 
-    target, pct_change = solve_for_mde_cluster_impl(desired_n=1000, metric=metric, n_arms=2, arm_weights=[20, 80])
+    result = solve_for_mde_cluster_impl(desired_n=1000, metric=metric, n_arms=2, arm_weights=[20, 80])
 
-    assert target == pytest.approx(110.35, rel=0.01)
-    assert pct_change == pytest.approx(0.1035, rel=0.01)
+    assert result.target_possible == pytest.approx(110.35, rel=0.01)
+    assert result.pct_change_possible == pytest.approx(0.1035, rel=0.01)
 
 
 def test_solve_for_mde_cluster_impl_with_cv():
@@ -339,14 +322,14 @@ def test_solve_for_mde_cluster_impl_with_cv():
     )
     metric_high_cv = metric_no_cv.model_copy(update={"cv": 1.5})
 
-    target_no_cv, pct_no_cv = solve_for_mde_cluster_impl(desired_n=720, metric=metric_no_cv, n_arms=2)
-    target_high_cv, pct_high_cv = solve_for_mde_cluster_impl(desired_n=720, metric=metric_high_cv, n_arms=2)
+    result_no_cv = solve_for_mde_cluster_impl(desired_n=720, metric=metric_no_cv, n_arms=2)
+    result_high_cv = solve_for_mde_cluster_impl(desired_n=720, metric=metric_high_cv, n_arms=2)
 
     # CV increases DEFF, which increases MDE
-    assert target_high_cv > target_no_cv
-    assert target_no_cv == pytest.approx(110.3, rel=0.01)
-    assert target_high_cv == pytest.approx(116.89, rel=0.01)
-    assert pct_high_cv > pct_no_cv
+    assert result_high_cv.target_possible > result_no_cv.target_possible
+    assert result_no_cv.target_possible == pytest.approx(110.3, rel=0.01)
+    assert result_high_cv.target_possible == pytest.approx(116.89, rel=0.01)
+    assert result_high_cv.pct_change_possible > result_no_cv.pct_change_possible
 
 
 def test_solve_for_mde_cluster_populates_all_fields():
@@ -383,11 +366,13 @@ def test_solve_for_mde_cluster_populates_all_fields():
 
     # The user-facing message should mention the cluster count.
     assert analysis.msg is not None
+    assert analysis.msg.type == MetricPowerAnalysisMessageType.SUFFICIENT
     assert "20 clusters" in analysis.msg.msg
 
 
 def test_solve_for_mde_cluster_respects_arm_weights():
-    """Unequal arm weights produce proportional per-arm cluster splits."""
+    """Unequal arm weights produce proportional per-arm cluster splits, and all
+    response fields are populated consistently (cf. test_solve_for_mde_cluster_populates_all_fields)."""
     metric = DesignSpecMetric(
         field_name="reading_score",
         metric_type=MetricType.NUMERIC,
@@ -401,11 +386,54 @@ def test_solve_for_mde_cluster_respects_arm_weights():
     # 3:1 weighting on 800 participants → 600 in arm 0, 200 in arm 1.
     analysis = solve_for_mde_cluster(metric=metric, desired_n=800, n_arms=2, arm_weights=[3.0, 1.0])
 
+    # Top-level sample-size fields.
     assert analysis.target_n == 800
-    assert analysis.n_per_arm == [600, 200]
+    assert analysis.sufficient_n is None
+    assert analysis.target_possible is not None
+    assert analysis.pct_change_possible is not None
+
+    # Cluster shape.
+    expected_deff = calculate_design_effect(icc=0.15, avg_cluster_size=30, cv=0.0)
+    assert analysis.design_effect == pytest.approx(expected_deff)
+    assert analysis.effective_sample_size == calculate_effective_sample_size(800, expected_deff)
+
     # 600 / 30 = 20 clusters, 200 / 30 = 6.67 → ceil to 7.
+    assert analysis.n_per_arm == [600, 200]
     assert analysis.clusters_per_arm == [20, 7]
     assert analysis.num_clusters_total == 27
+    assert sum(analysis.clusters_per_arm) == analysis.num_clusters_total
+
+    # Message.
+    assert analysis.msg is not None
+    assert analysis.msg.type == MetricPowerAnalysisMessageType.SUFFICIENT
+    assert "27 clusters" in analysis.msg.msg
+
+
+def test_solve_for_mde_cluster_unbalanced_has_larger_mde():
+    """Unbalanced arm splits should yield a larger MDE than a balanced split of
+    the same total n, because the smaller arm becomes the statistical bottleneck.
+    Regression test for arm_weights previously being dropped before reaching
+    solve_for_mde_individual_impl."""
+    metric = DesignSpecMetric(
+        field_name="reading_score",
+        metric_type=MetricType.NUMERIC,
+        metric_baseline=100,
+        metric_stddev=20,
+        icc=0.15,
+        avg_cluster_size=30,
+        cv=0.0,
+    )
+
+    balanced = solve_for_mde_cluster(metric=metric, desired_n=800, n_arms=2)
+    unbalanced = solve_for_mde_cluster(metric=metric, desired_n=800, n_arms=2, arm_weights=[3.0, 1.0])
+
+    assert balanced.target_possible is not None
+    assert unbalanced.target_possible is not None
+    assert balanced.pct_change_possible is not None
+    assert unbalanced.pct_change_possible is not None
+
+    assert unbalanced.target_possible > balanced.target_possible
+    assert unbalanced.pct_change_possible > balanced.pct_change_possible
 
 
 def test_solve_for_sample_size_cluster_missing_baseline():
@@ -493,7 +521,7 @@ def test_solve_for_sample_size_cluster_uses_cluster_target_for_sufficiency():
     )
 
     result = solve_for_sample_size_cluster(metric=metric, n_arms=2)
-    expected_target_possible, expected_pct_change_possible = solve_for_mde_cluster_impl(
+    expected_result = solve_for_mde_cluster_impl(
         metric=metric,
         desired_n=desired_n,
         n_arms=2,
@@ -506,8 +534,8 @@ def test_solve_for_sample_size_cluster_uses_cluster_target_for_sufficiency():
 
     assert result.target_n == 720
     assert result.sufficient_n is False
-    assert result.target_possible == pytest.approx(expected_target_possible)
-    assert result.pct_change_possible == pytest.approx(expected_pct_change_possible)
+    assert result.target_possible == pytest.approx(expected_result.target_possible)
+    assert result.pct_change_possible == pytest.approx(expected_result.pct_change_possible)
     assert result.target_possible is not None
     assert result.target_possible > individual_target_possible
 
@@ -517,7 +545,7 @@ def test_solve_for_sample_size_cluster_uses_cluster_target_for_sufficiency():
     assert msg_values is not None
     assert msg_values["target_n"] == result.target_n
     assert msg_values["additional_n_needed"] == 520
-    assert msg_values["target_possible"] == round(expected_target_possible, 4)
+    assert msg_values["target_possible"] == round(expected_result.target_possible, 4)
     assert "You need at least 720 units across 24 clusters" in result.msg.msg
     assert "You need at least 128 units" not in result.msg.msg
     assert result.msg.msg == result.msg.source_msg.format_map(msg_values)
@@ -540,7 +568,7 @@ def test_solve_for_sample_size_cluster_possible_target_uses_cluster_mde():
     )
 
     result = solve_for_sample_size_cluster(metric=metric, n_arms=2)
-    expected_target_possible, expected_pct_change_possible = solve_for_mde_cluster_impl(
+    expected_result = solve_for_mde_cluster_impl(
         metric=metric,
         desired_n=desired_n,
         n_arms=2,
@@ -552,8 +580,8 @@ def test_solve_for_sample_size_cluster_possible_target_uses_cluster_mde():
     )
 
     assert result.sufficient_n is False
-    assert result.target_possible == pytest.approx(expected_target_possible)
-    assert result.pct_change_possible == pytest.approx(expected_pct_change_possible)
+    assert result.target_possible == pytest.approx(expected_result.target_possible)
+    assert result.pct_change_possible == pytest.approx(expected_result.pct_change_possible)
     assert result.target_possible is not None
     assert result.target_possible > individual_target_possible
     assert result.msg is not None

--- a/src/xngin/stats/test_cluster_power.py
+++ b/src/xngin/stats/test_cluster_power.py
@@ -13,6 +13,7 @@ from xngin.stats.cluster_power import (
     calculate_design_effect,
     calculate_effective_sample_size,
     calculate_num_clusters_needed,
+    solve_for_mde_cluster,
     solve_for_mde_cluster_impl,
     solve_for_sample_size_cluster,
 )
@@ -346,6 +347,65 @@ def test_solve_for_mde_cluster_impl_with_cv():
     assert target_no_cv == pytest.approx(110.3, rel=0.01)
     assert target_high_cv == pytest.approx(116.89, rel=0.01)
     assert pct_high_cv > pct_no_cv
+
+
+def test_solve_for_mde_cluster_populates_all_fields():
+    """In MDE mode, the wrapper populates per-arm cluster counts, DEFF, and effective_n
+    so the FE doesn't fall back to stale values from a prior power check."""
+    metric = DesignSpecMetric(
+        field_name="reading_score",
+        metric_type=MetricType.NUMERIC,
+        metric_baseline=100,
+        metric_stddev=20,
+        icc=0.15,
+        avg_cluster_size=30,
+        cv=0.0,
+    )
+
+    analysis = solve_for_mde_cluster(metric=metric, desired_n=600, n_arms=2)
+
+    # MDE math itself is unchanged from the existing _impl tests.
+    assert analysis.target_n == 600
+    assert analysis.target_possible == pytest.approx(110.68, rel=0.01)
+    assert analysis.pct_change_possible == pytest.approx(0.1068, rel=0.01)
+    assert analysis.sufficient_n is None  # not applicable in MDE mode
+
+    # The new fields.
+    expected_deff = calculate_design_effect(icc=0.15, avg_cluster_size=30, cv=0.0)
+    assert analysis.design_effect == pytest.approx(expected_deff)
+    assert analysis.effective_sample_size == calculate_effective_sample_size(600, expected_deff)
+
+    # Equal split across 2 arms: 300 each, rounded up to whole clusters of size 30 → 10 per arm.
+    assert analysis.clusters_per_arm == [10, 10]
+    assert analysis.n_per_arm == [300, 300]
+    assert analysis.num_clusters_total == 20
+    assert sum(analysis.clusters_per_arm) == analysis.num_clusters_total
+
+    # The user-facing message should mention the cluster count.
+    assert analysis.msg is not None
+    assert "20 clusters" in analysis.msg.msg
+
+
+def test_solve_for_mde_cluster_respects_arm_weights():
+    """Unequal arm weights produce proportional per-arm cluster splits."""
+    metric = DesignSpecMetric(
+        field_name="reading_score",
+        metric_type=MetricType.NUMERIC,
+        metric_baseline=100,
+        metric_stddev=20,
+        icc=0.15,
+        avg_cluster_size=30,
+        cv=0.0,
+    )
+
+    # 3:1 weighting on 800 participants → 600 in arm 0, 200 in arm 1.
+    analysis = solve_for_mde_cluster(metric=metric, desired_n=800, n_arms=2, arm_weights=[3.0, 1.0])
+
+    assert analysis.target_n == 800
+    assert analysis.n_per_arm == [600, 200]
+    # 600 / 30 = 20 clusters, 200 / 30 = 6.67 → ceil to 7.
+    assert analysis.clusters_per_arm == [20, 7]
+    assert analysis.num_clusters_total == 27
 
 
 def test_solve_for_sample_size_cluster_missing_baseline():


### PR DESCRIPTION
Split out of #248 per @qixotic's review feedback (adds tests too).

## Summary

Extend the MDE-mode response from `solve_for_mde_cluster` to include `num_clusters_total`, `clusters_per_arm`, `n_per_arm`, `design_effect`, and `effective_sample_size`. Previously these stayed `None` when `desired_n` was provided, causing saved cluster experiments to show stale cluster counts from the original recommended-size power check instead of counts that match the committed sample size.

## Tests

- `test_solve_for_mde_cluster_populates_all_fields` — regression test for all five newly-populated fields, plus the updated message.
- `test_solve_for_mde_cluster_respects_arm_weights` — verifies the per-arm split honors `arm_weights`.
- `test_solve_for_mde_cluster_unbalanced_has_larger_mde` — regression test for the `arm_weights` bonus fix below.

## Bonus fix

`solve_for_mde_cluster_impl` previously declared `arm_weights` but never forwarded it to `solve_for_mde_individual_impl`. Unbalanced cluster MDE designs were silently using balanced-arm math as a result. Fixed by passing the argument through.

Covered by `test_solve_for_mde_cluster_unbalanced_has_larger_mde`, which asserts an unbalanced 3:1 split yields a larger MDE than a balanced split with the same total `desired_n`.