### PR TITLE
Add clustered assignment support to preassigned freq experiment creation.

### DIFF
--- a/src/xngin/apiserver/routers/assignment_adapters.py
+++ b/src/xngin/apiserver/routers/assignment_adapters.py
@@ -65,6 +65,7 @@ def assign_treatments_with_balance(
     quantiles: int = 4,
     random_state: int | None = None,
     arm_weights: list[float] | None = None,
+    cluster_col: str | None = None,
 ) -> AssignmentResult:
     """
     Perform stratified random assignment and balance checking.
@@ -80,6 +81,7 @@ def assign_treatments_with_balance(
         quantiles: number of buckets to use for stratification of numerics
         random_state: Random seed for reproducibility
         arm_weights: Optional list of weights (summing to 100) for unbalanced arm allocation
+        cluster_col: Optional cluster identifier column. When set, assignment is at cluster level.
 
     Returns:
         AssignmentResult containing assignments and balance check results
@@ -101,6 +103,7 @@ def assign_treatments_with_balance(
         quantiles=quantiles,
         random_state=random_state,
         arm_weights=arm_weights,
+        cluster_col=cluster_col,
     )
 
 

--- a/src/xngin/apiserver/routers/common_api_types.py
+++ b/src/xngin/apiserver/routers/common_api_types.py
@@ -973,6 +973,8 @@ class BaseFrequentistDesignSpec(BaseDesignSpec):
         """Validate that the strata are valid."""
         if any(stratum.field_name == self.primary_key for stratum in self.strata):
             raise ValueError(f"Primary key {self.primary_key} cannot be used in strata.")
+        if self.cluster_key is not None and self.strata:
+            raise ValueError("Cluster-randomized frequentist designs cannot also set strata.")
         return self
 
 

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -217,12 +217,15 @@ async def create_experiment_impl(
             metric_names = [m.field_name for m in request.design_spec.metrics]
             strata_names = [s.field_name for s in request.design_spec.strata]
             stratum_cols = strata_names + metric_names if stratify_on_metrics else strata_names
+            select_columns = {*stratum_cols, primary_key}
+            if preassigned_spec.cluster_key is not None:
+                select_columns.add(preassigned_spec.cluster_key)
 
             ds_config = datasource.get_config()
             async with DwhSession(ds_config.dwh) as dwh:
                 result = await dwh.get_participants(
                     table_name,
-                    select_columns={*stratum_cols, primary_key},
+                    select_columns=select_columns,
                     filters=request.design_spec.filters,
                     n=desired_n,
                 )
@@ -318,6 +321,7 @@ async def create_preassigned_experiment_impl(
         quantiles=4,
         random_state=random_state,
         arm_weights=arm_weights,
+        cluster_col=design_spec.cluster_key,
     )
     balance_check = make_balance_check(assignment_result.balance_result, design_spec.fstat_thresh)
 

--- a/src/xngin/apiserver/routers/experiments/test_experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_common.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from contextlib import AbstractContextManager
 from contextlib import nullcontext as does_not_raise
 from dataclasses import dataclass
@@ -15,6 +16,7 @@ from sqlalchemy.orm import selectinload
 from sqlalchemy.schema import CreateTable
 
 from xngin.apiserver.conftest import RowProtocolMixin
+from xngin.apiserver.dwh.dwh_session import DwhSession
 from xngin.apiserver.exceptions_common import LateValidationError
 from xngin.apiserver.routers.common_api_types import (
     Arm,
@@ -199,6 +201,27 @@ def make_createexperimentrequest_json(
             }
         case _:
             raise ValueError(f"Invalid experiment type: {experiment_type}")
+
+
+def make_design_spec_clustered(*, cluster_key: str | None = "cluster_equal") -> PreassignedFrequentistExperimentSpec:
+    return PreassignedFrequentistExperimentSpec(
+        experiment_type=ExperimentsType.FREQ_PREASSIGNED,
+        experiment_name="cluster analyze test",
+        description="test",
+        table_name="clustered_dwh",
+        primary_key="participant_id",
+        cluster_key=cluster_key,
+        start_date=datetime(2024, 1, 1, tzinfo=UTC),
+        end_date=datetime(2024, 12, 31, 23, 59, 59, tzinfo=UTC),
+        arms=[Arm(arm_name="control", arm_description="C"), Arm(arm_name="treatment", arm_description="T")],
+        strata=[],
+        metrics=[DesignSpecMetricRequest(field_name="test_score", metric_pct_change=0.1)],
+        filters=[],
+        desired_n=100,
+        power=0.8,
+        alpha=0.05,
+        fstat_thresh=0.2,
+    )
 
 
 def make_create_preassigned_experiment_request(desired_n: int | None = None) -> CreateExperimentRequest:
@@ -631,6 +654,56 @@ async def test_create_preassigned_experiment_impl(
     num_treat = sum(1 for a in assignments if a.arm_id == arm2_id)
     # Allow for group sizes to be unequal by up to 2.
     assert abs(num_control - num_treat) <= 2
+
+
+async def test_create_preassigned_experiment_impl_cluster_assignment(xngin_session, testing_datasource):
+    """Preassigned create with cluster_key assigns all members of a cluster to the same arm."""
+    design_spec = make_design_spec_clustered()
+    request = CreateExperimentRequest(design_spec=design_spec)
+    field_type_map = await fetch_fields_or_raise(testing_datasource.ds, design_spec)
+    assert design_spec.desired_n is not None
+    assert design_spec.cluster_key is not None
+
+    async with DwhSession(testing_datasource.ds.get_config().dwh) as dwh:
+        participant_result = await dwh.get_participants(
+            design_spec.table_name,
+            select_columns={design_spec.primary_key, design_spec.cluster_key, "test_score"},
+            filters=design_spec.filters,
+            n=design_spec.desired_n,
+        )
+        sa_table = participant_result.sa_table
+        dwh_participants = participant_result.participants
+
+    assert dwh_participants is not None
+    response = await create_preassigned_experiment_impl(
+        request=request,
+        datasource_id=testing_datasource.ds.id,
+        organization_id=testing_datasource.ds.organization_id,
+        dwh_sa_table=sa_table,
+        dwh_participants=dwh_participants,
+        random_state=42,
+        xngin_session=xngin_session,
+        stratify_on_metrics=False,
+        validated_webhooks=[],
+        field_type_map=field_type_map,
+    )
+
+    # Verify that each participant in a cluster was assigned to the same arm.
+    assignment_rows = (
+        await xngin_session.scalars(
+            select(tables.ArmAssignment).where(tables.ArmAssignment.experiment_id == response.experiment_id)
+        )
+    ).all()
+    arm_by_participant = {row.participant_id: row.arm_id for row in assignment_rows}
+    arms_by_cluster: dict[str, set[str]] = defaultdict(set)
+    for participant in dwh_participants:
+        participant_id = str(getattr(participant, design_spec.primary_key))
+        cluster_id = str(getattr(participant, design_spec.cluster_key))
+        arms_by_cluster[cluster_id].add(arm_by_participant[participant_id])
+
+    assert len(arms_by_cluster) > 1
+    assert all(len(arm_ids) == 1 for arm_ids in arms_by_cluster.values())
+    assert len(set.union(*arms_by_cluster.values())) == 2
 
 
 async def test_create_preassigned_experiment_impl_raises_on_duplicate_ids(

--- a/src/xngin/apiserver/routers/test_assignment_adapters.py
+++ b/src/xngin/apiserver/routers/test_assignment_adapters.py
@@ -210,6 +210,49 @@ def test_assign_treatments_with_balance_basic(sample_table, sample_rows):
     assert result.balance_result.f_pvalue == pytest.approx(0.99990, abs=1e-4)
 
 
+@dataclass
+class ClusterRow(RowProtocolMixin):
+    id: int
+    cluster: int
+    age: float
+    region: str
+
+
+def test_assign_treatments_with_balance_clustered():
+    """Cluster column assigns every member of a cluster to the same arm."""
+    cluster_ids = [0, 0, 0, 1, 1, 1]
+    rows = [
+        ClusterRow(id=i, cluster=cluster_id, age=30.0, region="North")
+        for i, cluster_id in enumerate(cluster_ids, start=1)
+    ]
+    metadata_obj = MetaData()
+    table = Table(
+        "clustered",
+        metadata_obj,
+        Column("id", Integer, primary_key=True),
+        Column("cluster", Integer),
+    )
+
+    result = assign_treatments_with_balance(
+        sa_table=table,
+        data=rows,
+        stratum_cols=["region"],
+        id_col="id",
+        n_arms=2,
+        random_state=42,
+        cluster_col="cluster",
+    )
+
+    # Strata are ignored in a cluster-randomized design.
+    assert result.stratum_cols == []
+    # Verify that each member of a cluster is assigned to the same treatment.
+    treatments_by_cluster: dict[int, set[int]] = defaultdict(set)
+    for cluster_id, treatment in zip(cluster_ids, result.treatment_ids, strict=True):
+        treatments_by_cluster[cluster_id].add(treatment)
+    assert treatments_by_cluster[0] == {0}
+    assert treatments_by_cluster[1] == {1}
+
+
 async def test_bulk_insert_arm_assignments_basic(
     xngin_session: AsyncSession,
     testing_datasource: DatasourceMetadata,

--- a/src/xngin/apiserver/routers/test_common_api_types.py
+++ b/src/xngin/apiserver/routers/test_common_api_types.py
@@ -209,3 +209,26 @@ def test_arm_weights_validation():
         match=r"(?s)Input should be a finite number.*Input should be a finite number",
     ):
         PreassignedFrequentistExperimentSpec.model_validate(invalid_inf)
+
+
+def test_cluster_key_and_strata_are_mutually_exclusive():
+    valid_spec = {
+        "experiment_type": "freq_preassigned",
+        "experiment_name": "test",
+        "description": "test",
+        "table_name": "dwh",
+        "primary_key": "id",
+        "cluster_key": "school_id",
+        "start_date": "2024-01-01T00:00:00+00:00",
+        "end_date": "2024-12-31T00:00:00+00:00",
+        "arms": [
+            {"arm_name": "C", "arm_description": "C"},
+            {"arm_name": "T", "arm_description": "T"},
+        ],
+        "strata": [{"field_name": "country"}],
+        "metrics": [{"field_name": "metric1", "metric_pct_change": 0.1}],
+        "filters": [],
+    }
+
+    with pytest.raises(ValidationError, match="Cluster-randomized frequentist designs cannot also set strata"):
+        PreassignedFrequentistExperimentSpec.model_validate(valid_spec)


### PR DESCRIPTION
## Description

Wire cluster_key into preassigned experiment assignment.
Also add extra validator on BaseFrequentistDesignSpec to ensure new experiment requests don't accidentally set strata on cluster designs for now.

Followup to #163 as part of issue #217.

## Future Tasks

Support analysis of clustered designs in API endpoint.

## How has this been tested?

unittests
