### PR TITLE
Handle check_power() errors in MDE mode

### DIFF
--- a/src/xngin/apiserver/exceptionhandlers.py
+++ b/src/xngin/apiserver/exceptionhandlers.py
@@ -63,7 +63,7 @@ def setup(app):
 
     @app.exception_handler(StatsError)
     async def exception_handler_statsmodelerror(_request: Request, exc: StatsError):
-        return JSONResponse(status_code=422, content=as_fastapi_http_validation_error(str(exc), "stats"))
+        return JSONResponse(status_code=422, content=as_fastapi_http_validation_error(str(exc), exc.__class__.__name__))
 
     @app.exception_handler(sqlalchemy.exc.OperationalError)
     async def exception_handler_sqlalchemy_opex(_request: Request, exc: sqlalchemy.exc.OperationalError):

--- a/src/xngin/apiserver/routers/admin/test_admin_api.py
+++ b/src/xngin/apiserver/routers/admin/test_admin_api.py
@@ -1845,7 +1845,7 @@ async def test_power_check_when_sample_size_insufficient_and_desired_n_has_data_
 
 
 def test_power_check_when_sample_size_sufficient_and_desired_n_fails(testing_datasource, aclient: AdminAPIClient):
-    """Although desired_n enrichment fails, we still preserve the minimum sample size result."""
+    """Invalid desired_n raises StatsPowerError."""
     design_spec = PreassignedFrequentistExperimentSpec(
         experiment_type=ExperimentsType.FREQ_PREASSIGNED,
         experiment_name="test power check desired_n failure",
@@ -1864,17 +1864,8 @@ def test_power_check_when_sample_size_sufficient_and_desired_n_fails(testing_dat
         desired_n=0,  # This should raise a ValueError as a precheck during the MDE calculation.
     )
 
-    power_response = aclient.power_check(
-        datasource_id=testing_datasource.datasource_id,
-        body=PowerRequest(design_spec=design_spec),
-    ).data
-    assert len(power_response.analyses) == 1
-    analysis = power_response.analyses[0]
-    # Primary analysis result (min sample size) still present even though desired_n MDE failed.
-    assert analysis.target_n == 474
-    assert analysis.msg is not None
-    assert analysis.msg.type == MetricPowerAnalysisMessageType.SUFFICIENT
-    assert analysis.pct_change_with_desired_n is None
+    with expect_status_code(422, detail_contains="Chosen sample size must be positive"):
+        aclient.power_check(datasource_id=testing_datasource.datasource_id, body=PowerRequest(design_spec=design_spec))
 
 
 async def test_power_check_validations(testing_datasource, aclient: AdminAPIClient):

--- a/src/xngin/apiserver/routers/power_adapters.py
+++ b/src/xngin/apiserver/routers/power_adapters.py
@@ -40,7 +40,7 @@ def calculate_icc_and_cv_from_database(
     try:
         icc = calculate_icc_from_dataframe(df, cluster_column=cluster_column, outcome_column=outcome_column)
     except ValueError as verr:
-        raise StatsPowerError(verr, outcome_column) from verr
+        raise StatsPowerError.from_error(verr, outcome_column) from verr
 
     return {
         "icc": icc,

--- a/src/xngin/stats/power.py
+++ b/src/xngin/stats/power.py
@@ -145,25 +145,29 @@ def check_power(
 
             # Optional desired_n MDE calculation added to the min sample size analysis:
             if desired_n is not None:
-                try:
-                    mde_analysis = analyze_metric_power(
-                        metric=metric,
-                        n_arms=n_arms,
-                        arm_weights=arm_weights,
-                        desired_n=desired_n,
-                        power=power,
-                        alpha=alpha,
-                    )
-                    # pct_change_possible may be None if there was any error created with
-                    # power_analysis_error().
-                    if mde_analysis.pct_change_possible is not None:
-                        analysis.pct_change_with_desired_n = mde_analysis.pct_change_possible
-                except ValueError:
-                    # Preserve the primary minimum-sample-size result when the optional MDE cannot
-                    # be computed.
-                    pass
+                mde_analysis = analyze_metric_power(
+                    metric=metric,
+                    n_arms=n_arms,
+                    arm_weights=arm_weights,
+                    desired_n=desired_n,
+                    power=power,
+                    alpha=alpha,
+                )
+                # pct_change_possible may be None if there was any error created with
+                # power_analysis_error().
+                if mde_analysis.pct_change_possible is not None:
+                    analysis.pct_change_with_desired_n = mde_analysis.pct_change_possible
 
             analyses.append(analysis)
+
+        except ZeroDivisionError as zde:
+            raise StatsPowerError("Zero division - You likely have too few samples.") from zde
         except ValueError as verr:
-            raise StatsPowerError(verr, metric.field_name) from verr
+            if "f(a) and f(b) must have different signs" in str(verr):
+                raise StatsPowerError(
+                    "Unable to solve. Check your sample size, effect size, or significance parameters."
+                ) from verr
+
+            raise StatsPowerError.from_error(verr, metric.field_name) from verr
+
     return analyses

--- a/src/xngin/stats/stats_errors.py
+++ b/src/xngin/stats/stats_errors.py
@@ -12,8 +12,12 @@ class StatsPowerError(StatsError):
     - metric_type must be NUMERIC or BINARY.
     """
 
-    def __init__(self, verr: ValueError, metric_field_name: str):
-        super().__init__(f"Power calc error for metric {metric_field_name}: {verr}")
+    def __init__(self, message: str):
+        super().__init__(message)
+
+    @classmethod
+    def from_error(cls, verr: Exception, metric_field_name: str):
+        return cls(f"Power calc error for metric {metric_field_name}: {verr}")
 
 
 class StatsBalanceError(StatsError):

--- a/src/xngin/stats/test_power.py
+++ b/src/xngin/stats/test_power.py
@@ -467,8 +467,8 @@ def test_check_power_with_desired_n():
     assert results[1].pct_change_with_desired_n == pytest.approx(-0.7998, abs=1e-4)
 
 
-def test_check_power_with_invalid_desired_n_preserves_primary_result():
-    """Invalid desired_n should not discard the minimum-sample-size analysis."""
+def test_check_power_with_invalid_desired_n_raises():
+    """Invalid desired_n raises StatsPowerError."""
     metric = DesignSpecMetric(
         field_name="metric1",
         metric_type=MetricType.NUMERIC,
@@ -479,13 +479,9 @@ def test_check_power_with_invalid_desired_n_preserves_primary_result():
         available_nonnull_n=10000,
     )
 
-    result = check_power([metric], n_arms=2, desired_n=0)[0]
-
-    assert result.target_n == 506
-    assert result.sufficient_n is True
-    assert result.msg is not None
-    assert result.msg.type == MetricPowerAnalysisMessageType.SUFFICIENT
-    assert result.pct_change_with_desired_n is None
+    with pytest.raises(StatsPowerError) as excinfo:
+        check_power([metric], n_arms=2, desired_n=0)
+    assert "Chosen sample size must be positive" in str(excinfo.value)
 
 
 def test_analyze_metric_power_without_desired_n_still_works():


### PR DESCRIPTION
No longer swallows the errors, but rather propagates them up to the outer try/except, so that it can explicitly handle some internal statsmodels errors and return friendlier messages.

Also refactors StatsPowerError to allow those custom messages, and the top level exception handler to display the specific StatsError class name instead of just a generic (stats).

## Ticket

Fixes #EVE-34

## Related PRs

https://github.com/agency-fund/evidential-fe/pull/262

## How has this been tested?

unittest updates
