### PR TITLE
Avoid triggering a PytestCollectionWarning.

### DIFF
--- a/src/xngin/apiserver/routers/admin/test_admin_api.py
+++ b/src/xngin/apiserver/routers/admin/test_admin_api.py
@@ -118,6 +118,8 @@ class HasName(Protocol):
 
 @dataclass(slots=True)
 class TestExperiment:
+    __test__ = False  # silence PytestCollectionWarning
+
     config: ExperimentConfig
     organization_id: str
     api_key: str


### PR DESCRIPTION
pytest will attempt to interpret classes that start with `Test` as a class full
of tests. Our TestExperiment is not a test, so it fails and emits a warning. I
can't come up with any better name for this class, so instead of renaming it,
I've marked it to be ignored by pytest's automatic test discovery.

This silences the following warning:
```
PytestCollectionWarning: cannot collect test class 'TestExperiment' because it has a __init__ constructor (from: src/xngin/apiserver/routers/admin/test_admin_api.py)
@dataclass(slots=True)
```
