### PR TITLE
catch failed assignments due to bad balance check [EVE-136]

### DIFF
--- a/src/xngin/stats/balance.py
+++ b/src/xngin/stats/balance.py
@@ -179,18 +179,32 @@ def check_balance_of_preprocessed_df(
     # While HC3 may be better at low sample sizes (Long & Ervin 2000), it is sensitive to high
     # leverage points, so use HC1 for now. Future work should consider:
     # https://blog.stata.com/2022/10/06/heteroskedasticity-robust-standard-errors-some-practical-considerations/
-    fit_kwargs: dict[str, str | dict] = dict(method="pinv", cov_type="HC1")
     if cluster_col is not None:
-        fit_kwargs.update(cov_type="cluster", cov_kwds={"groups": df_analysis[cluster_col]})
+        model = sm.OLS(endog, exog).fit(
+            method="pinv",
+            cov_type="cluster",
+            cov_kwds={"groups": df_analysis[cluster_col]},
+        )
+    else:
+        model = sm.OLS(endog, exog).fit(method="pinv", cov_type="HC1")
 
-    model = sm.OLS(endog, exog).fit(**fit_kwargs)
+    try:
+        return BalanceResult(
+            f_statistic=model.fvalue,
+            f_pvalue=model.f_pvalue,
+            numerator_df=model.df_model,
+            denominator_df=model.df_resid,
+            model_params=list(model.params),
+            model_param_std_errors=list(model.bse),
+            model_summary=model.summary().as_text(),
+        )
+    except ValueError as verr:
+        # Raised when there are too few residual degrees of freedom for the robust F-test
+        # (typically # predictors >= # participants resulting in residual df = 0).
+        if "r_matrix performs f_test for using dimensions that are asymptotically non-normal" in str(verr):
+            raise StatsBalanceError(
+                "Too few participants to perform a balance check. "
+                "Add more participants or reduce the number of metrics or fields used for stratification."
+            ) from verr
 
-    return BalanceResult(
-        f_statistic=model.fvalue,
-        f_pvalue=model.f_pvalue,
-        numerator_df=model.df_model,
-        denominator_df=model.df_resid,
-        model_params=list(model.params),
-        model_param_std_errors=list(model.bse),
-        model_summary=model.summary().as_text(),
-    )
+        raise

--- a/src/xngin/stats/test_balance.py
+++ b/src/xngin/stats/test_balance.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -511,3 +513,26 @@ def test_check_balance_with_missing_cluster_col_raises_stats_balance_error():
 
     with pytest.raises(StatsBalanceError, match=r"Cluster column 'cluster' not found in balance-check data."):
         check_balance_of_preprocessed_df(data, treatment_col="treat", cluster_col="cluster")
+
+
+def test_check_balance_too_few_participants_raises_stats_balance_error():
+    """When residual df is 0, the robust F-test fails and we raise StatsBalanceError.
+
+    A 4-level categorical with n=4 yields intercept + 3 dummies (full rank), so df_resid=0
+    and HC1 cannot form a usable parameter covariance for the balance F-test.
+    """
+    data = pd.DataFrame({
+        "treat": [0, 1, 0, 1],
+        "cat": ["a", "b", "c", "d"],
+    })
+
+    with warnings.catch_warnings():
+        # HC1 emits divide-by-zero / invalid-value RuntimeWarnings when df_resid=0 before the
+        # ValueError that we translate into StatsBalanceError.
+        warnings.filterwarnings(action="ignore", message=r"(divide by zero|invalid value).*", category=RuntimeWarning)
+
+        with pytest.raises(
+            StatsBalanceError,
+            match=r"Add more participants or reduce the number of metrics or fields used for stratification\.",
+        ):
+            check_balance_of_preprocessed_df(data, treatment_col="treat")


### PR DESCRIPTION
Catches the error `ValueError: r_matrix performs f_test for using dimensions that are asymptotically non-normal` that can occur during a balance check as part of assignment for preassigned freq experiments and returns a friendlier error message.

## How has this been tested?

unittest

## Checklist

- [x] I have updated the automated tests