### PR TITLE
Wire up cluster randomized experiment analysis to API

### DIFF
--- a/src/xngin/apiserver/routers/admin/test_admin_api.py
+++ b/src/xngin/apiserver/routers/admin/test_admin_api.py
@@ -4410,6 +4410,44 @@ def test_create_freq_preassigned_experiment_with_cluster_key_roundtrips(
         assert csv_assignment["created_at"] == created_at.isoformat(timespec="seconds").replace("+00:00", "Z")
 
 
+def test_analyze_cluster_preassigned_experiment(testing_datasource, aclient: AdminAPIClient):
+    """Basic test of clustered preassigned experiment analysis via the admin API."""
+    datasource_id = testing_datasource.datasource_id
+    experiment_request = CreateExperimentRequest(
+        design_spec=PreassignedFrequentistExperimentSpec(
+            experiment_type="freq_preassigned",
+            experiment_name="Cluster analyze e2e",
+            description="Verify clustered analysis via admin API.",
+            table_name="clustered_dwh",
+            primary_key="participant_id",
+            cluster_key="cluster_moderate",
+            start_date=datetime(2024, 1, 1, tzinfo=UTC),
+            end_date=datetime(2024, 1, 31, 23, 59, 59, tzinfo=UTC),
+            arms=[Arm(arm_name="control", arm_description="C"), Arm(arm_name="treatment", arm_description="T")],
+            metrics=[DesignSpecMetricRequest(field_name="converted", metric_pct_change=5)],
+            strata=[],
+            filters=[],
+            desired_n=100,
+        ),
+    )
+
+    created = aclient.create_experiment(datasource_id=datasource_id, body=experiment_request, random_state=42).data
+    exp_analysis = aclient.analyze_experiment(datasource_id=datasource_id, experiment_id=created.experiment_id).data
+    assert isinstance(exp_analysis, FreqExperimentAnalysisResponse)
+    assert exp_analysis.experiment_id == created.experiment_id
+    assert exp_analysis.num_participants == 100
+    assert exp_analysis.num_missing_participants == 0
+    assert len(exp_analysis.metric_analyses) == 1
+    metric_analysis = exp_analysis.metric_analyses[0]
+    assert metric_analysis.metric_name == "converted"
+    assert len(metric_analysis.arm_analyses) == 2
+    for arm_analysis in metric_analysis.arm_analyses:
+        assert arm_analysis.estimate is not None
+        assert not np.isnan(arm_analysis.estimate)
+        assert arm_analysis.std_error is not None
+        assert not np.isnan(arm_analysis.std_error)
+
+
 async def test_create_freq_preassigned_experiment_with_missing_cluster_key_raises(
     testing_datasource,
     aclient: AdminAPIClient,

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -1123,14 +1123,26 @@ async def analyze_experiment_freq_impl(
     )
 
 
-async def read_assignments_efficiently(xngin_session: AsyncSession, experiment_id: str) -> tuple[list[str], DataFrame]:
+async def read_assignments_efficiently(
+    xngin_session: AsyncSession,
+    experiment_id: str,
+    *,
+    include_cluster_key: bool = False,
+) -> tuple[list[str], DataFrame]:
     """Reads assignments directly from Postgres via a COPY statement.
 
     Reads CSV output in row-bounded chunks and concatenates the parsed frames.
     """
-    select_query = t"SELECT arm_id, participant_id FROM arm_assignments WHERE experiment_id = {experiment_id}"  # type: ignore
+    if include_cluster_key:
+        select_query = (
+            t"SELECT arm_id, participant_id, cluster_key FROM arm_assignments WHERE experiment_id = {experiment_id}"  # type: ignore
+        )
+        column_names = ["arm_id", "participant_id", "cluster_key"]
+    else:
+        select_query = t"SELECT arm_id, participant_id FROM arm_assignments WHERE experiment_id = {experiment_id}"  # type: ignore
+        column_names = ["arm_id", "participant_id"]
     dfs = [
-        pd.read_csv(io.BytesIO(chunk), names=["arm_id", "participant_id"], dtype=str)
+        pd.read_csv(io.BytesIO(chunk), names=column_names, dtype=str)
         async for chunk in select_as_csv(
             xngin_session, select_query, buffer_size_bytes=CSV_PARSE_CHUNK_SIZE_BYTES, newline_framed=True
         )
@@ -1138,7 +1150,7 @@ async def read_assignments_efficiently(xngin_session: AsyncSession, experiment_i
     if dfs:
         df = pd.concat(dfs, ignore_index=True)
     else:
-        df = pd.DataFrame(columns=["arm_id", "participant_id"]).astype(str)
+        df = pd.DataFrame(columns=column_names).astype(str)
     return df["participant_id"].to_list(), df
 
 

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 from fastapi import HTTPException, status
 from pandas import DataFrame
+from psycopg import sql
 from sqlalchemy import Select, Table, func, insert, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
@@ -1039,7 +1040,6 @@ async def analyze_experiment_freq_impl(
     if assignments_df.empty:
         raise StatsAnalysisError("No participants found for experiment.")
 
-    cluster_col = "cluster_key" if include_cluster else None
     async with DwhSession(dsconfig.dwh) as dwh:
         sa_table = await dwh.inspect_table(experiment.datasource_table)
 
@@ -1070,9 +1070,11 @@ async def analyze_experiment_freq_impl(
     analyze_results = analyze_freq_experiment(
         assignments_df,
         participant_outcomes,
-        baseline_arm_id,
+        unit_col=tables.ArmAssignment.participant_id.name,
+        arm_col=tables.ArmAssignment.arm_id.name,
+        cluster_col=tables.ArmAssignment.cluster_key.name if include_cluster else None,
+        baseline_arm_id=baseline_arm_id,
         alpha=experiment.alpha,
-        cluster_col=cluster_col,
     )
 
     metric_analyses = []
@@ -1139,14 +1141,15 @@ async def read_assignments_efficiently(
 
     Reads CSV output in row-bounded chunks and concatenates the parsed frames.
     """
+    column_names = [
+        tables.ArmAssignment.arm_id.name,
+        tables.ArmAssignment.participant_id.name,
+    ]
     if include_cluster_key:
-        select_query = (
-            t"SELECT arm_id, participant_id, cluster_key FROM arm_assignments WHERE experiment_id = {experiment_id}"  # type: ignore
-        )
-        column_names = ["arm_id", "participant_id", "cluster_key"]
-    else:
-        select_query = t"SELECT arm_id, participant_id FROM arm_assignments WHERE experiment_id = {experiment_id}"  # type: ignore
-        column_names = ["arm_id", "participant_id"]
+        column_names.append(tables.ArmAssignment.cluster_key.name)
+
+    joined_column_names = sql.SQL(", ").join(sql.Identifier(name) for name in column_names)
+    select_query = t"SELECT {joined_column_names:q} FROM arm_assignments WHERE experiment_id = {experiment_id}"  # type: ignore
     dfs = [
         pd.read_csv(io.BytesIO(chunk), names=column_names, dtype=str)
         async for chunk in select_as_csv(
@@ -1157,7 +1160,7 @@ async def read_assignments_efficiently(
         df = pd.concat(dfs, ignore_index=True)
     else:
         df = pd.DataFrame(columns=column_names).astype(str)
-    return df["participant_id"].to_list(), df
+    return df[tables.ArmAssignment.participant_id.name].to_list(), df
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -1032,9 +1032,14 @@ async def analyze_experiment_freq_impl(
     if experiment.datasource_table is None or unique_id_field is None:
         raise StatsAnalysisError("Experiment must have a datasource table and unique ID field to analyze.")
 
-    participant_ids, assignments_df = await read_assignments_efficiently(xngin_session, experiment.id)
+    include_cluster = experiment.cluster_key_field() is not None
+    participant_ids, assignments_df = await read_assignments_efficiently(
+        xngin_session, experiment.id, include_cluster_key=include_cluster
+    )
     if assignments_df.empty:
         raise StatsAnalysisError("No participants found for experiment.")
+
+    cluster_col = "cluster_key" if include_cluster else None
     async with DwhSession(dsconfig.dwh) as dwh:
         sa_table = await dwh.inspect_table(experiment.datasource_table)
 
@@ -1067,6 +1072,7 @@ async def analyze_experiment_freq_impl(
         participant_outcomes,
         baseline_arm_id,
         alpha=experiment.alpha,
+        cluster_col=cluster_col,
     )
 
     metric_analyses = []

--- a/src/xngin/apiserver/routers/experiments/test_experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_common.py
@@ -697,6 +697,92 @@ async def test_create_preassigned_experiment_impl_cluster_assignment(xngin_sessi
     assert len(set.union(*arms_by_cluster.values())) == 2
 
 
+async def _create_clustered_preassigned_experiment(
+    xngin_session: AsyncSession,
+    testing_datasource,
+    *,
+    cluster_key: str | None = "cluster_equal",
+    metric_name: str = "test_score",
+) -> tables.Experiment:
+    design_spec = make_design_spec_clustered(cluster_key=cluster_key)
+    request = CreateExperimentRequest(design_spec=design_spec)
+    field_type_map = await fetch_fields_or_raise(testing_datasource.ds, design_spec)
+    assert design_spec.desired_n is not None
+
+    select_columns = {design_spec.primary_key, metric_name}
+    if cluster_key is not None:
+        select_columns.add(cluster_key)
+    async with DwhSession(testing_datasource.ds.get_config().dwh) as dwh:
+        participant_result = await dwh.get_participants(
+            design_spec.table_name,
+            select_columns=select_columns,
+            filters=design_spec.filters,
+            n=design_spec.desired_n,
+        )
+        sa_table = participant_result.sa_table
+        dwh_participants = participant_result.participants
+
+    assert dwh_participants is not None
+    response = await create_preassigned_experiment_impl(
+        request=request,
+        datasource_id=testing_datasource.ds.id,
+        organization_id=testing_datasource.ds.organization_id,
+        dwh_sa_table=sa_table,
+        dwh_participants=dwh_participants,
+        random_state=42,
+        xngin_session=xngin_session,
+        stratify_on_metrics=False,
+        validated_webhooks=[],
+        field_type_map=field_type_map,
+    )
+    return await get_experiment_preloaded(xngin_session, response.experiment_id)
+
+
+async def test_analyze_experiment_freq_impl_with_cluster_key(
+    xngin_session,
+    testing_datasource,
+    use_deterministic_random,
+):
+    """``analyze_experiment_freq_impl`` uses cluster-robust SEs when the experiment has a cluster key.
+
+    Uses ``clustered_dwh`` with ``cluster_powerlaw`` and metric ``test_score`` (ICC ~0.20 on that
+    cluster id per ``tools/generate_clustered_data.py``). Runs analysis twice on the same
+    assignments and outcomes: first with cluster-robust SEs, then after clearing ``is_cluster_key``
+    on the experiment field so the second pass uses only basic heteroskedasticity-robust SEs.
+    Expect coefficients to be the same, but CRSE should usually be larger than HC1 SE in this case.
+    """
+    dsconfig = testing_datasource.ds.get_config()
+    experiment = await _create_clustered_preassigned_experiment(
+        xngin_session,
+        testing_datasource,
+        cluster_key="cluster_powerlaw",
+        metric_name="test_score",
+    )
+    baseline_arm_id = experiment.arms[0].id
+    treatment_arm_id = experiment.arms[1].id
+    metrics = [DesignSpecMetricRequest(field_name="test_score", metric_pct_change=0.1)]
+
+    crse_analysis = await analyze_experiment_freq_impl(xngin_session, dsconfig, experiment, baseline_arm_id, metrics)
+    crse_treatment = next(a for a in crse_analysis.metric_analyses[0].arm_analyses if a.arm_id == treatment_arm_id)
+    assert crse_treatment.std_error is not None
+    assert not np.isnan(crse_treatment.std_error)
+    assert crse_treatment.std_error > 0
+
+    # Same assignments/outcomes; uses HC1 instead of cluster-robust SEs. Unsets is_cluster_key only
+    # so cluster_key_field() is None on re-analysis.
+    field = experiment.cluster_key_field()
+    assert field is not None
+    field.is_cluster_key = False
+
+    hc1_analysis = await analyze_experiment_freq_impl(xngin_session, dsconfig, experiment, baseline_arm_id, metrics)
+    hc1_treatment = next(a for a in hc1_analysis.metric_analyses[0].arm_analyses if a.arm_id == treatment_arm_id)
+    assert hc1_treatment.std_error is not None
+    assert not np.isnan(hc1_treatment.std_error)
+    assert hc1_treatment.std_error > 0
+    assert crse_treatment.estimate == hc1_treatment.estimate
+    assert crse_treatment.std_error > hc1_treatment.std_error
+
+
 async def test_create_preassigned_experiment_impl_raises_on_duplicate_ids(
     xngin_session: AsyncSession,
     testing_datasource,

--- a/src/xngin/stats/analysis.py
+++ b/src/xngin/stats/analysis.py
@@ -5,6 +5,7 @@ import statsmodels.formula.api as smf
 from patsy.eval import EvalFactor
 
 from xngin.apiserver.dwh.analysis_types import ParticipantOutcome
+from xngin.stats.stats_errors import StatsAnalysisError
 
 
 @dataclasses.dataclass(slots=True)  # slots=True for performance
@@ -43,8 +44,8 @@ def analyze_experiment(
     participant_outcomes: list of outcomes for each unit in assignments_df, in the same order.
     unit_col: Name of column in assignments_df to use for participant identifiers.
     arm_col: Name of column in assignments_df to use for arm identifiers.
-    cluster_col: Name of column in assignments_df to use as cluster identifiers. If provided, the
-            analysis uses clustered instead of HC standard errors.
+    cluster_col: Name of column in assignments_df to use as cluster identifiers.
+            If provided, the analysis uses clustered SEs instead of HC SEs.
     baseline_arm_id: which arm to use as baseline; if not provided, uses the first arm seen
     alpha: significance level for confidence intervals (defaults to 0.05 if None for a 95% CI).
 
@@ -62,6 +63,10 @@ def analyze_experiment(
         raise ValueError(
             f"assignments_df shape is wrong: expected={','.join(sorted(expected_id_columns))},"
             f" got={','.join(sorted(actual_columns))}"
+        )
+    if cluster_col is not None and assignments_df[cluster_col].isna().any():
+        raise StatsAnalysisError(
+            f"One or more participants in a clustered experiment have a null {cluster_col}, which is disallowed."
         )
 
     if alpha is None:

--- a/src/xngin/stats/analysis.py
+++ b/src/xngin/stats/analysis.py
@@ -26,34 +26,42 @@ class ArmAnalysisResult:
 def analyze_experiment(
     assignments_df: pd.DataFrame,
     participant_outcomes: list[ParticipantOutcome],
+    *,
+    unit_col: str = "participant_id",
+    arm_col: str = "arm_id",
+    cluster_col: str | None = None,
     baseline_arm_id: str | None = None,
     alpha: float | None = None,
-    cluster_col: str | None = None,
 ) -> dict[str, dict[str, ArmAnalysisResult]]:
     """
     Perform statistical analysis with DesignSpec metrics and their values
 
     Args:
-    assignments_df: DataFrame of {participant_id, arm_id} strings, and optionally a column of cluster ids.
-    participant_outcomes: list of participant outcomes
+    assignments_df: DataFrame of {unit_col, arm_col[, cluster_col]} strings containing ids
+            corresponding to a unit of analysis (a participant), its treatment assignment, and
+            optionally the cluster id this unit is a part of for cluster-randomized experiments.
+    participant_outcomes: list of outcomes for each unit in assignments_df, in the same order.
+    unit_col: Name of column in assignments_df to use for participant identifiers.
+    arm_col: Name of column in assignments_df to use for arm identifiers.
+    cluster_col: Name of column in assignments_df to use as cluster identifiers. If provided, the
+            analysis uses clustered instead of HC standard errors.
     baseline_arm_id: which arm to use as baseline; if not provided, uses the first arm seen
     alpha: significance level for confidence intervals (defaults to 0.05 if None for a 95% CI).
-    cluster_col: Name of column to use as cluster identifiers in assignments_df. If provided, uses
-    clustered standard errors instead of HC1.
 
     Returns:
         map of metric name => map of arm_id (may be partial or empty!) => analysis results
         - If an arm is missing for a metric, it's because it had no valid data to process.
         - If *zero* arm analyses exist for a metric (e.g. since zero non-null outcomes were found
-          across all arms), the name will exist, but the inner dict will be empty.
+        across all arms), the name will exist, but the inner dict will be empty.
     """
-    expected_id_columns = {"participant_id", "arm_id"}
+    expected_id_columns = {unit_col, arm_col}
     if cluster_col is not None:
         expected_id_columns |= {cluster_col}
     actual_columns = set(assignments_df.columns)
     if actual_columns != expected_id_columns:
         raise ValueError(
-            f"assignments_df shape is wrong: expected={','.join(expected_id_columns)}, got={','.join(actual_columns)}"
+            f"assignments_df shape is wrong: expected={','.join(sorted(expected_id_columns))},"
+            f" got={','.join(sorted(actual_columns))}"
         )
 
     if alpha is None:
@@ -61,28 +69,28 @@ def analyze_experiment(
 
     rows = []
     for outcome in participant_outcomes:
-        data_row: dict[str, float | str | None] = {"participant_id": outcome.participant_id}
+        data_row: dict[str, float | str | None] = {unit_col: outcome.participant_id}
         for metric_value in outcome.metric_values:
             data_row[metric_value.metric_name] = metric_value.metric_value
         rows.append(data_row)
     outcomes_df = pd.DataFrame(rows)
 
-    merged_df = assignments_df.merge(outcomes_df, on="participant_id", how="left")
+    merged_df = assignments_df.merge(outcomes_df, on=unit_col, how="left")
 
     # Make arm_id categorical and ensure baseline_arm_id is first in the categories
-    merged_df["arm_id"] = pd.Categorical(merged_df["arm_id"])
-    if baseline_arm_id in merged_df["arm_id"].cat.categories:
-        arm_ids = merged_df["arm_id"].cat.categories.tolist()
+    merged_df[arm_col] = pd.Categorical(merged_df[arm_col])
+    if baseline_arm_id in merged_df[arm_col].cat.categories:
+        arm_ids = merged_df[arm_col].cat.categories.tolist()
         arm_ids.remove(baseline_arm_id)
         arm_ids.insert(0, baseline_arm_id)
-        merged_df["arm_id"] = merged_df["arm_id"].cat.reorder_categories(arm_ids)
+        merged_df[arm_col] = merged_df[arm_col].cat.reorder_categories(arm_ids)
 
     # Exclude various id columns
     metric_columns = [col for col in merged_df.columns if col not in expected_id_columns]
 
     # Calculate NaN counts for all metrics. Since assignments_df may have participants that are not
     # yet in the dwh (e.g. in an online experiment) we're also counting missing participants as having NaN as well.
-    nan_counts_df = merged_df.groupby("arm_id", observed=False)[metric_columns].agg(lambda s: s.isna().sum())
+    nan_counts_df = merged_df.groupby(arm_col, observed=False)[metric_columns].agg(lambda s: s.isna().sum())
 
     # Prep our dict of analyses to return.
     metric_analyses: dict[str, dict[str, ArmAnalysisResult]] = {}
@@ -99,24 +107,24 @@ def analyze_experiment(
         # but make it explicit here for developer clarity.
         if cluster_col is not None:
             merged_df_dropna = merged_df.dropna(subset=[metric_name])
-            model = smf.ols(f"{metric_name} ~ arm_id", data=merged_df_dropna).fit(
+            model = smf.ols(f"{metric_name} ~ {arm_col}", data=merged_df_dropna).fit(
                 cov_type="cluster",
                 cov_kwds={"groups": merged_df_dropna[cluster_col]},
             )
         else:
-            model = smf.ols(f"{metric_name} ~ arm_id", data=merged_df, missing="drop").fit(cov_type="HC1")
-        arm_ids = model.model.data.design_info.factor_infos[EvalFactor("arm_id")].categories
+            model = smf.ols(f"{metric_name} ~ {arm_col}", data=merged_df, missing="drop").fit(cov_type="HC1")
+        arm_ids = model.model.data.design_info.factor_infos[EvalFactor(arm_col)].categories
 
         # Calculate CIs for coefficients
         confidence_intervals = model.conf_int(alpha=alpha)
         # Calculate predicted means and their CIs (will be extracted from the summary frame)
-        pred_input = pd.DataFrame({"arm_id": arm_ids})
+        pred_input = pd.DataFrame({arm_col: arm_ids})
         predictions = model.get_prediction(pred_input)
         pred_summary = predictions.summary_frame(alpha=alpha)
 
         for i, arm_id in enumerate(arm_ids):
             # Determine parameter name to use for lookingup the coefficient CIs
-            param_name = "Intercept" if i == 0 else f"arm_id[T.{arm_id}]"
+            param_name = "Intercept" if i == 0 else f"{arm_col}[T.{arm_id}]"
 
             arm_analyses[arm_id] = ArmAnalysisResult(
                 is_baseline=i == 0 if baseline_arm_id is None else arm_id == baseline_arm_id,

--- a/src/xngin/stats/test_analysis.py
+++ b/src/xngin/stats/test_analysis.py
@@ -9,6 +9,7 @@ import pytest
 
 from xngin.apiserver.dwh.analysis_types import MetricValue, ParticipantOutcome
 from xngin.stats.analysis import analyze_experiment
+from xngin.stats.stats_errors import StatsAnalysisError
 
 
 @pytest.fixture(name="test_assignments")
@@ -287,6 +288,18 @@ def test_analysis_with_cluster_col_missing_from_df_raises():
             arm_col="arm",
             cluster_col="missing_cluster_column",
         )
+
+
+def test_analysis_with_null_cluster_col_raises():
+    """Clustered analysis rejects assignments with null cluster identifiers."""
+    assignments_df = pd.DataFrame({
+        "participant_id": ["0", "1"],
+        "arm_id": ["control", "treatment"],
+        "cluster": [np.nan, "school_a"],
+    })
+
+    with pytest.raises(StatsAnalysisError, match="null cluster"):
+        analyze_experiment(assignments_df, [], cluster_col="cluster")
 
 
 def test_analysis_with_cluster_col_unequal_sizes():

--- a/src/xngin/stats/test_analysis.py
+++ b/src/xngin/stats/test_analysis.py
@@ -268,12 +268,25 @@ def test_analysis_with_cluster_col():
 def test_analysis_with_cluster_col_missing_from_df_raises():
     """analyze_experiment raises ValueError if cluster_col is missing from assignments_df."""
     assignments_df = pd.DataFrame({
-        "participant_id": [str(i) for i in range(100)],
-        "arm_id": ["arm1", "arm2"] * 50,
+        "participant": [str(i) for i in range(100)],
+        "arm": ["arm1", "arm2"] * 50,
     })
     unused_participant_outcomes: list[ParticipantOutcome] = []
-    with pytest.raises(ValueError, match=r"assignments_df shape is wrong: expected=.*missing_cluster_column"):
-        analyze_experiment(assignments_df, unused_participant_outcomes, cluster_col="missing_cluster_column")
+
+    with pytest.raises(ValueError, match="assignments_df shape is wrong: expected=arm_id,participant_id, "):
+        analyze_experiment(assignments_df, unused_participant_outcomes)
+
+    with pytest.raises(
+        ValueError,
+        match="assignments_df shape is wrong: expected=arm,missing_cluster_column,participant, got=arm,participant",
+    ):
+        analyze_experiment(
+            assignments_df,
+            unused_participant_outcomes,
+            unit_col="participant",
+            arm_col="arm",
+            cluster_col="missing_cluster_column",
+        )
 
 
 def test_analysis_with_cluster_col_unequal_sizes():


### PR DESCRIPTION
## Description

Followup to #269: use the persisted cluster_key values in the analysis of a preassigned cluster randomized experiment, by passing those values into `analyze_freq_experiment`.

## Future Tasks

Extend UI to report when we're looking at a cluster-randomized experiment so the user knows it's being analyzed accordingly. Related: #217 

## How has this been tested?

unittests
