### PR TITLE
Clean up RUF069.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,6 @@ ignore = [
     "PLR6301", # method could be a function, class method, or static method
     "PT011", # pytest.raises(_) is too broad, set the `match` parameter or use a more specific exception
     "PT018", # Assertion should be broken down into multiple parts
-    "RUF069", # Unreliable floating point equality comparison
     "S101", # Use of `assert` detected
     "SIM108", # Use ternary operator instead of `if`-`else`-block
     "RUF029", # Unused async
@@ -155,6 +154,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "**/test_*" = [
+    "RUF069", # round-trip float equality with literals is fine in tests
     "S105",  # Possible hardcoded password assigned
     "S106",  # Possible hardcoded password assigned to argument
     "S311",  # Standard pseudo-random generators are not suitable for cryptographic purposes

--- a/src/xngin/stats/individual_power.py
+++ b/src/xngin/stats/individual_power.py
@@ -2,6 +2,8 @@
 Power analysis for individually-randomized designs.
 """
 
+import math
+
 import numpy as np
 import statsmodels.stats.api as sms
 
@@ -197,7 +199,7 @@ def solve_for_sample_size_individual(
     else:
         raise ValueError("metric_type must be NUMERIC or BINARY.")
 
-    if effect_size == 0.0:
+    if math.isclose(effect_size, 0.0):
         return power_analysis_error(
             metric,
             MetricPowerAnalysisMessageType.ZERO_EFFECT_SIZE,

--- a/src/xngin/stats/test_bandit_analysis.py
+++ b/src/xngin/stats/test_bandit_analysis.py
@@ -105,7 +105,7 @@ def test_analyze_normal_ci_correctness():
 
     mean, stddev, ci_upper, ci_lower = _analyze_normal(mu, covariance, outcome_std_dev, context)
 
-    assert mean == 10.0
+    assert np.isclose(mean, 10.0)
 
     # If we incorrectly used stddev for our CI, SEM = sqrt(1+100), much wider than the real
     # standard error of the mean = sqrt(1.0). So the correct 95% CI half-width is:


### PR DESCRIPTION
Tights up RUF069 in production code; allows it in tests because tests are not doing arithmetic, just testing round-trip values.
