### PR TITLE
Enables Ruff PT006.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,6 @@ ignore = [
     "PLR1702", # too many nested blocks
     "PLR2004", # magic value,
     "PLR6301", # method could be a function, class method, or static method
-    "PT006", # Wrong type passed to first argument of `pytest.mark.parametrize`; expected `tuple`
     "PT011", # pytest.raises(_) is too broad, set the `match` parameter or use a more specific exception
     "PT018", # Assertion should be broken down into multiple parts
     "PYI041", # Use `float` instead of `int | float`

--- a/src/xngin/apiserver/dwh/test_query_constructors.py
+++ b/src/xngin/apiserver/dwh/test_query_constructors.py
@@ -35,7 +35,7 @@ pytest_plugins = ("xngin.apiserver.dwh.dwh_test_support",)
 
 
 @pytest.mark.parametrize(
-    "select_columns, error_message",
+    ("select_columns", "error_message"),
     [
         (set(), "select_columns must have at least one item."),
         ({"missing_column"}, "Column missing_column not found in schema."),
@@ -57,7 +57,7 @@ SELECT_COLUMNS_CASES_PG = [
 ]
 
 
-@pytest.mark.parametrize("select_columns, expected_columns", SELECT_COLUMNS_CASES_PG)
+@pytest.mark.parametrize(("select_columns", "expected_columns"), SELECT_COLUMNS_CASES_PG)
 def test_compile_query_without_filters_pg(select_columns, expected_columns):
     # SQLAlchemy shares a base class for both psycopg2's and psycopg's dialect so they are very similar.
     dialects = (
@@ -82,7 +82,7 @@ SELECT_COLUMNS_CASES_BQ = [
 ]
 
 
-@pytest.mark.parametrize("select_columns, expected_columns", SELECT_COLUMNS_CASES_BQ)
+@pytest.mark.parametrize(("select_columns", "expected_columns"), SELECT_COLUMNS_CASES_BQ)
 def test_compile_query_without_filters_bq(select_columns, expected_columns):
     query = compose_query(SampleTable.get_table(), select_columns, [], 2)
     dialect = sqlalchemy_bigquery.dialect()
@@ -553,7 +553,7 @@ def test_allowed_date_or_datetime_filter_validation(column_type):
 
 
 @pytest.mark.parametrize(
-    "table_name,schema_name,expected_sql",
+    ("table_name", "schema_name", "expected_sql"),
     [
         ("foo", None, "SELECT * FROM foo LIMIT 0"),
         ("--bar", "my;schema", 'SELECT * FROM "my;schema"."--bar" LIMIT 0'),

--- a/src/xngin/apiserver/routers/admin/test_admin_api.py
+++ b/src/xngin/apiserver/routers/admin/test_admin_api.py
@@ -2141,7 +2141,7 @@ def test_create_and_get_freq_online_experiment(testing_datasource, aclient: Admi
 
 
 @pytest.mark.parametrize(
-    "reward_type,prior_type",
+    ("reward_type", "prior_type"),
     [
         (LikelihoodTypes.BERNOULLI, PriorTypes.BETA),
         (LikelihoodTypes.NORMAL, PriorTypes.NORMAL),
@@ -2212,7 +2212,7 @@ def test_create_and_get_online_mab_experiment(testing_datasource, aclient: Admin
 
 
 @pytest.mark.parametrize(
-    "reward_type,prior_type",
+    ("reward_type", "prior_type"),
     [
         (LikelihoodTypes.NORMAL, PriorTypes.NORMAL),
         (LikelihoodTypes.BERNOULLI, PriorTypes.NORMAL),
@@ -2276,7 +2276,7 @@ def test_create_online_cmab_experiment(testing_datasource, aclient: AdminAPIClie
 
 
 @pytest.mark.parametrize(
-    "experiment_type,reward_type,prior_type",
+    ("experiment_type", "reward_type", "prior_type"),
     [
         (ExperimentsType.MAB_ONLINE, LikelihoodTypes.NORMAL, PriorTypes.NORMAL),
         (ExperimentsType.MAB_ONLINE, LikelihoodTypes.BERNOULLI, PriorTypes.BETA),
@@ -2804,7 +2804,7 @@ def test_mab_experiments_analyze_with_no_participants(testing_bandit_experiment,
 
 
 @pytest.mark.parametrize(
-    "endpoint,initial_state,expected_status,expected_detail",
+    ("endpoint", "initial_state", "expected_status", "expected_detail"),
     [
         ("commit", ExperimentState.ASSIGNED, 204, None),  # Success case
         ("commit", ExperimentState.COMMITTED, 204, None),  # No-op

--- a/src/xngin/apiserver/routers/experiments/test_experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_api.py
@@ -181,7 +181,7 @@ def make_unvalidated_create_experiment_request(
 
 
 @pytest.mark.parametrize(
-    "key,expected_status,expected_message",
+    ("key", "expected_status", "expected_message"),
     [
         ("", 400, "request header is required"),
         ("a", 400, "must start with"),
@@ -237,7 +237,7 @@ async def test_get_experiment(testing_datasource, aclient: AdminAPIClient, eclie
 
 
 @pytest.mark.parametrize(
-    "experiment_type, table_name, primary_key, expected_status, expected_in_loc",
+    ("experiment_type", "table_name", "primary_key", "expected_status", "expected_in_loc"),
     [
         (ExperimentsType.FREQ_PREASSIGNED, None, None, 422, "table_name"),
         (ExperimentsType.FREQ_PREASSIGNED, "dwh", None, 422, "primary_key"),

--- a/src/xngin/apiserver/routers/experiments/test_experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_common.py
@@ -1025,7 +1025,7 @@ async def test_create_experiment_impl_for_freq_online_with_unbalanced_arms(
 
 
 @pytest.mark.parametrize(
-    "experiment_type, filters, match",
+    ("experiment_type", "filters", "match"),
     [
         (
             ExperimentsType.FREQ_ONLINE,
@@ -1345,7 +1345,7 @@ async def test_create_experiment_impl_for_cmab_online(xngin_session, testing_dat
 
 
 @pytest.mark.parametrize(
-    "experiment_type,reward_type,prior_type",
+    ("experiment_type", "reward_type", "prior_type"),
     [
         (ExperimentsType.MAB_ONLINE, LikelihoodTypes.NORMAL, PriorTypes.NORMAL),
         (ExperimentsType.MAB_ONLINE, LikelihoodTypes.BERNOULLI, PriorTypes.BETA),
@@ -2027,7 +2027,7 @@ async def test_create_assignment_for_participant_with_three_weighted_arms(xngin_
 
 
 @pytest.mark.parametrize(
-    "experiment_type,stopped_reason",
+    ("experiment_type", "stopped_reason"),
     [
         (ExperimentsType.FREQ_PREASSIGNED, StopAssignmentReason.PREASSIGNED),
         (ExperimentsType.FREQ_ONLINE, StopAssignmentReason.END_DATE),
@@ -2064,7 +2064,7 @@ async def test_create_assignment_for_participant_stopped_reason(
 
 
 @pytest.mark.parametrize(
-    "has_assignment, participant_id, sample_timestamp, income",
+    ("has_assignment", "participant_id", "sample_timestamp", "income"),
     [
         # These 2 will already exist in the database due to make_experiment_with_assignments
         (True, "p1", "2023", 0),
@@ -2124,7 +2124,7 @@ async def test_get_or_create_assignment_for_participant_with_filters_in_online_f
 
 
 @pytest.mark.parametrize(
-    "has_assignment, experiment_type, create_if_none, expected_exception",
+    ("has_assignment", "experiment_type", "create_if_none", "expected_exception"),
     [
         # Preassigned experiments can't add new assignments
         (False, ExperimentsType.FREQ_PREASSIGNED, False, does_not_raise()),
@@ -2164,7 +2164,7 @@ async def test_get_or_create_assignment_for_participant_without_filters(
 
 
 @pytest.mark.parametrize(
-    "experiment_type,prior_type,reward_type",
+    ("experiment_type", "prior_type", "reward_type"),
     [
         (ExperimentsType.MAB_ONLINE, PriorTypes.NORMAL, LikelihoodTypes.NORMAL),
         (ExperimentsType.MAB_ONLINE, PriorTypes.BETA, LikelihoodTypes.BERNOULLI),

--- a/src/xngin/apiserver/routers/test_common_api_types.py
+++ b/src/xngin/apiserver/routers/test_common_api_types.py
@@ -71,7 +71,7 @@ VALID_BETWEEN = [
 ]
 
 
-@pytest.mark.parametrize("value,descr", VALID_BETWEEN)
+@pytest.mark.parametrize(("value", "descr"), VALID_BETWEEN)
 def test_between_relation(value, descr):
     filter_spec = Filter(field_name="col", relation=Relation.BETWEEN, value=value)
     assert filter_spec.value == value, f"Failed for case: {descr}"
@@ -92,7 +92,7 @@ INVALID_BETWEEN = [
 ]
 
 
-@pytest.mark.parametrize("value,descr", INVALID_BETWEEN)
+@pytest.mark.parametrize(("value", "descr"), INVALID_BETWEEN)
 def test_between_relation_invalid(value, descr):
     # The third case occurs when Pydantic backtracks internally to solve the constraints on `value`.
     with pytest.raises(ValidationError, match=r"(BETWEEN relation|same type| validation errors )"):
@@ -113,7 +113,7 @@ VALID_OTHER = [
 ]
 
 
-@pytest.mark.parametrize("relation,value", VALID_OTHER)
+@pytest.mark.parametrize(("relation", "value"), VALID_OTHER)
 def test_other_relations(relation, value):
     Filter(field_name="col", relation=relation, value=value)
 

--- a/src/xngin/apiserver/test_request_encapsulation_middleware.py
+++ b/src/xngin/apiserver/test_request_encapsulation_middleware.py
@@ -52,7 +52,7 @@ def client():
 
 
 @pytest.mark.parametrize(
-    "method,query_path,input_data,expected",
+    ("method", "query_path", "input_data", "expected"),
     [
         (
             "POST",
@@ -89,7 +89,7 @@ def test_unwraps_nested_json_with_http_methods(client, method, query_path, input
 
 
 @pytest.mark.parametrize(
-    "query_path,input_data,expected",
+    ("query_path", "input_data", "expected"),
     [
         ("/message", {"message": "hello world"}, "hello world"),
         ("/nullable", {"nullable": None}, None),
@@ -119,7 +119,7 @@ def test_unwraps_primitive_values(client, query_path, input_data, expected):
 
 
 @pytest.mark.parametrize(
-    "query_path,input_data,expected",
+    ("query_path", "input_data", "expected"),
     [
         ("/text", {"text": ""}, ""),
         ("/obj", {"obj": {}}, {}),
@@ -140,7 +140,7 @@ def test_unwraps_empty_values(client, query_path, input_data, expected):
 
 
 @pytest.mark.parametrize(
-    "query_path,input_data",
+    ("query_path", "input_data"),
     [
         ("data", {"data": "value"}),  # Invalid JSON Pointer (must start with /)
         ("/nonexistent", {"data": "value"}),  # Path doesn't exist
@@ -160,7 +160,7 @@ def test_error_on_invalid_paths(client, query_path, input_data):
 
 
 @pytest.mark.parametrize(
-    "unwrap_param,query_param,query_value,input_data,expected",
+    ("unwrap_param", "query_param", "query_value", "input_data", "expected"),
     [
         (
             "_extract",
@@ -205,7 +205,7 @@ def test_handles_empty_request_body(client):
 
 
 @pytest.mark.parametrize(
-    "query_value,input_key,expected_data",
+    ("query_value", "input_key", "expected_data"),
     [
         ("/foo~1bar", "foo/bar", {"special": "key"}),
         ("/foo~0bar", "foo~bar", {"tilde": "value"}),

--- a/src/xngin/stats/test_bandit_analysis.py
+++ b/src/xngin/stats/test_bandit_analysis.py
@@ -12,7 +12,7 @@ from xngin.stats.test_bandit_sampling import make_experiment_table
 
 
 @pytest.mark.parametrize(
-    "prior_type,reward_type",
+    ("prior_type", "reward_type"),
     [
         (PriorTypes.BETA, LikelihoodTypes.BERNOULLI),
         (PriorTypes.NORMAL, LikelihoodTypes.BERNOULLI),
@@ -48,7 +48,7 @@ def test_mab_analysis(prior_type, reward_type):
 
 
 @pytest.mark.parametrize(
-    "prior_type,reward_type",
+    ("prior_type", "reward_type"),
     [
         (PriorTypes.NORMAL, LikelihoodTypes.BERNOULLI),
         (PriorTypes.NORMAL, LikelihoodTypes.NORMAL),

--- a/src/xngin/stats/test_bandit_weights_to_prior.py
+++ b/src/xngin/stats/test_bandit_weights_to_prior.py
@@ -10,7 +10,7 @@ from xngin.stats.bandit_weights_to_prior import (
 
 
 @pytest.mark.parametrize(
-    "expected_probabilities, expected_alphas",
+    ("expected_probabilities", "expected_alphas"),
     [
         ([12.5, 12.5, 25, 50], [0.174, 0.174, 0.584, 1.0]),
         ([25, 75], [0.344, 1.0]),
@@ -27,7 +27,7 @@ def test_bandit_weights_to_beta_prior(expected_probabilities: list[float], expec
 
 
 @pytest.mark.parametrize(
-    "expected_probabilities, num_dimensions, expected_mus",
+    ("expected_probabilities", "num_dimensions", "expected_mus"),
     [
         ([12.5, 12.5, 25, 50], 1, [-0.815, -0.815, -0.454, 0.0]),
         ([25, 75], 2, [-1.141, 0.0]),
@@ -47,7 +47,7 @@ def test_bandit_weights_to_normal_prior(
 
 
 @pytest.mark.parametrize(
-    "prior_type, expected_params", [(PriorTypes.BETA, [0.344, 1.0]), (PriorTypes.NORMAL, [-0.872, 0.0])]
+    ("prior_type", "expected_params"), [(PriorTypes.BETA, [0.344, 1.0]), (PriorTypes.NORMAL, [-0.872, 0.0])]
 )
 def test_convert_bandit_weights_to_prior_params(prior_type: PriorTypes, expected_params: list[float]):
     arm_weights = [25.0, 75.0]

--- a/src/xngin/stats/test_cluster_power.py
+++ b/src/xngin/stats/test_cluster_power.py
@@ -124,7 +124,7 @@ class TestCalculateDesignEffect:
         assert deft_ratio == pytest.approx(mde_ratio, rel=0.01)
 
     @pytest.mark.parametrize(
-        "icc, avg_cluster_size, cv, expected",
+        ("icc", "avg_cluster_size", "cv", "expected"),
         [
             pytest.param(0.0, 30, 0.0, 1.0, id="no_clustering"),
             pytest.param(1.0, 30, 0.0, 30.0, id="perfect_clustering"),
@@ -142,7 +142,7 @@ class TestCalculateDesignEffect:
         assert deff == expected
 
     @pytest.mark.parametrize(
-        "icc, avg_cluster_size, cv, expected_error",
+        ("icc", "avg_cluster_size", "cv", "expected_error"),
         [
             pytest.param(1.5, 30, 0.0, "ICC must be between 0 and 1, got 1.5", id="invalid_icc"),
             pytest.param(0.15, 0, 0.0, "Cluster size must be >= 1, got 0", id="invalid_cluster_size"),
@@ -676,7 +676,7 @@ def test_solve_for_sample_size_cluster_cv_affects_all_arms():
 
 
 @pytest.mark.parametrize(
-    "cv,expected_warning",
+    ("cv", "expected_warning"),
     [(0, None), (1.0, None), (1.5, "Warning: High cluster size variation (CV=1.50)")],
 )
 def test_solve_for_sample_size_cluster_cv_warning_message(cv: float, expected_warning: str | None):

--- a/src/xngin/stats/test_power.py
+++ b/src/xngin/stats/test_power.py
@@ -43,7 +43,7 @@ def test_analyze_metric_power_numeric():
 
 
 @pytest.mark.parametrize(
-    "available_nonnull_n,available_n,target_possible",
+    ("available_nonnull_n", "available_n", "target_possible"),
     [
         (789, 789, 23.8468),
         (104, 789, 42.9997),

--- a/src/xngin/xsecrets/test_gcp_kms_provider.py
+++ b/src/xngin/xsecrets/test_gcp_kms_provider.py
@@ -116,7 +116,7 @@ def test_unpack_envelope_ciphertext_invalid_format():
 
 
 @pytest.mark.parametrize(
-    "encrypted_dek,encrypted_data",
+    ("encrypted_dek", "encrypted_data"),
     [
         (b"", b""),
         (b"short_dek", b"short_data"),
@@ -152,7 +152,7 @@ def test_pack_envelope_ciphertext_large_dek():
 # Integration tests
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    "plaintext,aad",
+    ("plaintext", "aad"),
     [
         (b"", b""),
         (b"", b"some_aad"),

--- a/src/xngin/xsecrets/test_secretservice.py
+++ b/src/xngin/xsecrets/test_secretservice.py
@@ -15,7 +15,7 @@ from xngin.xsecrets.secretservice import (
 
 
 @pytest.mark.parametrize(
-    "backend,ciphertext",
+    ("backend", "ciphertext"),
     [
         ("test_backend", b"encrypted_data"),
         (
@@ -87,7 +87,7 @@ def fixture_nacl_secretservice():
 
 
 @pytest.mark.parametrize(
-    "plaintext,aad",
+    ("plaintext", "aad"),
     [
         ("This is a secret value", "test_context"),
         ("Unicode text with emojis 😀🔑🌍 and special chars €£¥", "unicode_test"),
@@ -112,7 +112,7 @@ def test_secretservice_encrypt_decrypt(nacl_secretservice, plaintext, aad):
 
 
 @pytest.mark.parametrize(
-    "plaintext,aad",
+    ("plaintext", "aad"),
     [
         ("This is not an encrypted value", "any_context"),
         ("", "empty_plaintext_test"),  # Test with empty plaintext
@@ -128,7 +128,7 @@ def test_secretservice_decrypt_unencrypted_value(nacl_secretservice, plaintext, 
 
 
 @pytest.mark.parametrize(
-    "plaintext,correct_aad,wrong_aad",
+    ("plaintext", "correct_aad", "wrong_aad"),
     [
         ("Secret message", "correct_context", "wrong_context"),
         ("", "correct_context", "wrong_context"),  # Empty plaintext


### PR DESCRIPTION
Enables Ruff's [PT006](https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/). The primary benefit is more consistent in-IDE type checking and code consistency.
