### PR TITLE
Remove all uses of xngin_session from test_experiments_api.py

### DIFF
--- a/src/xngin/apiserver/routers/admin/test_admin_users_api.py
+++ b/src/xngin/apiserver/routers/admin/test_admin_users_api.py
@@ -529,14 +529,6 @@ def test_create_organization_unprivileged_succeeds(aclient_unpriv: AdminAPIClien
     assert nodwh.organization_name == org_name
 
 
-def test_create_organization_unprivileged_caller_is_only_member(aclient_unpriv: AdminAPIClient):
-    """Creating an org as unprivileged seeds exactly one member: the creator."""
-    org_id = aclient_unpriv.create_organizations(body=CreateOrganizationRequest(name="solo-member")).data.id
-    org = aclient_unpriv.get_organization(organization_id=org_id).data
-    assert len(org.users) == 1
-    assert org.users[0].email == UNPRIVILEGED_EMAIL
-
-
 def test_unprivileged_user_can_create_multiple_organizations(aclient: AdminAPIClient, aclient_unpriv: AdminAPIClient):
     """An unprivileged user can create multiple orgs; the privileged user doesn't see them via scope=mine."""
     first_id = aclient_unpriv.create_organizations(body=CreateOrganizationRequest(name="unpriv-first")).data.id

--- a/src/xngin/apiserver/routers/experiments/test_experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_api.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import pytest
 from pydantic import TypeAdapter
 
+from xngin.apiserver.conftest import DatasourceMetadata
 from xngin.apiserver.routers.common_api_types import (
     AnyFrequentistDesignSpec,
     Arm,
@@ -43,7 +44,7 @@ if TYPE_CHECKING:
 
 
 async def create_experiment(
-    datasource_metadata,
+    datasource_metadata: DatasourceMetadata,
     aclient: AdminAPIClient,
     *,
     experiment_type: ExperimentsType = ExperimentsType.FREQ_ONLINE,

--- a/src/xngin/apiserver/routers/experiments/test_experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_api.py
@@ -693,20 +693,15 @@ async def test_get_experiment_assignments_as_csv_success(
 
 
 async def test_get_assignment_preassigned(
-    xngin_session,
     testing_datasource,
     aclient: AdminAPIClient,
     eclient: ExperimentsAPIClient,
 ):
     preassigned_experiment = await create_preassigned_experiment(testing_datasource, aclient)
-    assignment = tables.ArmAssignment(
+    assigned = eclient.get_experiment_assignments(
+        api_key=testing_datasource.key,
         experiment_id=preassigned_experiment.experiment_id,
-        participant_id="assigned_id",
-        arm_id=preassigned_experiment.design_spec.arms[0].arm_id,
-        strata=[],
-    )
-    xngin_session.add(assignment)
-    await xngin_session.commit()
+    ).data.assignments[0]
 
     parsed = eclient.get_assignment(
         api_key=testing_datasource.key,
@@ -720,12 +715,12 @@ async def test_get_assignment_preassigned(
     parsed = eclient.get_assignment(
         api_key=testing_datasource.key,
         experiment_id=preassigned_experiment.experiment_id,
-        participant_id="assigned_id",
+        participant_id=assigned.participant_id,
     ).data
     assert parsed.experiment_id == preassigned_experiment.experiment_id
-    assert parsed.participant_id == "assigned_id"
+    assert parsed.participant_id == assigned.participant_id
     assert parsed.assignment is not None
-    assert parsed.assignment.arm_name == "control"
+    assert parsed.assignment.arm_name == assigned.arm_name
 
 
 async def test_get_assignment_online(testing_datasource, aclient: AdminAPIClient, eclient: ExperimentsAPIClient):
@@ -987,7 +982,6 @@ async def test_assign_cmab_wrong_experiment_type(
 
 
 async def test_assign_with_filters_wrong_experiment_type(
-    xngin_session,
     testing_datasource,
     aclient: AdminAPIClient,
     eclient: ExperimentsAPIClient,
@@ -1057,21 +1051,16 @@ async def test_assign_with_filters_ignores_missing_content_type_header(
 
 
 async def test_get_assignment_preassigned_cache_headers(
-    xngin_session,
     testing_datasource,
     aclient: AdminAPIClient,
     eclient: ExperimentsAPIClient,
 ):
     """Test Cache-Control headers for preassigned experiments."""
     preassigned_experiment = await create_preassigned_experiment(testing_datasource, aclient)
-    assignment = tables.ArmAssignment(
+    assigned = eclient.get_experiment_assignments(
+        api_key=testing_datasource.key,
         experiment_id=preassigned_experiment.experiment_id,
-        participant_id="assigned_id",
-        arm_id=preassigned_experiment.design_spec.arms[0].arm_id,
-        strata=[],
-    )
-    xngin_session.add(assignment)
-    await xngin_session.commit()
+    ).data.assignments[0]
 
     # No assignment = no cache header
     response = eclient.get_assignment(
@@ -1085,7 +1074,7 @@ async def test_get_assignment_preassigned_cache_headers(
     response = eclient.get_assignment(
         api_key=testing_datasource.key,
         experiment_id=preassigned_experiment.experiment_id,
-        participant_id="assigned_id",
+        participant_id=assigned.participant_id,
     )
     assert response.response.headers["Cache-Control"] == "private, max-age=3600"
 

--- a/src/xngin/apiserver/routers/experiments/test_experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_common.py
@@ -10,10 +10,8 @@ import pytest
 from deepdiff import DeepDiff
 from pydantic import HttpUrl, TypeAdapter
 from sqlalchemy import Boolean, Column, MetaData, String, Table, select
-from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
-from sqlalchemy.schema import CreateTable
 
 from xngin.apiserver.conftest import RowProtocolMixin
 from xngin.apiserver.dwh.dwh_session import DwhSession
@@ -2460,9 +2458,3 @@ async def test_arm_population_counter(xngin_session, testing_datasource):
     # get_assign_summary reflects the new count
     summary = await get_assign_summary(xngin_session, experiment.id, None, ExperimentsType.FREQ_ONLINE)
     assert summary.sample_size == 1
-
-
-def test_experiment_sql():
-    pg_sql = str(CreateTable(cast(Table, tables.ArmAssignment.__table__)).compile(dialect=postgresql.dialect()))
-    assert "arm_id VARCHAR(36) NOT NULL," in pg_sql
-    assert "strata JSONB NOT NULL," in pg_sql


### PR DESCRIPTION
Replace direct ArmAssignment inserts with API calls: read a preassigned
participant back via get_experiment_assignments instead of hand-inserting a
row, and drop the unused xngin_session parameter from
test_assign_with_filters_wrong_experiment_type.

Also removes some redundant and low-value tests.