### PR TITLE
Enable Ruff FURB101, FURB103, FURB140 lints.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,9 +129,6 @@ select = [
 ]
 ignore = [
     "E266", # Too many leading `#` before block comment
-    "FURB101", # `open` and `read` should be replaced by `Path(file).read_text()`
-    "FURB103", # `open` and `write` should be replaced by `Path(filename)....`
-    "FURB140", # Use `itertools.starmap` instead of the generator
     "FURB152", # replace values that resemble mathemematical constants with constants (e.g. 3.14 => math.pi)
     "PD002", # `inplace=True` should be avoided; it has inconsistent behavior
     "PD003", # `.isna` is preferred to `.isnull`; functionality is equivalent"

--- a/src/xngin/apiserver/conftest.py
+++ b/src/xngin/apiserver/conftest.py
@@ -9,6 +9,7 @@ import os
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, assert_never, cast
 
 import pytest
@@ -427,8 +428,7 @@ def _convert_dwh_to_create_api_dsn(dwh: settings.Dwh) -> aapi.Dsn:
                 case settings.GcpServiceAccountInfo():
                     credentials_content = base64.standard_b64decode(dwh.credentials.content_base64).decode()
                 case settings.GcpServiceAccountFile():
-                    with open(dwh.credentials.path, encoding="utf-8") as credentials_file:
-                        credentials_content = credentials_file.read()
+                    credentials_content = Path(dwh.credentials.path).read_text(encoding="utf-8")
                 case _:
                     raise TypeError(f"Unsupported BigQuery credentials type: {type(dwh.credentials).__name__}")
             return aapi.BqDsn(

--- a/src/xngin/apiserver/routers/auth/token_cryptor.py
+++ b/src/xngin/apiserver/routers/auth/token_cryptor.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from pydantic import ValidationError
 
@@ -11,8 +12,7 @@ LOCAL_KEYSET_SENTINEL = "local"
 def _read_local_keyset(local_keyset_filename: str) -> str:
     """Development environments may use a key in the local filesystem."""
     try:
-        with open(local_keyset_filename) as f:
-            return f.read()
+        return Path(local_keyset_filename).read_text()
     except OSError as err:
         raise TokenCryptorMisconfiguredError(f"The {local_keyset_filename} file cannot be read.") from err
 

--- a/src/xngin/cli/main.py
+++ b/src/xngin/cli/main.py
@@ -284,8 +284,7 @@ def create_testing_dwh(
         ddl_file = re.sub(r"[.]csv([.]zst)?$", f".{flavor}.ddl", str(src))
         if Path(ddl_file).exists():
             print(f"Using provided DDL from {ddl_file}")
-            with open(ddl_file) as inp:
-                ddl = inp.read().replace("{{table_name}}", full_table_name)
+            ddl = Path(ddl_file).read_text().replace("{{table_name}}", full_table_name)
         else:
             print("Using inferred DDL (warning: may lose fidelity!)")
             ddl = df_to_ddl(
@@ -425,9 +424,8 @@ def export_json_schemas(output: Path = Path(".schemas")):
         output.mkdir()
     for model in (ParticipantsSchema, Datasource):
         filename = output / (model.__name__ + ".schema.json")
-        with open(filename, "w") as outf:
-            outf.write(json.dumps(model.model_json_schema(), indent=2, sort_keys=True))
-            print(f"Wrote {filename}.")
+        filename.write_text(json.dumps(model.model_json_schema(), indent=2, sort_keys=True))
+        print(f"Wrote {filename}.")
 
 
 @app.command()


### PR DESCRIPTION
This brings our Python file I/O up to modern Python conventions.
