### PR TITLE
Resolve localhost without using DNS resolver.

### DIFF
--- a/src/xngin/apiserver/dns/safe_resolve.py
+++ b/src/xngin/apiserver/dns/safe_resolve.py
@@ -17,7 +17,7 @@ UNSAFE_IP_FOR_TESTING = "127.0.0.9"
 # fixture flips this on so unit tests never depend on a working resolver. Hosts not in INTERCEPT_DNS_ALLOWLIST are
 # logged so we can spot tests that should be using a literal IP or a mock instead.
 INTERCEPT_DNS_FOR_TESTING = False
-INTERCEPT_DNS_ALLOWLIST = frozenset({"localhost", "example.com"})
+INTERCEPT_DNS_ALLOWLIST = frozenset({"example.com"})
 
 
 class DnsLookupError(Exception):
@@ -34,6 +34,12 @@ class DnsLookupUnsafeError(DnsLookupError):
 
 def lookup_v4(host: str) -> list[str] | None:
     """Returns the IP addresses for a hostname, or None if there was some kind of failure."""
+    if host.lower() == "localhost":
+        # localhost is a reserved name (RFC 6761). Resolvers that forward to an upstream server -- as in containers
+        # and most hosted environments -- usually answer it with NXDOMAIN, so dns.resolver.resolve() below fails it even
+        # though it is a perfectly valid loopback address. Whether it's actually safe to connect to is still decided
+        # by the caller's safety check.
+        return ["127.0.0.1"]
     if INTERCEPT_DNS_FOR_TESTING:
         if host not in INTERCEPT_DNS_ALLOWLIST:
             logger.warning(f"Intercepting unit test DNS lookup for unexpected host {host!r}; returning 127.0.0.1.")
@@ -71,10 +77,6 @@ def _is_safe_ip(ip: str):
     return parsed.is_global
 
 
-def _is_safe_ipset(ips: set[str]):
-    return all(_is_safe_ip(address) for address in ips)
-
-
 def _is_ip_literal(host: str) -> bool:
     try:
         ipaddress.ip_address(host)
@@ -102,10 +104,9 @@ def safe_resolve(host: str | None):
     answers = lookup_v4(host)
     if not answers:
         raise DnsLookupError(host)
-    safe = _is_safe_ipset(set(answers))
-    if not safe:
+    if not all(_is_safe_ip(address) for address in answers):
         raise DnsLookupUnsafeError(host)
-    return answers.pop()
+    return answers[0]
 
 
 if __name__ == "__main__":

--- a/src/xngin/apiserver/dns/test_safe_resolve.py
+++ b/src/xngin/apiserver/dns/test_safe_resolve.py
@@ -49,6 +49,10 @@ def _fail_lookup_v4(host: str):
     raise AssertionError(f"lookup_v4 must not be called for an IP literal: {host}")
 
 
+def _fail_resolver(*args, **kwargs):
+    raise AssertionError("localhost must be answered without consulting a resolver")
+
+
 @pytest.mark.parametrize(("addr", "expected"), _IP_CLASSIFICATION_CASES)
 def test_is_safe_ip_classifies_ipv4_and_non_ip_values(enforce_ip_safety, addr, expected):
     assert safe_resolve._is_safe_ip(addr) is expected
@@ -86,3 +90,17 @@ def test_safe_resolve_rejects_unsafe_ipv4_literal_without_resolving(enforce_ip_s
     monkeypatch.setattr(safe_resolve, "lookup_v4", _fail_lookup_v4)
     with pytest.raises(safe_resolve.DnsLookupUnsafeError):
         safe_resolve.safe_resolve("169.254.169.254")
+
+
+@pytest.mark.parametrize("host", ["localhost", "LocalHost"])
+def test_lookup_v4_answers_localhost_without_a_resolver(monkeypatch, host):
+    # Resolvers that forward upstream return NXDOMAIN for localhost, so it must never reach one.
+    monkeypatch.setattr(safe_resolve, "resolve", _fail_resolver)
+    monkeypatch.setattr(safe_resolve.socket, "getaddrinfo", _fail_resolver)
+    assert safe_resolve.lookup_v4(host) == ["127.0.0.1"]
+
+
+def test_safe_resolve_rejects_localhost_when_private_ips_disallowed(enforce_ip_safety):
+    # Answering localhost in lookup_v4() must not become a way to reach our own loopback interface.
+    with pytest.raises(safe_resolve.DnsLookupUnsafeError):
+        safe_resolve.safe_resolve("localhost")


### PR DESCRIPTION
localhost is a reserved name. Resolvers that forward to an upstream server --
as in containers and most hosted environments -- usually answer it with
NXDOMAIN, so lookup_v4() can fail on some systems.

Our fix is to answer it directly, without using the DNS server.  This is a
no-op unless ALLOW_CONNECTING_TO_PRIVATE_IPS is set: the safety check still
rejects 127.0.0.1 as non-global in production. In development environments,
we allow 127.0.0.1.
