### PR TITLE
Only snapshot COMMITTED experiments, and remove unused experiment states.

### DIFF
--- a/src/xngin/apiserver/routers/common_enums.py
+++ b/src/xngin/apiserver/routers/common_enums.py
@@ -19,8 +19,11 @@ class ExperimentState(enum.StrEnum):
     """
     Experiment lifecycle states.
 
-    note: [starting state], [[terminal state]]
-    [ASSIGNED]->{[[ABANDONED]], [[COMMITTED]]}
+    Experiments are born in to the ASSIGNED state. The abandon_experiment and commit_experiment APIs transition them to
+    the terminal ABANDONED or COMMITTED states, respectively.
+
+    The name of the ASSIGNED state was chosen when we only supported freq-preassigned experiments. Today it represents
+    an experiment in a draft state.
     """
 
     ASSIGNED = "assigned"

--- a/src/xngin/apiserver/routers/common_enums.py
+++ b/src/xngin/apiserver/routers/common_enums.py
@@ -23,7 +23,7 @@ class ExperimentState(enum.StrEnum):
     [ASSIGNED]->{[[ABANDONED]], [[COMMITTED]]}
     """
 
-    ASSIGNED = "assigned"  # TODO: rename to "REVIEWING"
+    ASSIGNED = "assigned"
     ABANDONED = "abandoned"
     COMMITTED = "committed"
 

--- a/src/xngin/apiserver/routers/common_enums.py
+++ b/src/xngin/apiserver/routers/common_enums.py
@@ -20,14 +20,12 @@ class ExperimentState(enum.StrEnum):
     Experiment lifecycle states.
 
     note: [starting state], [[terminal state]]
-    [DESIGNING]->[ASSIGNED]->{[[ABANDONED]], COMMITTED}->[[ABORTED]]
+    [ASSIGNED]->{[[ABANDONED]], [[COMMITTED]]}
     """
 
-    DESIGNING = "designing"  # TODO: https://github.com/agency-fund/xngin/issues/352
     ASSIGNED = "assigned"  # TODO: rename to "REVIEWING"
     ABANDONED = "abandoned"
     COMMITTED = "committed"
-    ABORTED = "aborted"
 
 
 class StopAssignmentReason(enum.StrEnum):

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -557,7 +557,7 @@ async def commit_experiment_impl(xngin_session: AsyncSession, experiment: tables
 def abandon_experiment_impl(experiment: tables.Experiment):
     if experiment.state == ExperimentState.ABANDONED:
         return AbandonExperimentResult.ABANDONED
-    if experiment.state not in {ExperimentState.DESIGNING, ExperimentState.ASSIGNED}:
+    if experiment.state != ExperimentState.ASSIGNED:
         return AbandonExperimentResult.INVALID_STATE
 
     experiment.state = ExperimentState.ABANDONED
@@ -614,7 +614,6 @@ async def list_organization_or_datasource_experiments_impl(
 
     stmt = stmt.where(
         tables.Experiment.state.in_([
-            ExperimentState.DESIGNING,
             ExperimentState.COMMITTED,
             ExperimentState.ASSIGNED,
         ])

--- a/src/xngin/apiserver/snapshots/snapshotter.py
+++ b/src/xngin/apiserver/snapshots/snapshotter.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import selectinload
 
 from xngin.apiserver import database
 from xngin.apiserver.routers.common_api_types import ExperimentAnalysisResponse
-from xngin.apiserver.routers.common_enums import ContextType, ExperimentsType
+from xngin.apiserver.routers.common_enums import ContextType, ExperimentState, ExperimentsType
 from xngin.apiserver.routers.experiments import experiments_common
 from xngin.apiserver.sqla import tables
 from xngin.apiserver.storage.storage_format_converters import ExperimentStorageConverter
@@ -47,6 +47,7 @@ async def create_pending_snapshots(snapshot_interval: int):
                     func.date_trunc("minute", tables.Experiment.start_date - buffer),
                     func.date_trunc("minute", tables.Experiment.end_date + buffer),
                 ),
+                tables.Experiment.state == ExperimentState.COMMITTED.value,
             )
             .order_by(tables.Experiment.id, tables.Snapshot.updated_at.desc())
             .cte()

--- a/src/xngin/apiserver/snapshots/test_snapshotter.py
+++ b/src/xngin/apiserver/snapshots/test_snapshotter.py
@@ -144,13 +144,20 @@ def create_snapshot_experiment(
     name: str,
     desired_n: int = 2,
     end_date: datetime | None = None,
+    commit: bool = True,
 ) -> str:
+    """Creates a preassigned frequentist experiment.
+
+    If commit is True, the experiment will be in a COMMITTED state. If commit is False, the experiment will be in
+    an ASSIGNED state.
+    """
     design_spec = make_snapshot_design_spec(name, end_date=end_date).model_copy(update={"desired_n": desired_n})
     experiment_id = aclient.create_experiment(
         datasource_id=testing_datasource.datasource_id,
         body=CreateExperimentRequest(design_spec=design_spec),
     ).data.experiment_id
-    aclient.commit_experiment(datasource_id=testing_datasource.datasource_id, experiment_id=experiment_id)
+    if commit:
+        aclient.commit_experiment(datasource_id=testing_datasource.datasource_id, experiment_id=experiment_id)
     return experiment_id
 
 
@@ -462,6 +469,31 @@ async def test_create_pending_snapshots_inserts_for_new_stale_and_failed_experim
     assert [snapshot.status for snapshot in list_snapshots(fresh_experiment_id)] == [SnapshotStatus.SUCCESS]
 
     assert [snapshot.status for snapshot in list_snapshots(inactive_experiment_id)] == []
+
+
+@pytest.mark.parametrize("state", [ExperimentState.ASSIGNED, ExperimentState.ABANDONED])
+async def test_create_pending_snapshots_skips_experiments_that_are_not_committed(
+    testing_datasource,
+    aclient: AdminAPIClient,
+    state: ExperimentState,
+):
+    experiment_id = create_snapshot_experiment(aclient, testing_datasource, name=f"{state} snapshot test", commit=False)
+    if state == ExperimentState.ABANDONED:
+        aclient.abandon_experiment(
+            datasource_id=testing_datasource.datasource_id,
+            experiment_id=experiment_id,
+        )
+
+    await create_pending_snapshots(3600)
+
+    assert (
+        aclient.list_snapshots(
+            organization_id=testing_datasource.organization_id,
+            datasource_id=testing_datasource.datasource_id,
+            experiment_id=experiment_id,
+        ).data.items
+        == []
+    )
 
 
 async def test_process_pending_snapshots_processes_until_empty(


### PR DESCRIPTION
## Ticket

EVE-169

## Description

- **Only create pending snapshots for committed experiments.**
- **Remove unused ExperimentState.DESIGNING and ABORTED.**
- **Remove stale TODO on ExperimentState.ASSIGNED**
- **Document the ExperimentState lifecycle.**
