### PR TITLE
Fix cluster assignment

### DIFF
--- a/migrations/sa_postgres/20260623120000_desired_n_clusters.sql
+++ b/migrations/sa_postgres/20260623120000_desired_n_clusters.sql
@@ -1,0 +1,2 @@
+-- Modify "experiments" table
+ALTER TABLE "public"."experiments" ADD COLUMN "desired_n_clusters" integer NULL;

--- a/migrations/sa_postgres/atlas.sum
+++ b/migrations/sa_postgres/atlas.sum
@@ -1,4 +1,4 @@
-h1:DGR5lKY6xtnfrwov5iwnnNwI3YGrNlW9KBCyMu45uag=
+h1:qFBda4vjmv+JNfBuIt3yc5y9CplGbdzQebltmELGWa4=
 20250109001424.sql h1:rFnjr3K1r+c46OGB5mVeN54Q6iOqSP5uWrfwdyDVTE4=
 20250216030513.sql h1:2H8Ot6o31I1LRS40b8AuiOZWAXQDbwdB+/1bp7nWJFg=
 20250226001153.sql h1:b0eC97alXiMQh52zfKHU6eP5IIyPPRBKXwnjqnjVygg=
@@ -72,3 +72,4 @@ h1:DGR5lKY6xtnfrwov5iwnnNwI3YGrNlW9KBCyMu45uag=
 20260619104620.sql h1:dzuwtU10rlYhyznSauvLn5MsK49M+S2gBXPTqC1/Z+g=
 20260619111757.sql h1:626EyjMYKqJqgJ30wHvOjGaEddyXO6x0jpoTl/ye8ew=
 20260623031104_arm_stats_cluster_count.sql h1:TVx7phjUBRQGovasPztcOMlJsArfXZi6gtzBrzeLSPQ=
+20260623120000_desired_n_clusters.sql h1:jp3lAp0B82VnqQZRxxGWOv3N0IfbGRJ17bm4cUGfhDw=

--- a/src/xngin/apiserver/dwh/dwh_session.py
+++ b/src/xngin/apiserver/dwh/dwh_session.py
@@ -8,7 +8,7 @@ from typing import Self
 import google.api_core.exceptions
 import sqlalchemy
 from loguru import logger
-from sqlalchemy import Engine, Inspector, event, text
+from sqlalchemy import ColumnElement, Engine, Inspector, event, text
 from sqlalchemy.engine.interfaces import DBAPIConnection
 from sqlalchemy.exc import NoSuchTableError, OperationalError
 from sqlalchemy.orm import Session
@@ -272,7 +272,7 @@ class DwhSession:
         self,
         table_name: str,
         filters: list[Filter],
-        compose_query: Callable[[sqlalchemy.Table, list[Filter]], sqlalchemy.Select],
+        compose_query: Callable[[sqlalchemy.Table, list[ColumnElement]], sqlalchemy.Select],
         use_sa_autoload: bool | None = None,
     ) -> GetParticipantsResult:
         """Inspects ``table_name``, runs the query built by ``compose_query``, and wraps the resulting rows.
@@ -284,7 +284,7 @@ class DwhSession:
         sa_table = self._inspect_table_blocking(table_name, use_sa_autoload=use_sa_autoload)
         sqla_filters = query_constructors.create_query_filters(sa_table, filters)
         participants = self.session.execute(compose_query(sa_table, sqla_filters)).all()
-        return GetParticipantsResult(sa_table=sa_table, participants=participants)
+        return GetParticipantsResult(sa_table=sa_table, participants=list(participants))
 
     def _get_participants_blocking(
         self,

--- a/src/xngin/apiserver/dwh/dwh_session.py
+++ b/src/xngin/apiserver/dwh/dwh_session.py
@@ -1,6 +1,7 @@
 """Async context manager for data warehouse connections."""
 
 import asyncio
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Self
 
@@ -267,36 +268,23 @@ class DwhSession:
             use_sa_autoload,
         )
 
-    def _query_for_participants_blocking(
+    def _get_result_blocking(
         self,
-        sa_table: sqlalchemy.Table,
-        select_columns: set[str],
+        table_name: str,
         filters: list[Filter],
-        desired_n: int,
-    ):
-        """Samples participants."""
-        sqla_filters = query_constructors.create_query_filters(sa_table, filters)
-        query = query_constructors.compose_query(sa_table, select_columns, sqla_filters, desired_n)
-        return self.session.execute(query).all()
+        compose_query: Callable[[sqlalchemy.Table, list[Filter]], sqlalchemy.Select],
+        use_sa_autoload: bool | None = None,
+    ) -> GetParticipantsResult:
+        """Inspects ``table_name``, runs the query built by ``compose_query``, and wraps the resulting rows.
 
-    def _query_for_clusters_blocking(
-        self,
-        sa_table: sqlalchemy.Table,
-        select_columns: set[str],
-        filters: list[Filter],
-        desired_n_clusters: int,
-        cluster_key: str,
-    ):
-        """Samples clusters and returns participants belonging to those clusters."""
+        ``compose_query`` receives the inspected table and the SQLAlchemy-translated ``filters`` and returns
+        the query to execute. Both individual-level and cluster-level sampling paths provide their
+        custom composer while sharing remaining logic.
+        """
+        sa_table = self._inspect_table_blocking(table_name, use_sa_autoload=use_sa_autoload)
         sqla_filters = query_constructors.create_query_filters(sa_table, filters)
-        query = query_constructors.compose_cluster_query(
-            sa_table,
-            select_columns | {cluster_key},
-            sqla_filters,
-            desired_n_clusters,
-            cluster_key,
-        )
-        return self.session.execute(query).all()
+        participants = self.session.execute(compose_query(sa_table, sqla_filters)).all()
+        return GetParticipantsResult(sa_table=sa_table, participants=participants)
 
     def _get_participants_blocking(
         self,
@@ -306,9 +294,12 @@ class DwhSession:
         n: int,
         use_sa_autoload: bool | None = None,
     ) -> GetParticipantsResult:
-        sa_table = self._inspect_table_blocking(table_name, use_sa_autoload=use_sa_autoload)
-        participants = self._query_for_participants_blocking(sa_table, select_columns, filters, n)
-        return GetParticipantsResult(sa_table=sa_table, participants=participants)
+        return self._get_result_blocking(
+            table_name,
+            filters,
+            lambda sa_table, sqla_filters: query_constructors.compose_query(sa_table, select_columns, sqla_filters, n),
+            use_sa_autoload,
+        )
 
     def _get_clusters_blocking(
         self,
@@ -319,15 +310,18 @@ class DwhSession:
         cluster_key: str,
         use_sa_autoload: bool | None = None,
     ) -> GetParticipantsResult:
-        sa_table = self._inspect_table_blocking(table_name, use_sa_autoload=use_sa_autoload)
-        participants = self._query_for_clusters_blocking(
-            sa_table,
-            select_columns,
+        return self._get_result_blocking(
+            table_name,
             filters,
-            desired_n_clusters,
-            cluster_key,
+            lambda sa_table, sqla_filters: query_constructors.compose_cluster_query(
+                sa_table,
+                select_columns | {cluster_key},
+                sqla_filters,
+                desired_n_clusters,
+                cluster_key,
+            ),
+            use_sa_autoload,
         )
-        return GetParticipantsResult(sa_table=sa_table, participants=participants)
 
     async def get_participants(
         self,

--- a/src/xngin/apiserver/dwh/dwh_session.py
+++ b/src/xngin/apiserver/dwh/dwh_session.py
@@ -279,6 +279,25 @@ class DwhSession:
         query = query_constructors.compose_query(sa_table, select_columns, sqla_filters, desired_n)
         return self.session.execute(query).all()
 
+    def _query_for_clusters_blocking(
+        self,
+        sa_table: sqlalchemy.Table,
+        select_columns: set[str],
+        filters: list[Filter],
+        desired_cluster_n: int,
+        cluster_key: str,
+    ):
+        """Samples clusters and returns participants belonging to those clusters."""
+        sqla_filters = query_constructors.create_query_filters(sa_table, filters)
+        query = query_constructors.compose_cluster_query(
+            sa_table,
+            select_columns | {cluster_key},
+            sqla_filters,
+            desired_cluster_n,
+            cluster_key,
+        )
+        return self.session.execute(query).all()
+
     def _get_participants_blocking(
         self,
         table_name: str,
@@ -289,6 +308,25 @@ class DwhSession:
     ) -> GetParticipantsResult:
         sa_table = self._inspect_table_blocking(table_name, use_sa_autoload=use_sa_autoload)
         participants = self._query_for_participants_blocking(sa_table, select_columns, filters, n)
+        return GetParticipantsResult(sa_table=sa_table, participants=participants)
+
+    def _get_clusters_blocking(
+        self,
+        table_name: str,
+        select_columns: set[str],
+        filters: list[Filter],
+        desired_cluster_n: int,
+        cluster_key: str,
+        use_sa_autoload: bool | None = None,
+    ) -> GetParticipantsResult:
+        sa_table = self._inspect_table_blocking(table_name, use_sa_autoload=use_sa_autoload)
+        participants = self._query_for_clusters_blocking(
+            sa_table,
+            select_columns,
+            filters,
+            desired_cluster_n,
+            cluster_key,
+        )
         return GetParticipantsResult(sa_table=sa_table, participants=participants)
 
     async def get_participants(
@@ -306,6 +344,7 @@ class DwhSession:
 
         Args:
             table_name: Name of the table to query
+            select_columns: DWH columns to return.
             filters: Filter conditions to apply
             n: Number of participants to retrieve
             use_sa_autoload: Whether to use SQLAlchemy reflection. If None, uses config default.
@@ -319,6 +358,44 @@ class DwhSession:
             select_columns,
             filters,
             n,
+            use_sa_autoload,
+        )
+
+    async def get_clusters_of_participants(
+        self,
+        table_name: str,
+        *,
+        select_columns: set[str],
+        filters: list[Filter],
+        desired_cluster_n: int,
+        cluster_key: str,
+        use_sa_autoload: bool | None = None,
+    ) -> GetParticipantsResult:
+        """Get participants from a random sample of clusters.
+
+        The random sample is taken over distinct values of ``cluster_key`` after applying ``filters``.
+        Returned participants are the filtered rows belonging to the sampled clusters.
+
+        Caveats documented on inspect_table() apply to the returned Table.
+
+        Args:
+            table_name: Name of the table to query
+            select_columns: DWH columns to return. ``cluster_key`` is always included.
+            filters: Filter conditions to apply before sampling clusters and fetching participants
+            desired_cluster_n: Number of clusters to sample
+            cluster_key: Column containing cluster identifiers
+            use_sa_autoload: Whether to use SQLAlchemy reflection. If None, uses config default.
+
+        Returns:
+            GetParticipantsResult containing both the SQLAlchemy table and participant query results
+        """
+        return await asyncio.to_thread(
+            self._get_clusters_blocking,
+            table_name,
+            select_columns,
+            filters,
+            desired_cluster_n,
+            cluster_key,
             use_sa_autoload,
         )
 

--- a/src/xngin/apiserver/dwh/dwh_session.py
+++ b/src/xngin/apiserver/dwh/dwh_session.py
@@ -284,7 +284,7 @@ class DwhSession:
         sa_table: sqlalchemy.Table,
         select_columns: set[str],
         filters: list[Filter],
-        desired_cluster_n: int,
+        desired_n_clusters: int,
         cluster_key: str,
     ):
         """Samples clusters and returns participants belonging to those clusters."""
@@ -293,7 +293,7 @@ class DwhSession:
             sa_table,
             select_columns | {cluster_key},
             sqla_filters,
-            desired_cluster_n,
+            desired_n_clusters,
             cluster_key,
         )
         return self.session.execute(query).all()
@@ -315,7 +315,7 @@ class DwhSession:
         table_name: str,
         select_columns: set[str],
         filters: list[Filter],
-        desired_cluster_n: int,
+        desired_n_clusters: int,
         cluster_key: str,
         use_sa_autoload: bool | None = None,
     ) -> GetParticipantsResult:
@@ -324,7 +324,7 @@ class DwhSession:
             sa_table,
             select_columns,
             filters,
-            desired_cluster_n,
+            desired_n_clusters,
             cluster_key,
         )
         return GetParticipantsResult(sa_table=sa_table, participants=participants)
@@ -367,7 +367,7 @@ class DwhSession:
         *,
         select_columns: set[str],
         filters: list[Filter],
-        desired_cluster_n: int,
+        desired_n_clusters: int,
         cluster_key: str,
         use_sa_autoload: bool | None = None,
     ) -> GetParticipantsResult:
@@ -382,7 +382,7 @@ class DwhSession:
             table_name: Name of the table to query
             select_columns: DWH columns to return. ``cluster_key`` is always included.
             filters: Filter conditions to apply before sampling clusters and fetching participants
-            desired_cluster_n: Number of clusters to sample
+            desired_n_clusters: Number of clusters to sample
             cluster_key: Column containing cluster identifiers
             use_sa_autoload: Whether to use SQLAlchemy reflection. If None, uses config default.
 
@@ -394,7 +394,7 @@ class DwhSession:
             table_name,
             select_columns,
             filters,
-            desired_cluster_n,
+            desired_n_clusters,
             cluster_key,
             use_sa_autoload,
         )

--- a/src/xngin/apiserver/dwh/dwh_test_support.py
+++ b/src/xngin/apiserver/dwh/dwh_test_support.py
@@ -90,9 +90,18 @@ class SampleTable(Base):
     experiment_ids = mapped_column(String, nullable=False)
 
 
+class SampleClusteredTable(Base):
+    __tablename__ = "test_clustered_table"
+
+    id = mapped_column(Integer, primary_key=True, autoincrement=False)
+    cluster_key = mapped_column(String, nullable=False)
+    int_col = mapped_column(Integer, nullable=False)
+
+
 class SampleTables(NamedTuple):
     sample_table: Table
     sample_nullable_table: Table
+    sample_clustered_table: Table
 
 
 @dataclass
@@ -133,6 +142,27 @@ SAMPLE_TABLE_ROWS = [
     ROW_100,
     ROW_200,
     ROW_300,
+]
+
+
+@dataclass
+class ClusteredRow:
+    id: int
+    cluster_key: str
+    int_col: int
+
+
+SAMPLE_CLUSTERED_TABLE_ROWS = [
+    ClusteredRow(id=1, cluster_key="a", int_col=10),
+    ClusteredRow(id=2, cluster_key="a", int_col=20),
+    ClusteredRow(id=3, cluster_key="b", int_col=30),
+    ClusteredRow(id=4, cluster_key="b", int_col=40),
+    ClusteredRow(id=5, cluster_key="b", int_col=50),
+    ClusteredRow(id=6, cluster_key="c", int_col=60),
+    ClusteredRow(id=7, cluster_key="d", int_col=70),
+    ClusteredRow(id=8, cluster_key="d", int_col=80),
+    ClusteredRow(id=9, cluster_key="d", int_col=90),
+    ClusteredRow(id=10, cluster_key="d", int_col=100),
 ]
 
 
@@ -188,10 +218,12 @@ def fixture_shared_sample_tables(queries_dwh_engine):
             session.add(SampleTable(**row.__dict__))
         for nullable_row in SAMPLE_NULLABLE_TABLE_ROWS:
             session.add(SampleNullableTable(**nullable_row.__dict__))
+        for clustered_row in SAMPLE_CLUSTERED_TABLE_ROWS:
+            session.add(SampleClusteredTable(**clustered_row.__dict__))
         session.commit()
 
     try:
-        yield SampleTables(SampleTable.get_table(), SampleNullableTable.get_table())
+        yield SampleTables(SampleTable.get_table(), SampleNullableTable.get_table(), SampleClusteredTable.get_table())
     finally:
         Base.metadata.drop_all(queries_dwh_engine)
 

--- a/src/xngin/apiserver/dwh/query_constructors.py
+++ b/src/xngin/apiserver/dwh/query_constructors.py
@@ -124,7 +124,7 @@ def compose_cluster_query(
     sa_table: Table,
     select_columns: set[str],
     filters: list[ColumnElement],
-    desired_cluster_n: int,
+    desired_n_clusters: int,
     cluster_key: str,
 ):
     """Builds a query that fetches rows belonging to a random sample of clusters."""
@@ -146,7 +146,7 @@ def compose_cluster_query(
     sampled_clusters = (
         select(sampled_cluster_col)
         .order_by(custom_functions.Random(sa_table=eligible_clusters))
-        .limit(desired_cluster_n)
+        .limit(desired_n_clusters)
     )
 
     return select(*columns).filter(*filters, cluster_col.in_(sampled_clusters))

--- a/src/xngin/apiserver/dwh/query_constructors.py
+++ b/src/xngin/apiserver/dwh/query_constructors.py
@@ -105,9 +105,8 @@ def create_inspect_table_from_cursor_query(table_name: str, schema_name: str | N
     return select(text("*")).select_from(table).limit(0)
 
 
-def compose_query(sa_table: Table, select_columns: set[str], filters: list[ColumnElement], desired_n: int):
-    """Builds a query to fetch rows from a list of filters and a set of column names to select."""
-
+def _resolve_columns(sa_table: Table, select_columns: set[str]) -> list[ColumnElement]:
+    """Resolves a set of column names to their SQLAlchemy columns, sorted by name for stable generated SQL."""
     if not select_columns:
         raise ValueError("select_columns must have at least one item.")
 
@@ -116,7 +115,12 @@ def compose_query(sa_table: Table, select_columns: set[str], filters: list[Colum
         if col not in sa_table.c:
             raise ValueError(f"Column {col} not found in schema.")
         columns.append(sa_table.c[col])
+    return columns
 
+
+def compose_query(sa_table: Table, select_columns: set[str], filters: list[ColumnElement], desired_n: int):
+    """Builds a query to fetch rows from a list of filters and a set of column names to select."""
+    columns = _resolve_columns(sa_table, select_columns)
     return select(*columns).filter(*filters).order_by(custom_functions.Random(sa_table=sa_table)).limit(desired_n)
 
 
@@ -128,18 +132,12 @@ def compose_cluster_query(
     cluster_key: str,
 ):
     """Builds a query that fetches rows belonging to a random sample of clusters."""
-
-    if not select_columns:
-        raise ValueError("select_columns must have at least one item.")
+    # cluster_key is validated separately because callers may sample on a column they don't select.
     if cluster_key not in sa_table.c:
         raise ValueError(f"Column {cluster_key} not found in schema.")
+    columns = _resolve_columns(sa_table, select_columns)
 
-    columns = []
-    for col in sorted(select_columns):  # sort for stable generated sql
-        if col not in sa_table.c:
-            raise ValueError(f"Column {col} not found in schema.")
-        columns.append(sa_table.c[col])
-
+    # Sample the clusters from those that have at least one row matching the filters.
     cluster_col = sa_table.c[cluster_key]
     eligible_clusters = select(cluster_col).filter(*filters).group_by(cluster_col).subquery()
     sampled_cluster_col = eligible_clusters.c[cluster_key]
@@ -149,4 +147,6 @@ def compose_cluster_query(
         .limit(desired_n_clusters)
     )
 
+    # Re-apply ``filters`` (not just cluster membership) so we return only the matching rows within each
+    # sampled cluster, consistent with the filtering used to choose the clusters above.
     return select(*columns).filter(*filters, cluster_col.in_(sampled_clusters))

--- a/src/xngin/apiserver/dwh/query_constructors.py
+++ b/src/xngin/apiserver/dwh/query_constructors.py
@@ -110,7 +110,7 @@ def _resolve_columns(sa_table: Table, select_columns: set[str]) -> list[ColumnEl
     if not select_columns:
         raise ValueError("select_columns must have at least one item.")
 
-    columns = []
+    columns: list[ColumnElement] = []
     for col in sorted(select_columns):  # sort for stable generated sql
         if col not in sa_table.c:
             raise ValueError(f"Column {col} not found in schema.")

--- a/src/xngin/apiserver/dwh/query_constructors.py
+++ b/src/xngin/apiserver/dwh/query_constructors.py
@@ -118,3 +118,35 @@ def compose_query(sa_table: Table, select_columns: set[str], filters: list[Colum
         columns.append(sa_table.c[col])
 
     return select(*columns).filter(*filters).order_by(custom_functions.Random(sa_table=sa_table)).limit(desired_n)
+
+
+def compose_cluster_query(
+    sa_table: Table,
+    select_columns: set[str],
+    filters: list[ColumnElement],
+    desired_cluster_n: int,
+    cluster_key: str,
+):
+    """Builds a query that fetches rows belonging to a random sample of clusters."""
+
+    if not select_columns:
+        raise ValueError("select_columns must have at least one item.")
+    if cluster_key not in sa_table.c:
+        raise ValueError(f"Column {cluster_key} not found in schema.")
+
+    columns = []
+    for col in sorted(select_columns):  # sort for stable generated sql
+        if col not in sa_table.c:
+            raise ValueError(f"Column {col} not found in schema.")
+        columns.append(sa_table.c[col])
+
+    cluster_col = sa_table.c[cluster_key]
+    sampled_clusters = (
+        select(cluster_col)
+        .filter(*filters)
+        .group_by(cluster_col)
+        .order_by(custom_functions.Random(sa_table=sa_table))
+        .limit(desired_cluster_n)
+    )
+
+    return select(*columns).filter(*filters, cluster_col.in_(sampled_clusters))

--- a/src/xngin/apiserver/dwh/query_constructors.py
+++ b/src/xngin/apiserver/dwh/query_constructors.py
@@ -141,11 +141,11 @@ def compose_cluster_query(
         columns.append(sa_table.c[col])
 
     cluster_col = sa_table.c[cluster_key]
+    eligible_clusters = select(cluster_col).filter(*filters).group_by(cluster_col).subquery()
+    sampled_cluster_col = eligible_clusters.c[cluster_key]
     sampled_clusters = (
-        select(cluster_col)
-        .filter(*filters)
-        .group_by(cluster_col)
-        .order_by(custom_functions.Random(sa_table=sa_table))
+        select(sampled_cluster_col)
+        .order_by(custom_functions.Random(sa_table=eligible_clusters))
         .limit(desired_cluster_n)
     )
 

--- a/src/xngin/apiserver/dwh/test_query_constructors.py
+++ b/src/xngin/apiserver/dwh/test_query_constructors.py
@@ -364,7 +364,7 @@ def test_compose_cluster_query_samples_clusters_and_returns_all_cluster_rows(que
         table,
         select_columns={"id", "int_col", "cluster_key"},
         filters=[],
-        desired_cluster_n=2,
+        desired_n_clusters=2,
         cluster_key="cluster_key",
     )
     rows = queries_dwh_session.execute(q).all()
@@ -396,7 +396,7 @@ def test_compose_cluster_query_raises_when_cluster_key_is_missing(shared_sample_
             table,
             select_columns={"id"},
             filters=[],
-            desired_cluster_n=2,
+            desired_n_clusters=2,
             cluster_key="missing_cluster_key",
         )
 
@@ -410,7 +410,7 @@ def test_compose_cluster_query_works_with_deterministic_random(queries_dwh_sessi
             table,
             select_columns={"id", "cluster_key"},
             filters=[],
-            desired_cluster_n=2,
+            desired_n_clusters=2,
             cluster_key="cluster_key",
         )
         rows = queries_dwh_session.execute(q).all()

--- a/src/xngin/apiserver/dwh/test_query_constructors.py
+++ b/src/xngin/apiserver/dwh/test_query_constructors.py
@@ -31,6 +31,7 @@ from xngin.apiserver.exceptions_common import LateValidationError
 from xngin.apiserver.routers.common_api_types import Filter, Relation
 from xngin.apiserver.routers.common_enums import DataType
 from xngin.apiserver.routers.experiments.test_property_filters import ALL_FILTER_CASES
+from xngin.db_extensions import custom_functions
 
 pytest_plugins = ("xngin.apiserver.dwh.dwh_test_support",)
 
@@ -398,6 +399,26 @@ def test_compose_cluster_query_raises_when_cluster_key_is_missing(shared_sample_
             desired_cluster_n=2,
             cluster_key="missing_cluster_key",
         )
+
+
+def test_compose_cluster_query_works_with_deterministic_random(queries_dwh_session, shared_sample_tables):
+    table: Table = shared_sample_tables.sample_clustered_table
+    old_value = custom_functions.USE_DETERMINISTIC_RANDOM
+    custom_functions.USE_DETERMINISTIC_RANDOM = True
+    try:
+        q = compose_cluster_query(
+            table,
+            select_columns={"id", "cluster_key"},
+            filters=[],
+            desired_cluster_n=2,
+            cluster_key="cluster_key",
+        )
+        rows = queries_dwh_session.execute(q).all()
+    finally:
+        custom_functions.USE_DETERMINISTIC_RANDOM = old_value
+
+    assert {row.cluster_key for row in rows} == {"a", "b"}
+    assert {row.id for row in rows} == {1, 2, 3, 4, 5}
 
 
 def _datatype_to_sqlalchemy_type(data_type: DataType, is_redshift: bool):

--- a/src/xngin/apiserver/dwh/test_query_constructors.py
+++ b/src/xngin/apiserver/dwh/test_query_constructors.py
@@ -21,6 +21,7 @@ from xngin.apiserver.dwh.dwh_test_support import (
     SampleTable,
 )
 from xngin.apiserver.dwh.query_constructors import (
+    compose_cluster_query,
     compose_query,
     create_filter,
     create_inspect_table_from_cursor_query,
@@ -354,6 +355,49 @@ def test_relations(testcase, queries_dwh_session, shared_sample_tables):
     q = compose_query(table, select_columns, filters, testcase.desired_n)
     query_results = queries_dwh_session.execute(q)
     assert list(sorted([r.id for r in query_results])) == list(sorted(r.id for r in testcase.matches)), testcase
+
+
+def test_compose_cluster_query_samples_clusters_and_returns_all_cluster_rows(queries_dwh_session, shared_sample_tables):
+    table: Table = shared_sample_tables.sample_clustered_table
+    q = compose_cluster_query(
+        table,
+        select_columns={"id", "int_col", "cluster_key"},
+        filters=[],
+        desired_cluster_n=2,
+        cluster_key="cluster_key",
+    )
+    rows = queries_dwh_session.execute(q).all()
+
+    returned_clusters = {row.cluster_key for row in rows}
+    assert len(returned_clusters) == 2
+    assert len(rows) > 2
+
+    expected_ids_by_cluster = {
+        "a": {1, 2},
+        "b": {3, 4, 5},
+        "c": {6},
+        "d": {7, 8, 9, 10},
+    }
+    actual_ids_by_cluster: dict[str, set[int]] = {}
+    for row in rows:
+        actual_ids_by_cluster.setdefault(row.cluster_key, set()).add(row.id)
+
+    assert actual_ids_by_cluster == {
+        cluster_key: expected_ids_by_cluster[cluster_key] for cluster_key in returned_clusters
+    }
+
+
+def test_compose_cluster_query_raises_when_cluster_key_is_missing(shared_sample_tables):
+    table: Table = shared_sample_tables.sample_clustered_table
+
+    with pytest.raises(ValueError, match="Column missing_cluster_key not found in schema"):
+        compose_cluster_query(
+            table,
+            select_columns={"id"},
+            filters=[],
+            desired_cluster_n=2,
+            cluster_key="missing_cluster_key",
+        )
 
 
 def _datatype_to_sqlalchemy_type(data_type: DataType, is_redshift: bool):

--- a/src/xngin/apiserver/routers/admin/test_admin_api.py
+++ b/src/xngin/apiserver/routers/admin/test_admin_api.py
@@ -4275,7 +4275,7 @@ def test_create_freq_preassigned_experiment_with_cluster_key_roundtrips(
             description="Verify cluster_key is persisted and read back.",
             table_name="clustered_dwh",
             primary_key="participant_id",
-            cluster_key="cluster_powerlaw",
+            cluster_key="cluster_equal",
             start_date=datetime(2024, 1, 1, tzinfo=UTC),
             end_date=datetime(2024, 1, 31, 23, 59, 59, tzinfo=UTC),
             arms=[
@@ -4286,17 +4286,20 @@ def test_create_freq_preassigned_experiment_with_cluster_key_roundtrips(
             strata=[],
             filters=[],
             desired_n=100,
+            desired_n_clusters=10,
         ),
         webhooks=[],
     )
 
     created = aclient.create_experiment(datasource_id=ds_id, body=experiment_request, random_state=42).data
     assert isinstance(created.design_spec, PreassignedFrequentistExperimentSpec)
-    assert created.design_spec.cluster_key == "cluster_powerlaw"
+    assert created.design_spec.cluster_key == "cluster_equal"
+    assert created.design_spec.desired_n_clusters == 10
 
     fetched = aclient.get_experiment_for_ui(datasource_id=ds_id, experiment_id=created.experiment_id).data
     assert isinstance(fetched.config.design_spec, PreassignedFrequentistExperimentSpec)
-    assert fetched.config.design_spec.cluster_key == "cluster_powerlaw"
+    assert fetched.config.design_spec.cluster_key == "cluster_equal"
+    assert fetched.config.design_spec.desired_n_clusters == 10
 
     # Verify the created and fetched experiment assign_summary objects match via pydantic model equality.
     create_summary = created.assign_summary
@@ -4351,7 +4354,7 @@ def test_analyze_cluster_preassigned_experiment(testing_datasource, aclient: Adm
             description="Verify clustered analysis via admin API.",
             table_name="clustered_dwh",
             primary_key="participant_id",
-            cluster_key="cluster_moderate",
+            cluster_key="cluster_equal",
             start_date=datetime(2024, 1, 1, tzinfo=UTC),
             end_date=datetime(2024, 1, 31, 23, 59, 59, tzinfo=UTC),
             arms=[Arm(arm_name="control", arm_description="C"), Arm(arm_name="treatment", arm_description="T")],
@@ -4359,6 +4362,7 @@ def test_analyze_cluster_preassigned_experiment(testing_datasource, aclient: Adm
             strata=[],
             filters=[],
             desired_n=100,
+            desired_n_clusters=10,
         ),
     )
 
@@ -4400,6 +4404,7 @@ async def test_create_freq_preassigned_experiment_with_missing_cluster_key_raise
             strata=[],
             filters=[],
             desired_n=100,
+            desired_n_clusters=10,
         ),
         webhooks=[],
     )
@@ -4428,6 +4433,7 @@ async def test_create_freq_preassigned_experiment_cluster_key_has_nulls(
             strata=[],
             filters=[],
             desired_n=1000,
+            desired_n_clusters=1000,
         ),
         webhooks=[],
     )

--- a/src/xngin/apiserver/routers/common_api_types.py
+++ b/src/xngin/apiserver/routers/common_api_types.py
@@ -894,8 +894,10 @@ class BaseFrequentistDesignSpec(BaseDesignSpec):
         Field(
             default=None,
             ge=0,
-            description="Used in both power calculations and experiment creation. "
-            "Required when creating preassigned experiments. Optional for power calculations. "
+            description="Desired number of individual participants. "
+            "Required when creating individual-randomized preassigned experiments. "
+            "For cluster-randomized preassigned experiment creation, use desired_n_clusters to control sampling; "
+            "desired_n remains available for power calculations. "
             "When set, the power check also returns the minimum detectable effect for this size, "
             "along with the minimum sample size.",
         ),
@@ -1054,11 +1056,24 @@ class PreassignedFrequentistExperimentSpec(BaseFrequentistDesignSpec):
             ),
         ),
     ] = None
+    desired_n_clusters: Annotated[
+        int | None,
+        Field(
+            default=None,
+            ge=1,
+            description=(
+                "Desired number of clusters to sample when creating a cluster-randomized preassigned experiment. "
+                "Only valid when cluster_key is set. All eligible participants in each sampled cluster are included."
+            ),
+        ),
+    ] = None
 
     @model_validator(mode="after")
     def validate_cluster_randomization(self) -> Self:
         if self.cluster_key is not None and self.strata:
             raise ValueError("Cluster-randomized frequentist designs cannot also set strata.")
+        if self.cluster_key is None and self.desired_n_clusters is not None:
+            raise ValueError("desired_n_clusters can only be set when cluster_key is set.")
         return self
 
 

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -243,9 +243,13 @@ async def create_experiment_impl(
     match request.design_spec:
         case PreassignedFrequentistExperimentSpec():
             preassigned_spec = request.design_spec
+            is_clustered = preassigned_spec.cluster_key is not None
             desired_n = preassigned_spec.desired_n
-            if desired_n is None:
-                raise LateValidationError("Preassigned experiments must have a desired_n.")
+            desired_n_clusters = preassigned_spec.desired_n_clusters
+            if is_clustered and desired_n_clusters is None:
+                raise LateValidationError("Cluster-randomized preassigned experiments must have a desired_n_clusters.")
+            if not is_clustered and desired_n is None:
+                raise LateValidationError("Individual-randomized preassigned experiments must have a desired_n.")
 
             table_name = preassigned_spec.table_name
             primary_key = preassigned_spec.primary_key
@@ -258,7 +262,7 @@ async def create_experiment_impl(
             stratum_cols = strata_names + metric_names if stratify_on_metrics else strata_names
             select_columns = {*stratum_cols, primary_key}
             eligibility_filters = request.design_spec.filters
-            if preassigned_spec.cluster_key is not None:
+            if is_clustered:
                 select_columns.add(preassigned_spec.cluster_key)
                 eligibility_filters = [
                     *eligibility_filters,
@@ -267,12 +271,21 @@ async def create_experiment_impl(
 
             ds_config = datasource.get_config()
             async with DwhSession(ds_config.dwh) as dwh:
-                result = await dwh.get_participants(
-                    table_name,
-                    select_columns=select_columns,
-                    filters=eligibility_filters,
-                    n=desired_n,
-                )
+                if is_clustered:
+                    result = await dwh.get_clusters_of_participants(
+                        table_name,
+                        select_columns=select_columns,
+                        filters=eligibility_filters,
+                        desired_cluster_n=desired_n_clusters,
+                        cluster_key=preassigned_spec.cluster_key,
+                    )
+                else:
+                    result = await dwh.get_participants(
+                        table_name,
+                        select_columns=select_columns,
+                        filters=eligibility_filters,
+                        n=desired_n,
+                    )
                 sa_table, participants = result.sa_table, result.participants
 
             if participants is None:

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -243,12 +243,12 @@ async def create_experiment_impl(
     match request.design_spec:
         case PreassignedFrequentistExperimentSpec():
             preassigned_spec = request.design_spec
-            is_clustered = preassigned_spec.cluster_key is not None
+            cluster_key = preassigned_spec.cluster_key
             desired_n = preassigned_spec.desired_n
             desired_n_clusters = preassigned_spec.desired_n_clusters
-            if is_clustered and desired_n_clusters is None:
+            if cluster_key is not None and desired_n_clusters is None:
                 raise LateValidationError("Cluster-randomized preassigned experiments must have a desired_n_clusters.")
-            if not is_clustered and desired_n is None:
+            if cluster_key is None and desired_n is None:
                 raise LateValidationError("Individual-randomized preassigned experiments must have a desired_n.")
 
             table_name = preassigned_spec.table_name
@@ -262,24 +262,26 @@ async def create_experiment_impl(
             stratum_cols = strata_names + metric_names if stratify_on_metrics else strata_names
             select_columns = {*stratum_cols, primary_key}
             eligibility_filters = request.design_spec.filters
-            if is_clustered:
-                select_columns.add(preassigned_spec.cluster_key)
+            if cluster_key is not None:
+                select_columns.add(cluster_key)
                 eligibility_filters = [
                     *eligibility_filters,
-                    Filter(field_name=preassigned_spec.cluster_key, relation=Relation.EXCLUDES, value=[None]),
+                    Filter(field_name=cluster_key, relation=Relation.EXCLUDES, value=[None]),
                 ]
 
             ds_config = datasource.get_config()
             async with DwhSession(ds_config.dwh) as dwh:
-                if is_clustered:
+                if cluster_key is not None:
+                    assert desired_n_clusters is not None  # covered by LateValidationError above
                     result = await dwh.get_clusters_of_participants(
                         table_name,
                         select_columns=select_columns,
                         filters=eligibility_filters,
                         desired_n_clusters=desired_n_clusters,
-                        cluster_key=preassigned_spec.cluster_key,
+                        cluster_key=cluster_key,
                     )
                 else:
+                    assert desired_n is not None  # covered by LateValidationError above
                     result = await dwh.get_participants(
                         table_name,
                         select_columns=select_columns,

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -276,7 +276,7 @@ async def create_experiment_impl(
                         table_name,
                         select_columns=select_columns,
                         filters=eligibility_filters,
-                        desired_cluster_n=desired_n_clusters,
+                        desired_n_clusters=desired_n_clusters,
                         cluster_key=preassigned_spec.cluster_key,
                     )
                 else:

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -290,7 +290,7 @@ async def create_experiment_impl(
                     )
                 sa_table, participants = result.sa_table, result.participants
 
-            if participants is None:
+            if not participants:
                 raise LateValidationError("Preassigned experiments must have eligible participants data")
 
             return await create_preassigned_experiment_impl(

--- a/src/xngin/apiserver/routers/experiments/test_experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_api.py
@@ -451,6 +451,7 @@ async def test_cluster_key_exports_with_preassigned_assignments(
             strata=[],
             filters=[],
             desired_n=24,
+            desired_n_clusters=24,
         ),
         webhooks=[],
     )
@@ -463,9 +464,9 @@ async def test_cluster_key_exports_with_preassigned_assignments(
     json_response = eclient.client.get(f"/v1/experiments/{experiment_id}/assignments", headers=eclient_headers)
     assert json_response.status_code == HTTPStatus.OK, json_response.content
     json_assignments = json_response.json()["assignments"]
-    assert len(json_assignments) == 24
     assert all("cluster_key" in assignment for assignment in json_assignments)
     assert all(assignment["cluster_key"] is not None for assignment in json_assignments)
+    assert len({assignment["cluster_key"] for assignment in json_assignments}) == 24
 
     csv_response = eclient.client.get(f"/v1/experiments/{experiment_id}/assignments/csv", headers=eclient_headers)
     assert csv_response.status_code == HTTPStatus.OK, csv_response.content

--- a/src/xngin/apiserver/routers/experiments/test_experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_common.py
@@ -243,7 +243,14 @@ def make_createexperimentrequest_json(
             raise ValueError(f"Invalid experiment type: {experiment_type}")
 
 
-def make_design_spec_clustered(*, cluster_key: str | None = "cluster_equal") -> PreassignedFrequentistExperimentSpec:
+def make_design_spec_clustered(
+    *,
+    cluster_key: str | None = "cluster_equal",
+    desired_n: int | None = 100,
+    desired_n_clusters: int | None = 10,
+) -> PreassignedFrequentistExperimentSpec:
+    if cluster_key is None:
+        desired_n_clusters = None
     return PreassignedFrequentistExperimentSpec(
         experiment_type=ExperimentsType.FREQ_PREASSIGNED,
         experiment_name="cluster analyze test",
@@ -257,7 +264,8 @@ def make_design_spec_clustered(*, cluster_key: str | None = "cluster_equal") -> 
         strata=[],
         metrics=[DesignSpecMetricRequest(field_name="test_score", metric_pct_change=0.1)],
         filters=[],
-        desired_n=100,
+        desired_n=desired_n,
+        desired_n_clusters=desired_n_clusters,
         power=0.8,
         alpha=0.05,
         fstat_thresh=0.2,
@@ -792,6 +800,81 @@ async def test_create_preassigned_experiment_impl_cluster_assignment(xngin_sessi
         assert arm_id is not None
         assert arm_size.cluster_count is not None
         assert arm_size.cluster_count == len(arm_to_clusters[arm_id])
+
+
+async def test_create_experiment_impl_clustered_requires_desired_n_clusters(xngin_session, testing_datasource):
+    design_spec = make_design_spec_clustered(desired_n_clusters=None)
+    request = CreateExperimentRequest(design_spec=design_spec)
+
+    with pytest.raises(
+        LateValidationError,
+        match="Cluster-randomized preassigned experiments must have a desired_n_clusters",
+    ):
+        await create_experiment_impl(
+            request=request,
+            datasource=testing_datasource.ds,
+            xngin_session=xngin_session,
+            stratify_on_metrics=False,
+            random_state=42,
+            validated_webhooks=[],
+        )
+
+
+async def test_create_experiment_impl_clustered_samples_clusters(xngin_session, testing_datasource):
+    """Clustered preassigned creation samples clusters, then includes every participant in each sampled cluster."""
+    design_spec = make_design_spec_clustered(
+        cluster_key="cluster_equal",
+        desired_n=999,
+        desired_n_clusters=3,
+    )
+    request = CreateExperimentRequest(design_spec=design_spec)
+
+    response = await create_experiment_impl(
+        request=request,
+        datasource=testing_datasource.ds,
+        xngin_session=xngin_session,
+        stratify_on_metrics=False,
+        random_state=42,
+        validated_webhooks=[],
+    )
+
+    assert isinstance(response.design_spec, PreassignedFrequentistExperimentSpec)
+    assert response.design_spec.desired_n == 999
+    assert response.design_spec.desired_n_clusters == 3
+    assert response.assign_summary is not None
+    assert response.assign_summary.arm_sizes is not None
+    assert response.assign_summary.sample_size == 30
+    assert sum(arm_size.cluster_count or 0 for arm_size in response.assign_summary.arm_sizes) == 3
+
+    experiment = await get_experiment_preloaded(xngin_session, response.experiment_id)
+    assert experiment.desired_n == 999
+    assert experiment.desired_n_clusters == 3
+    rehydrated_design_spec = await ExperimentStorageConverter(experiment).get_design_spec()
+    assert isinstance(rehydrated_design_spec, PreassignedFrequentistExperimentSpec)
+    assert rehydrated_design_spec.desired_n_clusters == 3
+
+    assignments = (
+        await xngin_session.scalars(
+            select(tables.ArmAssignment).where(tables.ArmAssignment.experiment_id == response.experiment_id)
+        )
+    ).all()
+    assert len(assignments) == 30
+
+    ids_by_cluster: dict[str, set[int]] = defaultdict(set)
+    arms_by_cluster: dict[str, set[str]] = defaultdict(set)
+    for assignment in assignments:
+        assert assignment.cluster_key is not None
+        ids_by_cluster[assignment.cluster_key].add(int(assignment.participant_id))
+        arms_by_cluster[assignment.cluster_key].add(assignment.arm_id)
+
+    assert len(ids_by_cluster) == 3
+    # Verify every participant in each sampled cluster was assigned.
+    for cluster_key, participant_ids in ids_by_cluster.items():
+        cluster_id = int(cluster_key)
+        # We know the cluster_equal column has 10 participants per cluster per tools/generated_clustered_data.py.
+        assert participant_ids == set(range(cluster_id * 10, cluster_id * 10 + 10))
+    # Each cluster should be tied to exactly 1 arm only.
+    assert all(len(arm_ids) == 1 for arm_ids in arms_by_cluster.values())
 
 
 async def _create_clustered_preassigned_experiment(

--- a/src/xngin/apiserver/routers/experiments/test_experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_common.py
@@ -820,6 +820,22 @@ async def test_create_experiment_impl_clustered_requires_desired_n_clusters(xngi
         )
 
 
+async def test_create_experiment_impl_clustered_rejects_empty_eligible_cohort(xngin_session, testing_datasource):
+    design_spec = make_design_spec_clustered()
+    design_spec.filters = [Filter(field_name="cluster_equal", relation=Relation.INCLUDES, value=[-1])]
+    request = CreateExperimentRequest(design_spec=design_spec)
+
+    with pytest.raises(LateValidationError, match="Preassigned experiments must have eligible participants data"):
+        await create_experiment_impl(
+            request=request,
+            datasource=testing_datasource.ds,
+            xngin_session=xngin_session,
+            stratify_on_metrics=False,
+            random_state=42,
+            validated_webhooks=[],
+        )
+
+
 async def test_create_experiment_impl_clustered_samples_clusters(xngin_session, testing_datasource):
     """Clustered preassigned creation samples clusters, then includes every participant in each sampled cluster."""
     design_spec = make_design_spec_clustered(

--- a/src/xngin/apiserver/routers/test_common_api_types.py
+++ b/src/xngin/apiserver/routers/test_common_api_types.py
@@ -238,6 +238,29 @@ def test_cluster_key_and_strata_are_mutually_exclusive():
         PreassignedFrequentistExperimentSpec.model_validate(valid_spec)
 
 
+def test_desired_n_clusters_requires_cluster_key():
+    invalid_spec = {
+        "experiment_type": "freq_preassigned",
+        "experiment_name": "test",
+        "description": "test",
+        "table_name": "dwh",
+        "primary_key": "id",
+        "start_date": "2024-01-01T00:00:00+00:00",
+        "end_date": "2024-12-31T00:00:00+00:00",
+        "arms": [
+            {"arm_name": "C", "arm_description": "C"},
+            {"arm_name": "T", "arm_description": "T"},
+        ],
+        "strata": [],
+        "metrics": [{"field_name": "metric1", "metric_pct_change": 0.1}],
+        "filters": [],
+        "desired_n_clusters": 10,
+    }
+
+    with pytest.raises(ValidationError, match="desired_n_clusters can only be set when cluster_key is set"):
+        PreassignedFrequentistExperimentSpec.model_validate(invalid_spec)
+
+
 def test_mab_dwh_primary_key_and_target_must_differ():
     """MABDwhExperimentSpec rejects a target_field_name equal to its primary_key."""
     valid_spec = {

--- a/src/xngin/apiserver/sqla/tables.py
+++ b/src/xngin/apiserver/sqla/tables.py
@@ -476,6 +476,7 @@ class Experiment(Base):
     alpha: Mapped[float | None] = mapped_column()
     fstat_thresh: Mapped[float | None] = mapped_column()
     desired_n: Mapped[int | None] = mapped_column()
+    desired_n_clusters: Mapped[int | None] = mapped_column()
 
     # Experiment Registry
     impact: Mapped[str] = mapped_column(server_default="")

--- a/src/xngin/apiserver/storage/storage_format_converters.py
+++ b/src/xngin/apiserver/storage/storage_format_converters.py
@@ -291,6 +291,7 @@ class ExperimentStorageConverter:
             if self.experiment.experiment_type == ExperimentsType.FREQ_PREASSIGNED.value:
                 cluster_key_field = self.experiment.cluster_key_field()
                 freq_spec_dict["cluster_key"] = cluster_key_field.field_name if cluster_key_field else None
+                freq_spec_dict["desired_n_clusters"] = self.experiment.desired_n_clusters
 
             return TypeAdapter(capi.DesignSpec).validate_python(freq_spec_dict)
 
@@ -452,6 +453,8 @@ class ExperimentStorageConverter:
                 experiment.alpha = design_spec.alpha
                 experiment.fstat_thresh = design_spec.fstat_thresh
                 experiment.desired_n = design_spec.desired_n
+                if isinstance(design_spec, capi.PreassignedFrequentistExperimentSpec):
+                    experiment.desired_n_clusters = design_spec.desired_n_clusters
 
                 experiment.arms = [
                     tables.Arm(

--- a/src/xngin/db_extensions/custom_functions.py
+++ b/src/xngin/db_extensions/custom_functions.py
@@ -34,7 +34,8 @@ def deterministic_random(element):
     if element.sa_table is None:
         raise ValueError("our_random requires sa_table= to be an inspectable table-like entity.")
     meta = inspect(element.sa_table)
-    columns = (c for c in meta.primary_key.columns) if meta.primary_key.columns else (c for c in meta.columns)
+    primary_key = list(meta.primary_key)
+    columns = primary_key or list(meta.columns)
     return ", ".join(str(c) for c in sorted(columns, key=lambda c: c.name))
 
 

--- a/src/xngin/db_extensions/test_custom_functions.py
+++ b/src/xngin/db_extensions/test_custom_functions.py
@@ -84,6 +84,12 @@ def test_deterministic_random():
     sql_text = str(query_nopk.compile(engine))
     assert "ORDER BY nopk_table.int_col, nopk_table.string_col" in sql_text
 
+    # deterministic random enabled for a selectable/subquery
+    subq = select(SampleTable.__table__.c.string_col).group_by(SampleTable.__table__.c.string_col).subquery()
+    query_subq = select(subq.c.string_col).order_by(custom_functions.Random(sa_table=subq))
+    sql_text = str(query_subq.compile(engine))
+    assert "ORDER BY anon_1.string_col" in sql_text
+
     # normal case
     custom_functions.USE_DETERMINISTIC_RANDOM = False
     query = select(SampleTable).order_by(custom_functions.Random(sa_table=SampleTable.__table__))


### PR DESCRIPTION
## Description

Assignment bug: For clustered experiments, we were incorrectly randomly sampling the _individual_ desired_n participants from the dwh, and then looking at what clusters they happened to be associated with. (This was an oversight when wiring up the API in #263.)

Fix: add a PreassignedFrequentistExperimentSpec.desired_n_clusters field and persist it in the table Experiments. Add a new DwhSesion.get_clusters_of_participants() and helpers to sample the number of clusters (instead of the number of participants). Since participant counts aren't guaranteed as entire clusters are assigned to arms, some tests needed updating as well to verify expected cluster counts.

related: https://github.com/agency-fund/evidential-fe/pull/272

## Future Tasks

* update the FE code to use this new interface
* consider updating the power check interface to also respect the new desired_n_clusters