### PR TITLE
Improve create-nacl-keyset reliability.

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -149,7 +149,7 @@ tasks:
       local development server.
     internal: true
     status:
-      - test -f .xngin_session_token_keyset
+      - test -s .xngin_session_token_keyset
     cmd: |
       uv run xngin-cli create-nacl-keyset > .xngin_session_token_keyset
       chmod og= .xngin_session_token_keyset

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -150,9 +150,7 @@ tasks:
     internal: true
     status:
       - test -s .xngin_session_token_keyset
-    cmd: |
-      uv run xngin-cli create-nacl-keyset > .xngin_session_token_keyset
-      chmod og= .xngin_session_token_keyset
+    cmd: uv run xngin-cli create-nacl-keyset --output .xngin_session_token_keyset
   start:
     desc: "Starts apiserver locally with settings compatible with local dash dev server."
     interactive: true

--- a/src/xngin/cli/common.py
+++ b/src/xngin/cli/common.py
@@ -1,5 +1,9 @@
 """Helpers shared by `cli/main.py` and the per-command modules under `cli/commands/`."""
 
+import os
+import stat
+from pathlib import Path
+
 import sqlalchemy
 from sqlalchemy import create_engine
 from sqlalchemy.exc import IntegrityError, OperationalError, ProgrammingError
@@ -7,6 +11,30 @@ from sqlalchemy.exc import IntegrityError, OperationalError, ProgrammingError
 from xngin.apiserver.dwh import dwh_utils
 
 SA_LOGGER_NAME_FOR_CLI = "cli_dwh"
+
+OWNER_ONLY_MODE = stat.S_IRUSR | stat.S_IWUSR
+
+
+def write_file_atomically(path: Path, content: str, *, private: bool = False) -> None:
+    """Writes content to path atomically.
+
+    Pass private=True for files holding secrets: the file is restricted to the current user, as if it had been
+    created and then `chmod og=`ed. This only has effect on Unix-like filesystems.
+    """
+    if path.exists() and not path.is_file():
+        # Character devices like /dev/null can't be renamed over, and atomicity means nothing for them.
+        path.write_text(content)
+        return
+
+    temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        if private:
+            temp_path.touch(mode=OWNER_ONLY_MODE)
+            temp_path.chmod(OWNER_ONLY_MODE)
+        temp_path.write_text(content)
+        os.replace(temp_path, path)
+    finally:
+        temp_path.unlink(missing_ok=True)
 
 
 def create_engine_and_database(url: sqlalchemy.URL, *, connect_args: dict | None = None):

--- a/src/xngin/cli/main.py
+++ b/src/xngin/cli/main.py
@@ -22,7 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import Session
 
 from xngin.cli.commands import create_testing_dwh as _create_testing_dwh_cmd
-from xngin.cli.common import create_engine_and_database
+from xngin.cli.common import create_engine_and_database, write_file_atomically
 from xngin.xsecrets import secretservice
 
 CLI_DB_APPLICATION_NAME = f"cli-{os.getpid()}"
@@ -84,7 +84,12 @@ def export_json_schemas(output: Path = Path(".schemas")):
 
 
 @app.command()
-def export_openapi_spec(output: Path = Path("openapi.json")):
+def export_openapi_spec(
+    output: Annotated[
+        Path,
+        typer.Option("--output", "-o", help="The file to write the spec to."),
+    ] = Path("openapi.json"),
+):
     """Writes the OpenAPI spec to the file specified by --output."""
     from fastapi import FastAPI  # noqa: PLC0415
 
@@ -94,8 +99,7 @@ def export_openapi_spec(output: Path = Path("openapi.json")):
     from xngin.apiserver import routes  # noqa: PLC0415
 
     routes.register(app)
-    with open(output, "w") as outf:
-        json.dump(xngin.apiserver.openapi.custom_openapi(app), outf, sort_keys=True, indent=2)
+    write_file_atomically(output, json.dumps(xngin.apiserver.openapi.custom_openapi(app), sort_keys=True, indent=2))
 
 
 @app.command()
@@ -279,24 +283,37 @@ async def add_user(
 
 @app.command()
 def create_nacl_keyset(
-    output: Annotated[
+    output_format: Annotated[
         Base64OrJson,
-        typer.Option(help="Output format. Use base64 when generating a key for use in an environment variable."),
+        typer.Option(
+            "--format",
+            "-f",
+            help="Output format. Use base64 when generating a key for use in an environment variable.",
+        ),
     ] = Base64OrJson.base64,
+    output: Annotated[
+        Path | None,
+        typer.Option("--output", "-o", help="Write the keyset to this file instead of stdout."),
+    ] = None,
 ):
     """Generate an encryption keyset for the "nacl" secret provider.
 
-    The encoded encryption key will be written to stdout.
+    The encoded encryption key will be written to stdout, or to the file named by --output.
 
-    When --output=base64 (default), the output can be used as the XNGIN_SECRETS_NACL_KEYSET environment variable.
+    When --format=base64 (default), the output can be used as the XNGIN_SECRETS_NACL_KEYSET environment variable.
     """
     from xngin.xsecrets.nacl_provider import NaclProviderKeyset  # noqa: PLC0415
 
     keyset = NaclProviderKeyset.create()
-    if output == Base64OrJson.base64:
-        print(keyset.serialize_base64())
+    if output_format == Base64OrJson.base64:
+        serialized = keyset.serialize_base64()
     else:
-        print(keyset.serialize_json())
+        serialized = keyset.serialize_json()
+
+    if output is None:
+        print(serialized)
+    else:
+        write_file_atomically(output, serialized + "\n", private=True)
 
 
 @app.command()


### PR DESCRIPTION
create-nacl-keyset now writes to the output file directly and atomically,
avoiding the potential of a failure leaving a zero byte keyset file around.
