### PR TITLE
Simplify the Taskfile.

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -20,6 +20,7 @@ env:
 
   # Disable Atlas telemetry.
   ATLAS_NO_ANON_TELEMETRY: "true"
+  ATLAS_NO_UPDATE_NOTIFIER: "true"
   DO_NOT_TRACK: "1"
 
   # Allow connecting to data warehouses residing in private IP ranges.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -262,12 +262,6 @@ tasks:
     desc: "Rehash your migration file (see atlas.sum) if you had to modify the generated migration file afterwards, e.g. to add a custom backfill."
     cmds:
       - uv run atlas migrate hash --env sa_postgres
-  migration-reset:
-    desc: "Drop the local development database's schema, tables, and Atlas migration state. Use this when your local database is out of sync with merged migrations."
-    cmds:
-      - uv run atlas schema clean --env sa_postgres --url "{{.XNGIN_DEVAPP_STANDARD_DSN}}"
-      - psql "{{.XNGIN_DEVAPP_STANDARD_DSN}}" -c "CREATE SCHEMA public;"
-      - task: apply-migrations
   migration-lint:
     desc: "Lint the latest migration file. Add 'LATEST=N' to lint the N most recent files."
     vars:


### PR DESCRIPTION
- **Disable atlas update notifier.**: This triggers unnecessary DNS calls.
- **Remove `task migration-reset`**: `task drop-databases` is sufficient and safer.
