### PR TITLE
Allow users to re-trigger outbound webhooks.

### DIFF
--- a/src/xngin/apiserver/routers/admin/admin_api.py
+++ b/src/xngin/apiserver/routers/admin/admin_api.py
@@ -143,7 +143,9 @@ from xngin.apiserver.settings import (
 from xngin.apiserver.snapshots import snapshotter
 from xngin.apiserver.sqla import tables
 from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter
+from xngin.events.webhook_sent import WebhookSentEvent
 from xngin.stats import check_power
+from xngin.tq.task_payload_types import WEBHOOK_OUTBOUND_TASK_TYPE
 
 GENERIC_SUCCESS = Response(status_code=status.HTTP_204_NO_CONTENT)
 RESPONSE_CACHE_MAX_AGE_SECONDS = timedelta(minutes=15).seconds
@@ -783,6 +785,35 @@ def convert_events_to_eventsummaries(events):
             )
         )
     return event_summaries
+
+
+@router.post(
+    "/organizations/{organization_id}/events/{event_id}/resend",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def resend_organization_event(
+    organization_id: str,
+    event_id: str,
+    session: Annotated[AsyncSession, Depends(xngin_db_session)],
+    user: Annotated[tables.User, Depends(require_user_from_token)],
+):
+    """Re-enqueues the outbound webhook task that produced a webhook.sent event."""
+    org = await get_organization_or_raise(session, user, organization_id)
+    event = await session.get(tables.Event, event_id)
+    if event is None or event.organization_id != org.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found.")
+    data = event.get_data()
+    if not isinstance(data, WebhookSentEvent):
+        # Only webhook.sent events can be resent.
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event type cannot be resent.")
+    session.add(
+        tables.Task(
+            task_type=WEBHOOK_OUTBOUND_TASK_TYPE,
+            payload=data.request.model_dump(),
+        )
+    )
+    await session.commit()
+    return GENERIC_SUCCESS
 
 
 @router.post("/organizations/{organization_id}/members", status_code=status.HTTP_204_NO_CONTENT)

--- a/src/xngin/apiserver/routers/admin/admin_api.py
+++ b/src/xngin/apiserver/routers/admin/admin_api.py
@@ -781,7 +781,7 @@ def convert_events_to_eventsummaries(events):
                 type=event.type,
                 summary=data.summarize() if data else "Unknown",
                 link=data.link() if data else None,
-                details=data.model_dump() if data else None,
+                details=data.sanitize().model_dump() if data else None,
             )
         )
     return event_summaries

--- a/src/xngin/apiserver/routers/admin/admin_api.py
+++ b/src/xngin/apiserver/routers/admin/admin_api.py
@@ -782,6 +782,7 @@ def convert_events_to_eventsummaries(events):
                 summary=data.summarize() if data else "Unknown",
                 link=data.link() if data else None,
                 details=data.sanitize().model_dump() if data else None,
+                status_icon=data.status_icon() if data else "info",
             )
         )
     return event_summaries

--- a/src/xngin/apiserver/routers/admin/admin_api_types.py
+++ b/src/xngin/apiserver/routers/admin/admin_api_types.py
@@ -138,6 +138,10 @@ class EventSummary(AdminApiBaseModel):
     summary: Annotated[str, Field(description="Human-readable summary of the event.")]
     link: Annotated[str | None, Field(description="A navigable link to related information.")] = None
     details: Annotated[dict | None, Field(description="Details")]
+    status_icon: Annotated[
+        Literal["success", "info", "failure"],
+        Field(description="Status icon to display for this event."),
+    ] = "info"
 
 
 class ListOrganizationEventsResponse(PaginatedResponse, AdminApiBaseModel):

--- a/src/xngin/apiserver/routers/admin/test_admin_api.py
+++ b/src/xngin/apiserver/routers/admin/test_admin_api.py
@@ -18,7 +18,7 @@ from sqlalchemy import select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from xngin.apiserver import flags
+from xngin.apiserver import constants, flags
 from xngin.apiserver.conftest import delete_seeded_users, expect_status_code
 from xngin.apiserver.dns import safe_resolve
 from xngin.apiserver.dwh.inspection_types import FieldDescriptor, ParticipantsSchema
@@ -3994,7 +3994,14 @@ async def test_list_organization_events_pagination_with_same_timestamp_is_id_des
     assert page2.items[0].created_at == tied_created_at
 
 
-async def _insert_webhook_sent_event(xngin_session: AsyncSession, organization_id: str) -> tuple[str, dict]:
+_PERSISTED_WEBHOOK_TOKEN = "sample-token"
+
+
+async def _insert_webhook_sent_event(
+    xngin_session: AsyncSession,
+    organization_id: str,
+    webhook_token_header: str = constants.HEADER_WEBHOOK_TOKEN,
+) -> tuple[str, dict]:
     """Inserts a webhook.sent event for the given org. Returns (event_id, expected_outbound_payload).
 
     Done via direct insert because the only way to produce a webhook.sent event in production is to run the
@@ -4004,7 +4011,7 @@ async def _insert_webhook_sent_event(xngin_session: AsyncSession, organization_i
         organization_id=organization_id,
         url="https://example.com/webhook",
         body={"hello": "world"},
-        headers={"x-auth": "secret"},
+        headers={webhook_token_header: _PERSISTED_WEBHOOK_TOKEN},
     )
     event = tables.Event(organization_id=organization_id, type=WebhookSentEvent.TYPE).set_data(
         WebhookSentEvent(request=outbound, success=False, response="boom")
@@ -4015,7 +4022,7 @@ async def _insert_webhook_sent_event(xngin_session: AsyncSession, organization_i
 
 
 async def test_resend_organization_event_enqueues_task(xngin_session: AsyncSession, aclient: AdminAPIClient):
-    """Resending a webhook.sent event inserts a webhook.outbound task with the original payload."""
+    """Resending a webhook.sent event inserts a webhook.outbound task with the original (unredacted) payload."""
     org_id = aclient.create_organizations(body=CreateOrganizationRequest(name="resend-happy")).data.id
     event_id, expected_payload = await _insert_webhook_sent_event(xngin_session, org_id)
 
@@ -4025,8 +4032,30 @@ async def test_resend_organization_event_enqueues_task(xngin_session: AsyncSessi
         await xngin_session.scalars(select(tables.Task).where(tables.Task.task_type == WEBHOOK_OUTBOUND_TASK_TYPE))
     )
     assert len(tasks) == 1
-    assert tasks[0].payload == expected_payload
     assert tasks[0].status == "pending"
+    # The new task carries the original payload verbatim, including the unredacted auth token, so the downstream
+    # webhook receives the same authenticated request as the original.
+    assert tasks[0].payload == expected_payload
+    assert tasks[0].payload["headers"][constants.HEADER_WEBHOOK_TOKEN] == _PERSISTED_WEBHOOK_TOKEN
+
+
+@pytest.mark.parametrize(
+    "webhook_token_header",
+    [constants.HEADER_WEBHOOK_TOKEN, constants.HEADER_WEBHOOK_TOKEN.lower()],
+)
+async def test_list_organization_events_redacts_webhook_token(
+    xngin_session: AsyncSession,
+    aclient: AdminAPIClient,
+    webhook_token_header: str,
+):
+    """The webhook.sent event details surfaced by the API mask the webhook token header."""
+    org_id = aclient.create_organizations(body=CreateOrganizationRequest(name="resend-redact")).data.id
+    event_id, _ = await _insert_webhook_sent_event(xngin_session, org_id, webhook_token_header=webhook_token_header)
+
+    events = aclient.list_organization_events(organization_id=org_id).data.items
+    event = next(ev for ev in events if ev.id == event_id)
+    assert event.details is not None
+    assert event.details["request"]["headers"][webhook_token_header] == "***"
 
 
 async def test_resend_organization_event_rejects_non_webhook_event(

--- a/src/xngin/apiserver/routers/admin/test_admin_api.py
+++ b/src/xngin/apiserver/routers/admin/test_admin_api.py
@@ -3890,6 +3890,9 @@ def test_list_organization_events_pagination(testing_datasource, aclient: AdminA
     all_events = aclient.list_organization_events(organization_id=org_id).data
     total = len(all_events.items)
     assert total >= 3
+    experiment_created_events = [ev for ev in all_events.items if ev.type == "experiment.created"]
+    assert experiment_created_events
+    assert all(ev.status_icon == "info" for ev in experiment_created_events)
 
     # Page through with page_size=1
     page1 = aclient.list_organization_events(organization_id=org_id, page_size=1).data
@@ -4056,6 +4059,7 @@ async def test_list_organization_events_redacts_webhook_token(
     event = next(ev for ev in events if ev.id == event_id)
     assert event.details is not None
     assert event.details["request"]["headers"][webhook_token_header] == "***"
+    assert event.status_icon == "failure"
 
 
 async def test_resend_organization_event_rejects_non_webhook_event(

--- a/src/xngin/apiserver/routers/admin/test_admin_api.py
+++ b/src/xngin/apiserver/routers/admin/test_admin_api.py
@@ -103,7 +103,10 @@ from xngin.apiserver.storage.storage_format_converters import ExperimentStorageC
 from xngin.apiserver.testing.admin_api_client import AdminAPIClient
 from xngin.apiserver.testing.experiments_api_client import ExperimentsAPIClient
 from xngin.apiserver.testing.testing_dwh_def import TESTING_DWH_PARTICIPANT_DEF
+from xngin.events.experiment_created import ExperimentCreatedEvent
+from xngin.events.webhook_sent import WebhookSentEvent
 from xngin.stats.bandit_sampling import update_arm
+from xngin.tq.task_payload_types import WEBHOOK_OUTBOUND_TASK_TYPE, WebhookOutboundTask
 
 SAMPLE_GCLOUD_SERVICE_ACCOUNT = {
     "auth_provider_x509_cert_url": "",
@@ -3989,6 +3992,73 @@ async def test_list_organization_events_pagination_with_same_timestamp_is_id_des
     assert page2.items[0].id == expected_tied_order[1]
     assert page2.items[0].id != page1.items[0].id
     assert page2.items[0].created_at == tied_created_at
+
+
+async def _insert_webhook_sent_event(xngin_session: AsyncSession, organization_id: str) -> tuple[str, dict]:
+    """Inserts a webhook.sent event for the given org. Returns (event_id, expected_outbound_payload).
+
+    Done via direct insert because the only way to produce a webhook.sent event in production is to run the
+    task queue, which we don't want tests to depend on.
+    """
+    outbound = WebhookOutboundTask(
+        organization_id=organization_id,
+        url="https://example.com/webhook",
+        body={"hello": "world"},
+        headers={"x-auth": "secret"},
+    )
+    event = tables.Event(organization_id=organization_id, type=WebhookSentEvent.TYPE).set_data(
+        WebhookSentEvent(request=outbound, success=False, response="boom")
+    )
+    xngin_session.add(event)
+    await xngin_session.commit()
+    return event.id, outbound.model_dump()
+
+
+async def test_resend_organization_event_enqueues_task(xngin_session: AsyncSession, aclient: AdminAPIClient):
+    """Resending a webhook.sent event inserts a webhook.outbound task with the original payload."""
+    org_id = aclient.create_organizations(body=CreateOrganizationRequest(name="resend-happy")).data.id
+    event_id, expected_payload = await _insert_webhook_sent_event(xngin_session, org_id)
+
+    aclient.resend_organization_event(organization_id=org_id, event_id=event_id)
+
+    tasks = list(
+        await xngin_session.scalars(select(tables.Task).where(tables.Task.task_type == WEBHOOK_OUTBOUND_TASK_TYPE))
+    )
+    assert len(tasks) == 1
+    assert tasks[0].payload == expected_payload
+    assert tasks[0].status == "pending"
+
+
+async def test_resend_organization_event_rejects_non_webhook_event(
+    xngin_session: AsyncSession, aclient: AdminAPIClient
+):
+    """Resending an experiment.created event returns 404 (only webhook.sent events can be resent)."""
+    org_id = aclient.create_organizations(body=CreateOrganizationRequest(name="resend-non-webhook")).data.id
+    event = tables.Event(organization_id=org_id, type=ExperimentCreatedEvent.TYPE).set_data(
+        ExperimentCreatedEvent(datasource_id=None, experiment_id="exp_abc")
+    )
+    xngin_session.add(event)
+    await xngin_session.commit()
+
+    with expect_status_code(404, text="cannot be resent"):
+        aclient.resend_organization_event(organization_id=org_id, event_id=event.id)
+
+
+async def test_resend_organization_event_missing_event(aclient: AdminAPIClient):
+    """Resending an unknown event id returns 404."""
+    org_id = aclient.create_organizations(body=CreateOrganizationRequest(name="resend-missing")).data.id
+    with expect_status_code(404, text="Event not found"):
+        aclient.resend_organization_event(organization_id=org_id, event_id="evt_does_not_exist")
+
+
+async def test_resend_organization_event_cross_org_isolation(xngin_session: AsyncSession, aclient: AdminAPIClient):
+    """An event id from org A cannot be resent through org B's URL, even by a member of both orgs."""
+    org_a_id = aclient.create_organizations(body=CreateOrganizationRequest(name="resend-cross-org-a")).data.id
+    org_b_id = aclient.create_organizations(body=CreateOrganizationRequest(name="resend-cross-org-b")).data.id
+    event_id, _ = await _insert_webhook_sent_event(xngin_session, org_a_id)
+
+    with expect_status_code(404, text="Event not found"):
+        aclient.resend_organization_event(organization_id=org_b_id, event_id=event_id)
 
 
 async def test_list_experiments(

--- a/src/xngin/apiserver/testing/admin_api_client.py
+++ b/src/xngin/apiserver/testing/admin_api_client.py
@@ -1433,6 +1433,88 @@ class AdminAPIClient:  # noqa: RUF100,PLR0904
         )
 
     @overload
+    def resend_organization_event(
+        self,
+        *,
+        organization_id: str,
+        event_id: str,
+        raise_if_not_default_status: Literal[True] = True,
+        client_exts: AdminAPIClientExtensions | None = None,
+    ) -> AdminAPIClientResult[Literal[HTTPStatus.NO_CONTENT], None, None]: ...
+    @overload
+    def resend_organization_event(
+        self,
+        *,
+        organization_id: str,
+        event_id: str,
+        raise_if_not_default_status: Literal[False],
+        client_exts: AdminAPIClientExtensions | None = None,
+    ) -> (
+        AdminAPIClientResult[Literal[HTTPStatus.NO_CONTENT], None, None]
+        | AdminAPIClientResult[Literal[HTTPStatus.BAD_REQUEST], HTTPExceptionError, type[HTTPExceptionError]]
+        | AdminAPIClientResult[Literal[HTTPStatus.UNAUTHORIZED], HTTPExceptionError, type[HTTPExceptionError]]
+        | AdminAPIClientResult[Literal[HTTPStatus.FORBIDDEN], HTTPExceptionError, type[HTTPExceptionError]]
+        | AdminAPIClientResult[Literal[HTTPStatus.NOT_FOUND], HTTPExceptionError, type[HTTPExceptionError]]
+        | AdminAPIClientResult[
+            Literal[HTTPStatus.UNPROCESSABLE_CONTENT],
+            AdminAPIClientHTTPValidationError,
+            type[AdminAPIClientHTTPValidationError],
+        ]
+    ): ...
+    def resend_organization_event(
+        self,
+        *,
+        organization_id: str,
+        event_id: str,
+        raise_if_not_default_status: bool = True,
+        client_exts: AdminAPIClientExtensions | None = None,
+    ) -> (
+        AdminAPIClientResult[Literal[HTTPStatus.NO_CONTENT], None, None]
+        | AdminAPIClientResult[Literal[HTTPStatus.BAD_REQUEST], HTTPExceptionError, type[HTTPExceptionError]]
+        | AdminAPIClientResult[Literal[HTTPStatus.UNAUTHORIZED], HTTPExceptionError, type[HTTPExceptionError]]
+        | AdminAPIClientResult[Literal[HTTPStatus.FORBIDDEN], HTTPExceptionError, type[HTTPExceptionError]]
+        | AdminAPIClientResult[Literal[HTTPStatus.NOT_FOUND], HTTPExceptionError, type[HTTPExceptionError]]
+        | AdminAPIClientResult[
+            Literal[HTTPStatus.UNPROCESSABLE_CONTENT],
+            AdminAPIClientHTTPValidationError,
+            type[AdminAPIClientHTTPValidationError],
+        ]
+    ):
+        return cast(
+            (
+                AdminAPIClientResult[Literal[HTTPStatus.NO_CONTENT], None, None]
+                | AdminAPIClientResult[Literal[HTTPStatus.BAD_REQUEST], HTTPExceptionError, type[HTTPExceptionError]]
+                | AdminAPIClientResult[Literal[HTTPStatus.UNAUTHORIZED], HTTPExceptionError, type[HTTPExceptionError]]
+                | AdminAPIClientResult[Literal[HTTPStatus.FORBIDDEN], HTTPExceptionError, type[HTTPExceptionError]]
+                | AdminAPIClientResult[Literal[HTTPStatus.NOT_FOUND], HTTPExceptionError, type[HTTPExceptionError]]
+                | AdminAPIClientResult[
+                    Literal[HTTPStatus.UNPROCESSABLE_CONTENT],
+                    AdminAPIClientHTTPValidationError,
+                    type[AdminAPIClientHTTPValidationError],
+                ]
+            ),
+            self._route_handler(
+                path="/v1/m/organizations/{organization_id}/events/{event_id}/resend",  # noqa: RUF100,RUF027
+                method=HTTPMethod.POST,
+                default_status=HTTPStatus.NO_CONTENT,
+                models={
+                    HTTPStatus.NO_CONTENT: None,
+                    HTTPStatus.BAD_REQUEST: HTTPExceptionError,
+                    HTTPStatus.UNAUTHORIZED: HTTPExceptionError,
+                    HTTPStatus.FORBIDDEN: HTTPExceptionError,
+                    HTTPStatus.NOT_FOUND: HTTPExceptionError,
+                    HTTPStatus.UNPROCESSABLE_CONTENT: AdminAPIClientHTTPValidationError,
+                },
+                path_params={
+                    "organization_id": organization_id,
+                    "event_id": event_id,
+                },
+                raise_if_not_default_status=raise_if_not_default_status,
+                client_exts=client_exts,
+            ),
+        )
+
+    @overload
     def add_member_to_organization(
         self,
         *,

--- a/src/xngin/events/common.py
+++ b/src/xngin/events/common.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict
 
 
@@ -8,6 +10,10 @@ class BaseEventModel(BaseModel):
     """
 
     model_config = ConfigDict(extra="forbid")
+
+    def status_icon(self) -> Literal["success", "info", "failure"]:
+        """Returns the status icon to display for this event in the UI."""
+        return "info"
 
     def summarize(self) -> str:
         """Returns a human-readable one-sentence summary of this event."""

--- a/src/xngin/events/common.py
+++ b/src/xngin/events/common.py
@@ -19,3 +19,7 @@ class BaseEventModel(BaseModel):
         This is displayed in the UI so it may be an absolute path in the Dash UI.
         """
         return None
+
+    def sanitize(self):
+        """Sanitizes the event for display in the UI."""
+        return self

--- a/src/xngin/events/webhook_sent.py
+++ b/src/xngin/events/webhook_sent.py
@@ -21,3 +21,6 @@ class WebhookSentEvent(BaseEventModel):
         else:
             summary += " (failed)"
         return summary
+
+    def sanitize(self):
+        return self.model_copy(update={"request": self.request.sanitize()})

--- a/src/xngin/events/webhook_sent.py
+++ b/src/xngin/events/webhook_sent.py
@@ -22,5 +22,8 @@ class WebhookSentEvent(BaseEventModel):
             summary += " (failed)"
         return summary
 
+    def status_icon(self) -> Literal["success", "info", "failure"]:
+        return "success" if self.success else "failure"
+
     def sanitize(self):
         return self.model_copy(update={"request": self.request.sanitize()})

--- a/src/xngin/tq/task_payload_types.py
+++ b/src/xngin/tq/task_payload_types.py
@@ -4,7 +4,10 @@ from typing import Literal
 
 from pydantic import BaseModel
 
+from xngin.apiserver.constants import HEADER_WEBHOOK_TOKEN
+
 WEBHOOK_OUTBOUND_TASK_TYPE = "webhook.outbound"
+_WEBHOOK_TOKEN_HEADER = HEADER_WEBHOOK_TOKEN.casefold()
 
 
 class WebhookOutboundTask(BaseModel):
@@ -15,3 +18,12 @@ class WebhookOutboundTask(BaseModel):
     headers: dict[str, str] = dict()
     organization_id: str
     method: Literal["POST", "GET"] = "POST"
+
+    def sanitize(self):
+        sanitized_headers = {
+            header: "***" if header.casefold() == _WEBHOOK_TOKEN_HEADER else value
+            for header, value in self.headers.items()
+        }
+        if sanitized_headers == self.headers:
+            return self
+        return self.model_copy(update={"headers": sanitized_headers})

--- a/src/xngin/tq/test_task_payload_types.py
+++ b/src/xngin/tq/test_task_payload_types.py
@@ -1,0 +1,32 @@
+import pytest
+
+from xngin.apiserver import constants
+from xngin.tq.task_payload_types import WebhookOutboundTask
+
+
+@pytest.mark.parametrize(
+    "webhook_token_header",
+    [
+        constants.HEADER_WEBHOOK_TOKEN,
+        constants.HEADER_WEBHOOK_TOKEN.lower(),
+        constants.HEADER_WEBHOOK_TOKEN.upper(),
+    ],
+)
+def test_webhook_outbound_task_sanitize_redacts_webhook_token_case_insensitively(webhook_token_header: str):
+    task = WebhookOutboundTask(
+        organization_id="org_123",
+        url="https://example.com/webhook",
+        body={"hello": "world"},
+        headers={
+            webhook_token_header: "secret-token",
+            "X-Other": "kept",
+        },
+    )
+
+    sanitized = task.sanitize()
+
+    assert sanitized.headers == {
+        webhook_token_header: "***",
+        "X-Other": "kept",
+    }
+    assert task.headers[webhook_token_header] == "secret-token"


### PR DESCRIPTION
Allows users to re-trigger an outbound HTTP webhook, strips webhook-tokens from UI, and adds a structured status icon field to the user-facing EventSummary.

Corresponding FE change to enable the feature: https://github.com/agency-fund/evidential-fe/pull/254