### PR TITLE
Replace a deprecated constant for 422.

### DIFF
--- a/src/xngin/apiserver/routers/admin_integrations/admin_integrations_api.py
+++ b/src/xngin/apiserver/routers/admin_integrations/admin_integrations_api.py
@@ -127,7 +127,7 @@ async def _call_turn_api(
     except ValidationError as exc:
         logger.error(f"Turn.io API returned unexpected response structure at {method} {TURN_JOURNEYS_URL}: {exc}")
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=f"The retrieved journeys from Turn.io did not have the expected fields 'name' and 'uuid'. "
             f"Details: {exc}",
         ) from exc


### PR DESCRIPTION
This resolves the following warning:
```
src/xngin/apiserver/routers/admin_integrations/admin_integrations_api.py:142: StarletteDeprecationWarning: 'HTTP_422_UNPROCESSABLE_ENTITY' is deprecated. Use 'HTTP_422_UNPROCESSABLE_CONTENT' instead.
    return await _call_turn_api(httpx_client=httpx_client, turn_api_token=turn_api_token, method="GET")
```
