### PR TITLE
Change GetExperimentForUiResponse.participant_type => experiment_schema

### DIFF
--- a/src/xngin/apiserver/routers/admin/admin_api.py
+++ b/src/xngin/apiserver/routers/admin/admin_api.py
@@ -140,7 +140,7 @@ from xngin.apiserver.routers.experiments import experiments_common, experiments_
 from xngin.apiserver.routers.experiments.experiments_common import (
     AbandonExperimentResult,
     convert_table_to_fields_or_raise,
-    make_participants_def_from_experiment,
+    make_schema_from_experiment,
 )
 from xngin.apiserver.routers.experiments.experiments_common_csv import CsvStreamingResponse
 from xngin.apiserver.routers.power_adapters import calculate_icc_and_cv_from_database
@@ -2051,7 +2051,7 @@ async def get_experiment_for_ui(
     )
     return GetExperimentForUiResponse(
         config=await experiments_common.get_experiment_impl(session, experiment),
-        participant_type=make_participants_def_from_experiment(experiment),
+        experiment_schema=make_schema_from_experiment(experiment),
     )
 
 

--- a/src/xngin/apiserver/routers/admin/admin_api_types.py
+++ b/src/xngin/apiserver/routers/admin/admin_api_types.py
@@ -619,13 +619,13 @@ class CreateApiKeyResponse(AdminApiBaseModel):
 
 
 class GetExperimentForUiResponse(AdminApiBaseModel):
-    """Experiment configuration and participant type information."""
+    """Experiment configuration for the admin UI."""
 
     config: Annotated[ExperimentConfig, Field()]
-    participant_type: Annotated[
-        ParticipantsDef | None,
+    experiment_schema: Annotated[
+        ParticipantsSchema | None,
         Field(
-            description="If available, the Participant Type information for this experiment. "
+            description="If available, the schema information (fields used, data types) for this experiment. "
             "This field is null for experiments that only use an 'API Only' datasource."
         ),
     ]

--- a/src/xngin/apiserver/routers/admin/test_admin_api.py
+++ b/src/xngin/apiserver/routers/admin/test_admin_api.py
@@ -1459,8 +1459,7 @@ async def test_lifecycle_with_db(testing_datasource, aclient: AdminAPIClient, ac
         datasource_id=testing_datasource.datasource_id, experiment_id=parsed_experiment_id
     ).data
     assert get_exp.config.state == ExperimentState.COMMITTED
-    assert get_exp.participant_type is not None
-    assert get_exp.participant_type.participant_type == ""
+    assert get_exp.experiment_schema is not None
 
     # Update the experiment.
     aclient.update_experiment(
@@ -1908,9 +1907,7 @@ async def test_create_and_get_freq_preassigned_experiment(
 
     # Now get the experiment using the admin API and verify config matches the created experiment.
     admin_experiment = aclient.get_experiment_for_ui(datasource_id=datasource_id, experiment_id=experiment_id).data
-    assert admin_experiment.participant_type is not None
-    assert admin_experiment.participant_type.participant_type == ""
-    assert admin_experiment.participant_type.hidden is True
+    assert admin_experiment.experiment_schema is not None
     ui_experiment = admin_experiment.config
     diff = DeepDiff(
         created_experiment,
@@ -1928,7 +1925,7 @@ async def test_create_and_get_freq_preassigned_experiment(
     )
     assert not diff, f"Objects differ:\n{diff.pretty()}"
     # Verify that participant field metadata was stored correctly.
-    experiment_fields = admin_experiment.participant_type.fields
+    experiment_fields = admin_experiment.experiment_schema.fields
     assert len(experiment_fields) == 3
     unique_id_field = next((f for f in experiment_fields if f.is_unique_id), None)
     assert unique_id_field is not None
@@ -2133,9 +2130,7 @@ def test_create_and_get_freq_online_experiment(testing_datasource, aclient: Admi
 
     # Now get the experiment using the admin API and verify config matches the created experiment.
     fetched_resp = aclient.get_experiment_for_ui(datasource_id=datasource_id, experiment_id=parsed_experiment_id).data
-    assert fetched_resp.participant_type is not None
-    assert fetched_resp.participant_type.participant_type == ""
-    assert fetched_resp.participant_type.hidden is True
+    assert fetched_resp.experiment_schema is not None
     ui_experiment = fetched_resp.config
     diff = DeepDiff(
         created_experiment,
@@ -2206,7 +2201,7 @@ def test_create_and_get_online_mab_experiment(testing_datasource, aclient: Admin
 
     # Now get the experiment using the admin API and verify config matches the created experiment.
     fetched_resp = aclient.get_experiment_for_ui(datasource_id=datasource_id, experiment_id=parsed_experiment_id).data
-    assert fetched_resp.participant_type is None
+    assert fetched_resp.experiment_schema is None
     ui_experiment = fetched_resp.config
     diff = DeepDiff(
         created_experiment,

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -18,7 +18,7 @@ from sqlalchemy.orm import selectinload
 
 from xngin.apiserver import constants, flags
 from xngin.apiserver.dwh.dwh_session import DwhSession
-from xngin.apiserver.dwh.inspection_types import FieldDescriptor
+from xngin.apiserver.dwh.inspection_types import FieldDescriptor, ParticipantsSchema
 from xngin.apiserver.dwh.participant_metrics_queries import get_participant_metrics
 from xngin.apiserver.exceptions_common import LateValidationError
 from xngin.apiserver.routers.assignment_adapters import (
@@ -60,7 +60,7 @@ from xngin.apiserver.routers.common_enums import (
     UpdateTypeNormal,
 )
 from xngin.apiserver.routers.experiments.property_filters import passes_filters, validate_filter_value
-from xngin.apiserver.settings import DatasourceConfig, ParticipantsDef
+from xngin.apiserver.settings import DatasourceConfig
 from xngin.apiserver.sql.queries import select_as_csv
 from xngin.apiserver.sqla import tables
 from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter
@@ -95,8 +95,8 @@ class AbandonExperimentResult(enum.StrEnum):
     INVALID_STATE = "invalid_state"
 
 
-def make_participants_def_from_experiment(experiment: tables.Experiment) -> ParticipantsDef | None:
-    """Build a ParticipantsDef from stored experiment fields."""
+def make_schema_from_experiment(experiment: tables.Experiment) -> ParticipantsSchema | None:
+    """Build a ParticipantsSchema from stored experiment fields."""
     if experiment.experiment_type not in {ExperimentsType.FREQ_ONLINE.value, ExperimentsType.FREQ_PREASSIGNED.value}:
         return None
 
@@ -120,11 +120,8 @@ def make_participants_def_from_experiment(experiment: tables.Experiment) -> Part
         if ef.is_strata:
             fd.is_strata = True
 
-    return ParticipantsDef(
-        type="schema",
+    return ParticipantsSchema(
         table_name=table_name,
-        participant_type="",
-        hidden=True,
         fields=list(sorted(schema.values(), key=lambda x: x.field_name)),
     )
 

--- a/src/xngin/apiserver/routers/experiments/test_experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_common.py
@@ -57,7 +57,7 @@ from xngin.apiserver.routers.experiments.experiments_common import (
     get_existing_assignment_for_participant,
     get_experiment_impl,
     get_or_create_assignment_for_participant,
-    make_participants_def_from_experiment,
+    make_schema_from_experiment,
     update_bandit_arm_with_outcome_impl,
 )
 from xngin.apiserver.routers.experiments.experiments_common_csv import get_experiment_assignments_as_csv_impl
@@ -421,30 +421,30 @@ def _make_experiment(
     return exp
 
 
-def test_make_participants_def_from_experiment_non_frequentist_returns_none():
+def test_make_schema_from_experiment_non_frequentist_returns_none():
     exp = _make_experiment(ExperimentsType.MAB_ONLINE)
-    assert make_participants_def_from_experiment(exp) is None
+    assert make_schema_from_experiment(exp) is None
 
 
-def test_make_participants_def_from_experiment_missing_uid_returns_none():
+def test_make_schema_from_experiment_missing_uid_returns_none():
     # No field has is_unique_id=True, so unique_id_field() returns None.
     exp = _make_experiment(
         ExperimentsType.FREQ_ONLINE,
         fields=[_make_experiment_field("revenue", DataType.DOUBLE_PRECISION, metric_pct_change=0.1)],
     )
-    assert make_participants_def_from_experiment(exp) is None
+    assert make_schema_from_experiment(exp) is None
 
 
-def test_make_participants_def_from_experiment_missing_table_returns_none():
+def test_make_schema_from_experiment_missing_table_returns_none():
     exp = _make_experiment(
         ExperimentsType.FREQ_PREASSIGNED,
         datasource_table=None,
         fields=[_make_experiment_field("id", DataType.INTEGER, is_unique_id=True)],
     )
-    assert make_participants_def_from_experiment(exp) is None
+    assert make_schema_from_experiment(exp) is None
 
 
-def test_make_participants_def_from_experiment_builds_participants_def():
+def test_make_schema_from_experiment_builds_participants_schema():
     fields = [
         _make_experiment_field("id", DataType.INTEGER, is_unique_id=True),
         _make_experiment_field("revenue", DataType.DOUBLE_PRECISION, metric_pct_change=0.05),
@@ -468,12 +468,10 @@ def test_make_participants_def_from_experiment_builds_participants_def():
         fields=fields,
     )
 
-    result = make_participants_def_from_experiment(exp)
+    result = make_schema_from_experiment(exp)
 
     assert result is not None
     assert result.table_name == "my_table"
-    assert result.participant_type == ""
-    assert result.hidden is True
     field_names = [f.field_name for f in result.fields]
     assert field_names == ["country", "id", "revenue"]  # sorted by name
     id_fd = next(f for f in result.fields if f.field_name == "id")


### PR DESCRIPTION
Now returns a ParticipantsSchema directly instead of a ParticipantsDef.

This is a small step in the greater cleanup of "participant types".

## Future Tasks

Besides additional ParticipantsDef cleanup to do, this structure could also be the basis of future experiment field drift from the underlying dwh table's schema.

## How has this been tested?

unittests