### PR TITLE
Swap the names on webhook-related response types for clarity.

### DIFF
--- a/src/xngin/apiserver/routers/admin/admin_api_types.py
+++ b/src/xngin/apiserver/routers/admin/admin_api_types.py
@@ -313,8 +313,8 @@ AddWebhookToOrganizationRequest = Annotated[
 ]
 
 
-class AddWebhookToOrganizationResponse(AdminApiBaseModel):
-    """Information on the successfully created webhook."""
+class WebhookSummary(AdminApiBaseModel):
+    """Summarizes a Webhook configuration for an organization."""
 
     id: Annotated[str, Field(description="The ID of the newly created webhook.")]
     type: str
@@ -332,8 +332,8 @@ class AddWebhookToOrganizationResponse(AdminApiBaseModel):
     ]
 
 
-class WebhookSummary(AddWebhookToOrganizationResponse):
-    """Summarizes a Webhook configuration for an organization."""
+class AddWebhookToOrganizationResponse(WebhookSummary):
+    """Information on the successfully created webhook."""
 
 
 class UpdateOrganizationWebhookRequest(AdminApiBaseModel):


### PR DESCRIPTION
Rename some types for clarity: WebhookSummary describes the webhook data model, and AddWebhookToOrganizationResponse happens to be an instance of it. 
