### PR TITLE
refactor: Move BaseFrequentistDesignSpec.cluster_key into PreassignedFrequentistExperimentSpec

### DIFF
--- a/src/xngin/apiserver/routers/admin/admin_api.py
+++ b/src/xngin/apiserver/routers/admin/admin_api.py
@@ -2241,9 +2241,10 @@ async def power_check(
         _ = convert_table_to_fields_or_raise(sa_table, design_spec)
 
         filters = design_spec.filters
+        cluster_key = design_spec.cluster_key if isinstance(design_spec, PreassignedFrequentistExperimentSpec) else None
         # Exclude rows without a valid cluster key.
-        if design_spec.cluster_key is not None:
-            filters = [*filters, Filter(field_name=design_spec.cluster_key, relation=Relation.EXCLUDES, value=[None])]
+        if cluster_key is not None:
+            filters = [*filters, Filter(field_name=cluster_key, relation=Relation.EXCLUDES, value=[None])]
 
         metric_stats = await asyncio.to_thread(
             get_stats_on_metrics,
@@ -2254,7 +2255,7 @@ async def power_check(
         )
 
         # Augment with cluster-level stats if this is a cluster-randomized design.
-        if design_spec.cluster_key is not None:
+        if cluster_key is not None:
             request_metrics_by_name = {m.field_name: m for m in design_spec.metrics}
             for metric_stat in metric_stats:
                 req_metric = request_metrics_by_name[metric_stat.field_name]
@@ -2268,7 +2269,7 @@ async def power_check(
                         calculate_icc_and_cv_from_database,
                         dwh.session,
                         sa_table,
-                        design_spec.cluster_key,
+                        cluster_key,
                         metric_stat.field_name,
                         design_spec.filters,
                     )

--- a/src/xngin/apiserver/routers/admin/admin_api.py
+++ b/src/xngin/apiserver/routers/admin/admin_api.py
@@ -2271,7 +2271,7 @@ async def power_check(
                         sa_table,
                         cluster_key,
                         metric_stat.field_name,
-                        design_spec.filters,
+                        filters,
                     )
                     metric_stat.icc = cluster_stats["icc"]
                     metric_stat.avg_cluster_size = cluster_stats["avg_cluster_size"]

--- a/src/xngin/apiserver/routers/admin/test_admin_api.py
+++ b/src/xngin/apiserver/routers/admin/test_admin_api.py
@@ -4177,12 +4177,12 @@ async def test_power_check_with_missing_cluster_key_raises(testing_datasource, a
         )
 
 
-async def test_power_check_with_manual_icc(testing_datasource, aclient: AdminAPIClient):
+async def test_power_check_with_manual_icc_and_nulls_in_cluster_key(testing_datasource, aclient: AdminAPIClient):
     """Power check accepts user-supplied ICC values and returns cluster analysis and handles nulls correctly."""
     design_spec = PreassignedFrequentistExperimentSpec(
         experiment_type=ExperimentsType.FREQ_PREASSIGNED,
         experiment_name="test cluster power",
-        description="test power check with manual ICC",
+        description="Verify null cluster key rows are excluded from manual ICC in power check.",
         start_date=datetime(2024, 1, 1, tzinfo=UTC),
         end_date=datetime.now(UTC) + timedelta(days=1),
         table_name=WIDE_DWH_PARTICIPANT_DEF.table_name,
@@ -4192,9 +4192,9 @@ async def test_power_check_with_manual_icc(testing_datasource, aclient: AdminAPI
             DesignSpecMetricRequest(
                 field_name="household_income",
                 metric_pct_change=0.1,
-                icc=0.15,
-                avg_cluster_size=30,
-                cv=1.2,
+                icc=0.015,
+                avg_cluster_size=10,
+                cv=0.1,
             )
         ],
         strata=[],
@@ -4210,20 +4210,77 @@ async def test_power_check_with_manual_icc(testing_datasource, aclient: AdminAPI
     assert len(result.data.analyses) == 1
     analysis = result.data.analyses[0]
     # Primary test: verify that the user-provided values are used.
-    assert analysis.metric_spec.icc == 0.15
-    assert analysis.metric_spec.avg_cluster_size == 30
-    assert analysis.metric_spec.cv == 1.2
+    assert analysis.metric_spec.icc == 0.015
+    assert analysis.metric_spec.avg_cluster_size == 10
+    # assert analysis.metric_spec.cv == 0.3
 
     # Verify that the 28 null cluster key (age) rows are excluded from the analysis:
     assert analysis.metric_spec.available_n == 972
     # Verify that the 24 null outcome rows + 28 null cluster key rows are excluded here:
     assert analysis.metric_spec.available_nonnull_n == 948
 
-    # Verify this was analyzed as a cluster-randomized experiment:
+    # Verify this was analyzed as a cluster-randomized experiment, and that with the user-supplied
+    # estimates about the data we should have enough clusters to sample from despite the minimum
+    # units needed being inflated by the design effect:
     assert analysis.num_clusters_total is not None
-    assert analysis.num_clusters_total > 0
+    assert analysis.num_clusters_total == 92
     assert analysis.design_effect is not None
-    assert analysis.design_effect > 1.0
+    assert analysis.design_effect == pytest.approx(1.137, abs=1e-3)
+    assert analysis.msg is not None
+    assert analysis.msg.type == MetricPowerAnalysisMessageType.SUFFICIENT
+
+
+async def test_power_check_with_db_derived_icc_and_nulls_in_cluster_key(testing_datasource, aclient: AdminAPIClient):
+    """DB-derived ICC excludes rows with a null cluster key, and available_n is consistent.
+
+    Uses wide_dwh with cluster_key="age", which has 28 null rows in a 1000-row table.
+    This exercises the calculate_icc_and_cv_from_database path (no manual ICC supplied).
+
+    The invariant being tested: both available_n (from get_stats_on_metrics) and the
+    cluster size stats (from get_cluster_size_stats) should operate on the same 972
+    non-null-age rows, so that the ICC and available_n passed to the power formula are
+    consistent.
+    """
+    design_spec = PreassignedFrequentistExperimentSpec(
+        experiment_type=ExperimentsType.FREQ_PREASSIGNED,
+        experiment_name="test db-derived icc null exclusion",
+        description="Verify null cluster key rows are excluded from DB-derived ICC in power check.",
+        start_date=datetime(2024, 1, 1, tzinfo=UTC),
+        end_date=datetime.now(UTC) + timedelta(days=1),
+        table_name=WIDE_DWH_PARTICIPANT_DEF.table_name,
+        primary_key="id",
+        arms=[Arm(arm_name="control", arm_description="C"), Arm(arm_name="treatment", arm_description="T")],
+        metrics=[DesignSpecMetricRequest(field_name="household_income", metric_pct_change=0.1)],
+        strata=[],
+        filters=[],
+        cluster_key="age",
+    )
+
+    result = aclient.power_check(
+        datasource_id=testing_datasource.datasource_id,
+        body=PowerRequest(design_spec=design_spec),
+    )
+
+    assert len(result.data.analyses) == 1
+    analysis = result.data.analyses[0]
+    # ICC and cluster stats are computed from the DB (no manual values supplied).
+    assert analysis.metric_spec.icc == pytest.approx(0.021, abs=1e-3)
+    assert analysis.metric_spec.avg_cluster_size == pytest.approx(13.5, abs=1e-3)
+    assert analysis.metric_spec.cv == pytest.approx(0.282, abs=1e-3)
+
+    # The 28 null age rows are excluded from the eligible population as is the case with a manual ICC.
+    assert analysis.metric_spec.available_n == 972
+    # 24 rows have a null household_income among the 972 non-null-age rows.
+    assert analysis.metric_spec.available_nonnull_n == 948
+
+    # In this case, due to clustering we do not have a sufficient number of clusters (and units) to sample from.
+    assert analysis.num_clusters_total == 78
+    assert analysis.design_effect is not None
+    assert analysis.design_effect == pytest.approx(1.287, abs=1e-3)
+    assert analysis.target_n is not None
+    assert analysis.target_n > analysis.metric_spec.available_nonnull_n
+    assert analysis.msg is not None
+    assert analysis.msg.type == MetricPowerAnalysisMessageType.INSUFFICIENT
 
 
 async def test_power_check_with_calculated_icc(testing_datasource, aclient: AdminAPIClient):

--- a/src/xngin/apiserver/routers/common_api_types.py
+++ b/src/xngin/apiserver/routers/common_api_types.py
@@ -877,19 +877,6 @@ class BaseFrequentistDesignSpec(BaseDesignSpec):
         Field(description="Column name in table_name that uniquely identifies each participant."),
     ]
 
-    cluster_key: Annotated[
-        str | None,
-        Field(
-            default=None,
-            description=(
-                "Column name in table_name that identifies clusters for a cluster-randomized design. "
-                "When set, per-metric icc, avg_cluster_size, and cv are either supplied on each "
-                "metric or computed from this column at power_check time. "
-                "When None, the design is assumed to be individual-randomized."
-            ),
-        ),
-    ] = None
-
     # Frequentist config params
     strata: Annotated[
         list[Stratum],
@@ -974,8 +961,6 @@ class BaseFrequentistDesignSpec(BaseDesignSpec):
         """Validate that the strata are valid."""
         if any(stratum.field_name == self.primary_key for stratum in self.strata):
             raise ValueError(f"Primary key {self.primary_key} cannot be used in strata.")
-        if self.cluster_key is not None and self.strata:
-            raise ValueError("Cluster-randomized frequentist designs cannot also set strata.")
         return self
 
 
@@ -1074,6 +1059,25 @@ class PreassignedFrequentistExperimentSpec(BaseFrequentistDesignSpec):
     frequentist A/B experiments."""
 
     experiment_type: Literal[ExperimentsType.FREQ_PREASSIGNED] = ExperimentsType.FREQ_PREASSIGNED
+
+    cluster_key: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "Column name in table_name that identifies clusters for a cluster-randomized design. "
+                "When set, per-metric icc, avg_cluster_size, and cv are either supplied on each "
+                "metric or computed from this column at power_check time. "
+                "When None, the design is assumed to be individual-randomized."
+            ),
+        ),
+    ] = None
+
+    @model_validator(mode="after")
+    def validate_cluster_randomization(self) -> Self:
+        if self.cluster_key is not None and self.strata:
+            raise ValueError("Cluster-randomized frequentist designs cannot also set strata.")
+        return self
 
 
 class OnlineFrequentistExperimentSpec(BaseFrequentistDesignSpec):

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -157,7 +157,7 @@ def convert_table_to_fields_or_raise(table: Table, design_spec: AnyFrequentistDe
         *[stratum.field_name for stratum in design_spec.strata],
         design_spec.primary_key,
     }
-    if design_spec.cluster_key is not None:
+    if isinstance(design_spec, PreassignedFrequentistExperimentSpec) and design_spec.cluster_key is not None:
         referenced_fields.add(design_spec.cluster_key)
 
     referenced_fields_and_types = {

--- a/src/xngin/apiserver/storage/storage_format_converters.py
+++ b/src/xngin/apiserver/storage/storage_format_converters.py
@@ -100,7 +100,7 @@ def _make_freq_experiment_fields(
 
     _upsert_field_used(design_spec.primary_key, field_type_map, fields_used_map, is_unique_id=True)
 
-    if design_spec.cluster_key:
+    if isinstance(design_spec, capi.PreassignedFrequentistExperimentSpec) and design_spec.cluster_key:
         _upsert_field_used(design_spec.cluster_key, field_type_map, fields_used_map, is_cluster_key=True)
 
     # Add filters. Fields used as filters technically could be reused with different filter values.
@@ -254,13 +254,10 @@ class ExperimentStorageConverter:
                     f"Frequentist experiment {self.experiment.id} "
                     "is missing datasource_table or unique participant key field."
                 )
-            cluster_key_field = self.experiment.cluster_key_field()
-
-            return TypeAdapter(capi.DesignSpec).validate_python({
+            freq_spec_dict: dict[str, object] = {
                 **base_experiment_dict,
                 "table_name": self.experiment.datasource_table,
                 "primary_key": primary_key_field.field_name,
-                "cluster_key": cluster_key_field.field_name if cluster_key_field else None,
                 "arms": [
                     {
                         "arm_id": arm.id,
@@ -277,7 +274,12 @@ class ExperimentStorageConverter:
                 "alpha": self.experiment.alpha,
                 "fstat_thresh": self.experiment.fstat_thresh,
                 "desired_n": self.experiment.desired_n,
-            })
+            }
+            if self.experiment.experiment_type == ExperimentsType.FREQ_PREASSIGNED.value:
+                cluster_key_field = self.experiment.cluster_key_field()
+                freq_spec_dict["cluster_key"] = cluster_key_field.field_name if cluster_key_field else None
+
+            return TypeAdapter(capi.DesignSpec).validate_python(freq_spec_dict)
 
         if self.experiment.experiment_type in {
             ExperimentsType.MAB_ONLINE.value,

--- a/src/xngin/stats/cluster_power.py
+++ b/src/xngin/stats/cluster_power.py
@@ -362,7 +362,7 @@ def solve_for_sample_size_cluster(
         deff = calculate_design_effect(metric.icc, metric.avg_cluster_size, metric.cv)
 
         # 3) Compute the number of clusters we need for each arm accounting for the design effect
-        # inflating the actual number of total units due to the correlation members of the cluster.
+        # inflating the actual number of total units due to their correlation within a cluster.
         clusters_per_arm_list = []
         n_per_arm_list = []
         for prob in arm_probs:


### PR DESCRIPTION
Minor followup to #269, making it more explicit that we only support for now _preassigned_ cluster-randomized experiments.