### PR TITLE
Refine bandit outcome update API.

### DIFF
--- a/src/xngin/apiserver/routers/experiments/experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_api.py
@@ -55,7 +55,7 @@ from xngin.apiserver.routers.experiments.experiments_common import (
     get_experiment_impl,
     get_or_create_assignment_for_participant,
     list_organization_or_datasource_experiments_impl,
-    update_bandit_arm_with_outcome_impl,
+    update_bandit_with_outcome_impl,
 )
 from xngin.apiserver.routers.experiments.experiments_common_csv import (
     CsvStreamingResponse,
@@ -403,27 +403,27 @@ async def update_bandit_arm_with_participant_outcome(
     experiment: Annotated[tables.Experiment, Depends(experiment_and_datasource_dependency)],
     session: Annotated[AsyncSession, Depends(xngin_db_session)],
 ) -> ArmBandit:
-    # Update the arm with the outcome
     if experiment.experiment_type == ExperimentsType.CMAB_ONLINE.value:
         await experiment.awaitable_attrs.contexts
 
-    updated_arm = await update_bandit_arm_with_outcome_impl(
+    arm = await update_bandit_with_outcome_impl(
         xngin_session=session,
         experiment=experiment,
         participant_id=participant_id,
         outcome=body.outcome,
     )
+    await session.commit()
 
     return ArmBandit(
-        arm_id=updated_arm.id,
-        arm_name=updated_arm.name,
-        arm_description=updated_arm.description,
-        alpha_init=updated_arm.alpha_init,
-        beta_init=updated_arm.beta_init,
-        alpha=updated_arm.alpha,
-        beta=updated_arm.beta,
-        mu_init=updated_arm.mu_init,
-        sigma_init=updated_arm.sigma_init,
-        mu=updated_arm.mu,
-        covariance=updated_arm.covariance,
+        arm_id=arm.id,
+        arm_name=arm.name,
+        arm_description=arm.description,
+        alpha_init=arm.alpha_init,
+        beta_init=arm.beta_init,
+        alpha=arm.alpha,
+        beta=arm.beta,
+        mu_init=arm.mu_init,
+        sigma_init=arm.sigma_init,
+        mu=arm.mu,
+        covariance=arm.covariance,
     )

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -1068,9 +1068,9 @@ async def _read_arm_draw_state(
 ) -> ArmDrawState | None:
     """Read a participant's draw and the arm it is on, or returns None if it does not exist.
 
-    This query uses Postgres' FOR UPDATE OF to ensure that no other active transactions acquire a write lock on the rows
-    that the caller is anticipated to update. Any other session updating these two rows will block until the current
-    transaction commits.
+    This query uses Postgres' FOR NO KEY UPDATE OF to ensure that no other active transactions acquire a write lock on
+    the rows that the caller is anticipated to update. Any other session updating these two rows will block until the
+    current transaction commits.
     """
     row: tables.Draw | None = (
         await xngin_session.execute(
@@ -1084,7 +1084,7 @@ async def _read_arm_draw_state(
                 contains_eager(tables.Draw.arm),  # workaround tables.Draw.arm being lazy="joined"
                 raiseload(tables.Draw.experiment),  # inhibit lazy-loading of tables.Draw.experiment
             )
-            .with_for_update(of=[tables.Arm, tables.Draw])
+            .with_for_update(of=[tables.Arm, tables.Draw], key_share=True)
             .execution_options(populate_existing=True)  # update ORM's cache of these rows from this read, if present.
         )
     ).scalar_one_or_none()

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -11,11 +11,11 @@ import pandas as pd
 from fastapi import HTTPException, status
 from pandas import DataFrame
 from psycopg import sql
-from sqlalchemy import Integer, Select, Table, func, insert, select, update
+from sqlalchemy import Integer, Select, Table, func, insert, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import contains_eager, raiseload, selectinload
 
 from xngin.apiserver import constants, flags
 from xngin.apiserver.dwh.dwh_session import DwhSession
@@ -41,6 +41,7 @@ from xngin.apiserver.routers.common_api_types import (
     CMABExperimentSpec,
     CreateExperimentRequest,
     CreateExperimentResponse,
+    DesignSpec,
     DesignSpecMetricRequest,
     Filter,
     FreqExperimentAnalysisResponse,
@@ -1041,54 +1042,63 @@ def _check_outcome_against_mab_dwh_target(
         )
 
 
-async def _fetch_outcomes_and_context_for_arm(
+@dataclass(frozen=True, slots=True)
+class ArmDrawState:
+    """A participant's draw and the arm it is on, as of one read."""
+
+    arm: tables.Arm
+    draw: tables.Draw
+
+
+@dataclass(frozen=True, slots=True)
+class OutcomeUpdatePlan:
+    """Describes the input to a bandit update, and the computed output."""
+
+    state: ArmDrawState
+    outcome: float
+    autofailed_outcome: bool
+
+    parameters: UpdateTypeBeta | UpdateTypeNormal
+
+
+async def _read_arm_draw_state(
     xngin_session: AsyncSession,
     experiment_id: str,
-    arm_id: str,
-    outcome: float,
-    context_vals: list[float] | None,
-) -> tuple[list[float], list[list[float]] | None]:
-    """Return the just-recorded outcome plus the arm's prior outcomes, newest first.
+    participant_id: str,
+) -> ArmDrawState | None:
+    """Read a participant's draw and the arm it is on, or returns None if it does not exist.
 
-    Context values are aggregated alongside the outcomes and returned only for contextual
-    bandits, i.e. when the current draw carries context.
+    This query uses Postgres' FOR UPDATE OF to ensure that no other active transactions acquire a write lock on the rows
+    that the caller is anticipated to update. Any other session updating these two rows will block until the current
+    transaction commits.
     """
-    has_context = context_vals is not None
-    subq = (
-        select(tables.Draw.outcome, tables.Draw.context_vals)
-        .where(
-            tables.Draw.experiment_id == experiment_id,
-            tables.Draw.arm_id == arm_id,
-            tables.Draw.outcome.is_not(None),
+    row: tables.Draw | None = (
+        await xngin_session.execute(
+            select(tables.Draw)
+            .join(tables.Draw.arm)
+            .where(
+                tables.Draw.experiment_id == experiment_id,
+                tables.Draw.participant_id == participant_id,
+            )
+            .options(
+                contains_eager(tables.Draw.arm),  # workaround tables.Draw.arm being lazy="joined"
+                raiseload(tables.Draw.experiment),  # inhibit lazy-loading of tables.Draw.experiment
+            )
+            .with_for_update(of=[tables.Arm, tables.Draw])
+            .execution_options(populate_existing=True)  # update ORM's cache of these rows from this read, if present.
         )
-        .order_by(tables.Draw.created_at.desc())
-        .limit(100)  # TODO: Make draw limiting configurable
-        .subquery()
-    )
-    agg_cols = [func.array_agg(subq.c.outcome)]
-    if has_context:
-        agg_cols.append(func.array_agg(subq.c.context_vals))
-    agg_result = await xngin_session.execute(select(*agg_cols).select_from(subq))
-    agg_row = agg_result.one()
-
-    all_prior_outcomes = agg_row[0]
-    outcomes = [outcome] + (all_prior_outcomes or [])
-    all_context_vals = ([context_vals] + (agg_row[1] or [])) if has_context else None
-    return outcomes, all_context_vals
+    ).scalar_one_or_none()
+    return None if row is None else ArmDrawState(arm=row.arm, draw=row)
 
 
-async def update_bandit_arm_with_outcome_impl(
-    xngin_session: AsyncSession,
+def _validate_outcome_update(
     experiment: tables.Experiment,
+    design_spec: DesignSpec,
+    state: ArmDrawState | None,
     participant_id: str,
     outcome: float,
-    autofailed_outcome: bool = False,
-    commit_on_success: bool = True,
-) -> tables.Arm:
-    """Update the Draw table with the outcome for a bandit experiment."""
-    # Not supported for frequentist experiments
-    design_spec = await ExperimentStorageConverter(experiment).get_design_spec()
-
+) -> ArmDrawState:
+    """Validate a request to update an outcome and return its non-optional locked state."""
     match design_spec:
         case MABExperimentSpec() | MABDwhExperimentSpec() | CMABExperimentSpec():
             pass
@@ -1096,19 +1106,6 @@ async def update_bandit_arm_with_outcome_impl(
             raise LateValidationError("Cannot dynamically update arms for frequentist experiments.")
         case _:
             assert_never(design_spec)
-
-    # Look up the participant's assignment if it exists
-    assignment = await get_existing_assignment_for_participant(
-        xngin_session, experiment.id, participant_id, experiment.experiment_type
-    )
-    if not assignment:
-        raise ExperimentsAssignmentError(
-            f"Participant {participant_id} does not have an assignment for which to record an outcome.",
-        )
-    if assignment.outcome is not None:
-        raise ExperimentsAssignmentError(
-            f"Participant {participant_id} already has an outcome recorded.",
-        )
 
     if design_spec.reward_type == LikelihoodTypes.BERNOULLI and outcome not in {
         0,
@@ -1120,83 +1117,80 @@ async def update_bandit_arm_with_outcome_impl(
     if isinstance(design_spec, MABDwhExperimentSpec):
         _check_outcome_against_mab_dwh_target(experiment.experiment_fields, outcome)
 
-    try:
-        result = await xngin_session.execute(
-            update(tables.Draw)
-            .where(
-                tables.Draw.participant_id == participant_id,
-                tables.Draw.experiment_id == experiment.id,
-                tables.Draw.outcome.is_(None),  # guard against double-write at DB level
-            )
-            .values(observed_at=datetime.now(UTC), outcome=outcome, autofailed_outcome=autofailed_outcome)
-            .returning(tables.Draw.arm_id, tables.Draw.context_vals)
-        )
-        draw_record = result.one_or_none()
-        if draw_record is None:
-            raise ExperimentsAssignmentError(
-                f"Participant '{participant_id}' already has a recorded outcome for this experiment.",
-            )
-
-        arm_to_update = next(arm for arm in experiment.arms if arm.id == draw_record.arm_id)
-
-        # Get all prior draws for this arm, sorted by creation date
-        outcomes, context_vals = await _fetch_outcomes_and_context_for_arm(
-            xngin_session,
-            experiment_id=experiment.id,
-            arm_id=draw_record.arm_id,
-            outcome=outcome,
-            context_vals=draw_record.context_vals,
-        )
-
-        updated_parameters = update_bandit_arm(
-            experiment=experiment,
-            arm_to_update=arm_to_update,
-            outcomes=outcomes,
-            context=context_vals,
-        )
-
-        # Update the draw record and arm with the new parameters
-        update_draw_params: dict[str, float | list[float] | list[list[float]]]
-        match updated_parameters:
-            case UpdateTypeBeta():
-                update_draw_params = {
-                    "current_alpha": updated_parameters.alpha,
-                    "current_beta": updated_parameters.beta,
-                }
-                arm_to_update.alpha = updated_parameters.alpha
-                arm_to_update.beta = updated_parameters.beta
-            case UpdateTypeNormal():
-                update_draw_params = {
-                    "current_mu": updated_parameters.mu,
-                    "current_covariance": updated_parameters.covariance,
-                }
-                arm_to_update.mu = updated_parameters.mu
-                arm_to_update.covariance = updated_parameters.covariance
-            case _:
-                raise ExperimentsAssignmentError(
-                    f"Unsupported prior update type: {type(updated_parameters)} for prior type {experiment.prior_type}"
-                )
-
-        await xngin_session.execute(
-            update(tables.Draw)
-            .where(
-                tables.Draw.participant_id == participant_id,
-                tables.Draw.experiment_id == experiment.id,
-                tables.Draw.arm_id == arm_to_update.id,
-            )
-            .values(**update_draw_params)
-        )
-        xngin_session.add(arm_to_update)
-        if commit_on_success:
-            await xngin_session.commit()
-
-    except IntegrityError as e:
-        await xngin_session.rollback()
+    if state is None:
         raise ExperimentsAssignmentError(
-            f"Failed to update assignment for participant '{participant_id}' with outcome {outcome}: {e}"
-        ) from e
+            f"Participant {participant_id} does not have an assignment for which to record an outcome.",
+        )
+    if state.draw.outcome is not None:
+        raise ExperimentsAssignmentError(
+            f"Participant {participant_id} already has an outcome recorded.",
+        )
+    return state
 
-    return arm_to_update
+
+def _compute_update(
+    experiment: tables.Experiment,
+    state: ArmDrawState,
+    outcome: float,
+    *,
+    autofailed_outcome: bool = False,
+) -> OutcomeUpdatePlan:
+    """Compute the row updates given their current state and the new outcome."""
+    parameters = update_bandit_arm(
+        experiment=experiment,
+        arm_to_update=state.arm,
+        outcomes=[outcome],
+        context=None if state.draw.context_vals is None else [state.draw.context_vals],
+    )
+    return OutcomeUpdatePlan(
+        state=state,
+        outcome=outcome,
+        autofailed_outcome=autofailed_outcome,
+        parameters=parameters,
+    )
+
+
+def _apply_update_plan(plan: OutcomeUpdatePlan) -> None:
+    """Apply a planned update to the rows it was planned against."""
+    plan.state.draw.observed_at = datetime.now(UTC)
+    plan.state.draw.outcome = plan.outcome
+    plan.state.draw.autofailed_outcome = plan.autofailed_outcome
+
+    match plan.parameters:
+        case UpdateTypeBeta(alpha=alpha, beta=beta):
+            plan.state.arm.alpha, plan.state.arm.beta = alpha, beta
+            plan.state.draw.current_alpha, plan.state.draw.current_beta = alpha, beta
+        case UpdateTypeNormal(mu=mu, covariance=covariance):
+            plan.state.arm.mu, plan.state.arm.covariance = mu, covariance
+            plan.state.draw.current_mu, plan.state.draw.current_covariance = mu, covariance
+
+
+async def update_bandit_with_outcome_impl(
+    xngin_session: AsyncSession,
+    experiment: tables.Experiment,
+    participant_id: str,
+    outcome: float,
+    *,
+    autofailed_outcome: bool = False,
+) -> tables.Arm:
+    """Read, validate, compute and write one recorded outcome."""
+    design_spec = await ExperimentStorageConverter(experiment).get_design_spec()
+    state = await _read_arm_draw_state(xngin_session, experiment.id, participant_id)
+    state = _validate_outcome_update(
+        experiment,
+        design_spec,
+        state,
+        participant_id,
+        outcome,
+    )
+    plan = _compute_update(
+        experiment,
+        state,
+        outcome,
+        autofailed_outcome=autofailed_outcome,
+    )
+    _apply_update_plan(plan)
+    return plan.state.arm
 
 
 def convert_assignment_results_to_assign_summary(

--- a/src/xngin/apiserver/routers/experiments/test_bandit_update_concurrency.py
+++ b/src/xngin/apiserver/routers/experiments/test_bandit_update_concurrency.py
@@ -225,3 +225,33 @@ async def test_concurrent_outcomes_for_one_participant_refuse_the_second(
     alpha_after = _get_arm(aclient, testing_datasource.datasource_id, bandit).alpha
     assert alpha_after is not None
     assert alpha_after - alpha_before == 1
+
+
+async def test_outcome_update_does_not_block_new_assignment_on_same_arm(
+    aclient: AdminAPIClient,
+    eclient: ExperimentsAPIClient,
+    testing_datasource: DatasourceMetadata,
+):
+    bandit = await _create_contended_bandit(aclient, eclient, testing_datasource)
+    participant_id = bandit.participant_ids[0]
+
+    async with (
+        asyncio.timeout(30),
+        _hold_outcome_update(bandit.experiment_id, bandit.design_spec, participant_id, 1),
+        database.async_session() as assignment_session,
+    ):
+        experiment = await _load_experiment(assignment_session, bandit.experiment_id)
+        random_state = next(
+            seed
+            for seed in range(100)
+            if experiments_common.choose_bandit_arm(experiment, random_state=seed).id == bandit.arm_id
+        )
+        assignment = await experiments_common.create_assignment_for_participant(
+            assignment_session,
+            experiment,
+            "assignment-while-outcome-is-locked",
+            random_state=random_state,
+        )
+
+    assert assignment is not None
+    assert assignment.arm_id == bandit.arm_id

--- a/src/xngin/apiserver/routers/experiments/test_bandit_update_concurrency.py
+++ b/src/xngin/apiserver/routers/experiments/test_bandit_update_concurrency.py
@@ -1,0 +1,227 @@
+"""Vibed test to validate that two concurrent update_bandit_arm_with_participant_outcome calls don't lose updates."""
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+import sqlalchemy
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from xngin.apiserver import database
+from xngin.apiserver.conftest import DatasourceMetadata
+from xngin.apiserver.routers.common_api_types import ArmBandit, CreateExperimentRequest, DesignSpec, MABExperimentSpec
+from xngin.apiserver.routers.common_enums import ExperimentsType, LikelihoodTypes, PriorTypes
+from xngin.apiserver.routers.experiments import experiments_common
+from xngin.apiserver.routers.experiments.experiments_common import ExperimentsAssignmentError
+from xngin.apiserver.sqla import tables
+
+if TYPE_CHECKING:
+    from xngin.apiserver.testing.admin_api_client import AdminAPIClient
+    from xngin.apiserver.testing.experiments_api_client import ExperimentsAPIClient
+
+
+@dataclass(frozen=True, slots=True)
+class _ContendedBandit:
+    experiment_id: str
+    design_spec: DesignSpec
+    arm_id: str
+    participant_ids: tuple[str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class _PendingOutcomeUpdate:
+    task: asyncio.Task[tables.Arm | ExperimentsAssignmentError]
+    backend_pid: asyncio.Future[int]
+
+    async def expect_blocked(self) -> None:
+        """Wait until PostgreSQL reports that this update is blocked acquiring a lock."""
+        backend_pid = await self.backend_pid
+        async with database.async_session() as monitor_session:
+            while True:
+                waiting_on_lock = await monitor_session.scalar(
+                    sqlalchemy.text("SELECT wait_event_type = 'Lock' FROM pg_stat_activity WHERE pid = :pid"),
+                    {"pid": backend_pid},
+                )
+                if waiting_on_lock:
+                    return
+                await asyncio.sleep(0.01)
+
+    async def result(self) -> tables.Arm:
+        result = await self.task
+        if isinstance(result, ExperimentsAssignmentError):
+            raise result
+        return result
+
+
+async def _create_contended_bandit(
+    aclient: AdminAPIClient,
+    eclient: ExperimentsAPIClient,
+    datasource: DatasourceMetadata,
+) -> _ContendedBandit:
+    design_spec = MABExperimentSpec(
+        experiment_name="concurrent outcome updates",
+        description="",
+        start_date=datetime.now(UTC),
+        end_date=datetime.now(UTC) + timedelta(days=1),
+        experiment_type=ExperimentsType.MAB_ONLINE,
+        prior_type=PriorTypes.BETA,
+        reward_type=LikelihoodTypes.BERNOULLI,
+        arms=[
+            ArmBandit(arm_name="control", arm_description="", alpha_init=1, beta_init=1),
+            ArmBandit(arm_name="treatment", arm_description="", alpha_init=1, beta_init=1),
+        ],
+    )
+    experiment_id = aclient.create_experiment(
+        datasource_id=datasource.datasource_id,
+        body=CreateExperimentRequest(design_spec=design_spec),
+    ).data.experiment_id
+    aclient.commit_experiment(datasource_id=datasource.datasource_id, experiment_id=experiment_id)
+
+    participants_by_arm: dict[str, list[str]] = {}
+    for participant_id in ("p1", "p2", "p3"):
+        assignment = eclient.get_assignment(
+            api_key=datasource.key,
+            experiment_id=experiment_id,
+            participant_id=participant_id,
+            create_if_none=True,
+        ).data.assignment
+        assert assignment is not None
+        participants = participants_by_arm.setdefault(assignment.arm_id, [])
+        participants.append(participant_id)
+        if len(participants) == 2:
+            return _ContendedBandit(
+                experiment_id=experiment_id,
+                design_spec=design_spec,
+                arm_id=assignment.arm_id,
+                participant_ids=(participants[0], participants[1]),
+            )
+
+    raise AssertionError("three participants assigned across two arms must include a shared arm")
+
+
+async def _load_experiment(session: AsyncSession, experiment_id: str) -> tables.Experiment:
+    experiment = await session.scalar(
+        select(tables.Experiment)
+        .where(tables.Experiment.id == experiment_id)
+        .options(selectinload(tables.Experiment.arms))
+    )
+    assert experiment is not None
+    return experiment
+
+
+def _get_arm(aclient: AdminAPIClient, datasource_id: str, bandit: _ContendedBandit) -> ArmBandit:
+    design_spec = aclient.get_experiment_for_ui(
+        datasource_id=datasource_id,
+        experiment_id=bandit.experiment_id,
+    ).data.config.design_spec
+    assert isinstance(design_spec, MABExperimentSpec)
+    return next(arm for arm in design_spec.arms if arm.arm_id == bandit.arm_id)
+
+
+@asynccontextmanager
+async def _hold_outcome_update(
+    experiment_id: str,
+    design_spec: DesignSpec,
+    participant_id: str,
+    outcome: float,
+) -> AsyncIterator[None]:
+    """Hold an outcome's row locks, then apply and commit it when released."""
+    async with database.async_session() as session:
+        experiment = await _load_experiment(session, experiment_id)
+        state = await experiments_common._read_arm_draw_state(session, experiment_id, participant_id)
+        state = experiments_common._validate_outcome_update(
+            experiment,
+            design_spec,
+            state,
+            participant_id,
+            outcome,
+        )
+        plan = experiments_common._compute_update(experiment, state, outcome)
+        yield
+        experiments_common._apply_update_plan(plan)
+        await session.commit()
+
+
+def _start_outcome_update(
+    task_group: asyncio.TaskGroup,
+    experiment_id: str,
+    participant_id: str,
+    outcome: float,
+) -> _PendingOutcomeUpdate:
+    backend_pid: asyncio.Future[int] = asyncio.get_running_loop().create_future()
+
+    async def record() -> tables.Arm | ExperimentsAssignmentError:
+        async with database.async_session() as session:
+            experiment = await _load_experiment(session, experiment_id)
+            pid = await session.scalar(sqlalchemy.text("SELECT pg_backend_pid()"))
+            assert pid is not None
+            backend_pid.set_result(pid)
+            try:
+                arm = await experiments_common.update_bandit_with_outcome_impl(
+                    session,
+                    experiment,
+                    participant_id,
+                    outcome,
+                )
+            except ExperimentsAssignmentError as exc:
+                return exc
+            await session.commit()
+            return arm
+
+    return _PendingOutcomeUpdate(task=task_group.create_task(record()), backend_pid=backend_pid)
+
+
+async def test_concurrent_outcomes_on_one_arm_do_not_lose_contributions(
+    aclient: AdminAPIClient,
+    eclient: ExperimentsAPIClient,
+    testing_datasource: DatasourceMetadata,
+):
+    bandit = await _create_contended_bandit(aclient, eclient, testing_datasource)
+    alpha_before = _get_arm(aclient, testing_datasource.datasource_id, bandit).alpha
+    assert alpha_before is not None
+    first_participant, second_participant = bandit.participant_ids
+
+    async with (
+        asyncio.timeout(30),
+        asyncio.TaskGroup() as task_group,
+        _hold_outcome_update(bandit.experiment_id, bandit.design_spec, first_participant, 1),
+    ):
+        second = _start_outcome_update(task_group, bandit.experiment_id, second_participant, 1)
+        await second.expect_blocked()
+
+    _ = await second.result()
+    alpha_after = _get_arm(aclient, testing_datasource.datasource_id, bandit).alpha
+    assert alpha_after is not None
+    assert alpha_after - alpha_before == 2
+
+
+async def test_concurrent_outcomes_for_one_participant_refuse_the_second(
+    aclient: AdminAPIClient,
+    eclient: ExperimentsAPIClient,
+    testing_datasource: DatasourceMetadata,
+):
+    bandit = await _create_contended_bandit(aclient, eclient, testing_datasource)
+    alpha_before = _get_arm(aclient, testing_datasource.datasource_id, bandit).alpha
+    assert alpha_before is not None
+    participant_id = bandit.participant_ids[0]
+
+    async with (
+        asyncio.timeout(30),
+        asyncio.TaskGroup() as task_group,
+        _hold_outcome_update(bandit.experiment_id, bandit.design_spec, participant_id, 1),
+    ):
+        duplicate = _start_outcome_update(task_group, bandit.experiment_id, participant_id, 1)
+        await duplicate.expect_blocked()
+
+    with pytest.raises(ExperimentsAssignmentError, match="already has an outcome recorded"):
+        await duplicate.result()
+
+    alpha_after = _get_arm(aclient, testing_datasource.datasource_id, bandit).alpha
+    assert alpha_after is not None
+    assert alpha_after - alpha_before == 1

--- a/src/xngin/apiserver/routers/experiments/test_experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_api.py
@@ -1178,14 +1178,14 @@ async def test_get_assignment_mab_cache_headers(
 async def test_normal_prior_binary_reward_fits_each_outcome_exactly_once(
     testing_datasource, aclient: AdminAPIClient, eclient: ExperimentsAPIClient
 ):
-    """Recording one outcome moves the arm's posterior by exactly one observation.
+    """The endpoint folds one recorded outcome into a Normal/Bernoulli posterior exactly once.
 
-    A Normal prior with a binary reward is the one combination whose update is a numerical fit over
-    a set of observations rather than a closed-form step, so it is the only one that can fit the
-    same outcome more than once -- which it used to, by refitting a window of past outcomes that
-    already included the one being recorded. Beta priors and Normal priors with real-valued rewards
-    take a single observation by construction, so this has to use reward_type=BERNOULLI to be
-    capable of failing at all.
+    Normal/Bernoulli is the only update_arm branch that consumes every entry in its outcomes
+    argument; the Beta/Bernoulli and Normal/Normal branches use only outcomes[0]. This makes it the
+    branch that detects if the endpoint accidentally supplies duplicate or previously absorbed
+    outcomes instead of the intended singleton. Draw rows continue to retain the complete outcome
+    and context history, so a future batch implementation can deliberately recompute from the
+    original prior without weakening this incremental-update invariant.
     """
     # A single arm dimension keeps the posterior easy to read. Arms start at
     # mu=[mu_init] and covariance=diag([sigma_init]) (storage_format_converters.py:532).

--- a/src/xngin/apiserver/routers/experiments/test_experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_api.py
@@ -40,6 +40,7 @@ from xngin.apiserver.routers.common_enums import (
     StopAssignmentReason,
     UpdateTypeNormal,
 )
+from xngin.apiserver.routers.experiments.test_experiments_common import make_create_online_bandit_experiment_request
 from xngin.apiserver.sqla import tables
 from xngin.apiserver.testing.admin_api_client import AdminAPIClientHTTPValidationError
 from xngin.apiserver.testing.experiments_api_client import ExperimentsAPIClientNotDefaultStatusError
@@ -1173,6 +1174,242 @@ async def test_get_assignment_mab_cache_headers(
     assert response.data.assignment is not None
     assert response.data.assignment.outcome == 1.0
     assert response.response.headers["Cache-Control"] == "private, max-age=3600"
+
+
+@pytest.mark.parametrize(
+    ("experiment_type", "prior_type", "reward_type"),
+    [
+        (ExperimentsType.MAB_ONLINE, PriorTypes.NORMAL, LikelihoodTypes.NORMAL),
+        (ExperimentsType.MAB_ONLINE, PriorTypes.BETA, LikelihoodTypes.BERNOULLI),
+        (ExperimentsType.MAB_ONLINE, PriorTypes.NORMAL, LikelihoodTypes.BERNOULLI),
+        (ExperimentsType.CMAB_ONLINE, PriorTypes.NORMAL, LikelihoodTypes.NORMAL),
+        (ExperimentsType.CMAB_ONLINE, PriorTypes.NORMAL, LikelihoodTypes.BERNOULLI),
+    ],
+)
+async def test_update_bandit_arm_with_outcome(
+    testing_datasource,
+    aclient: AdminAPIClient,
+    eclient: ExperimentsAPIClient,
+    experiment_type: ExperimentsType,
+    prior_type: PriorTypes,
+    reward_type: LikelihoodTypes,
+):
+    """Record an outcome and verify the updated draw and arm through API responses."""
+    arms = [
+        ArmBandit(
+            arm_name="control",
+            arm_description="Control group",
+            **(
+                {"alpha_init": 1.0, "beta_init": 1.0}
+                if prior_type == PriorTypes.BETA
+                else {"mu_init": 0.0, "sigma_init": 1.0}
+            ),
+        ),
+        ArmBandit(
+            arm_name="treatment",
+            arm_description="Treatment group",
+            **(
+                {"alpha_init": 1.0, "beta_init": 1.0}
+                if prior_type == PriorTypes.BETA
+                else {"mu_init": 0.0, "sigma_init": 1.0}
+            ),
+        ),
+    ]
+    design_spec: MABExperimentSpec | CMABExperimentSpec
+    if experiment_type == ExperimentsType.CMAB_ONLINE:
+        design_spec = CMABExperimentSpec(
+            experiment_type=experiment_type,
+            experiment_name="API outcome update",
+            description="API outcome update",
+            start_date=datetime(2024, 1, 1, tzinfo=UTC),
+            end_date=datetime.now(UTC) + timedelta(days=1),
+            arms=arms,
+            prior_type=prior_type,
+            reward_type=reward_type,
+            contexts=[
+                Context(context_name="c1", context_description="Context 1", value_type=ContextType.REAL_VALUED),
+                Context(context_name="c2", context_description="Context 2", value_type=ContextType.REAL_VALUED),
+            ],
+        )
+    else:
+        design_spec = MABExperimentSpec(
+            experiment_type=experiment_type,
+            experiment_name="API outcome update",
+            description="API outcome update",
+            start_date=datetime(2024, 1, 1, tzinfo=UTC),
+            end_date=datetime.now(UTC) + timedelta(days=1),
+            arms=arms,
+            prior_type=prior_type,
+            reward_type=reward_type,
+            contexts=None,
+        )
+    experiment_id = aclient.create_experiment(
+        datasource_id=testing_datasource.datasource_id,
+        body=CreateExperimentRequest(design_spec=design_spec),
+    ).data.experiment_id
+    aclient.commit_experiment(datasource_id=testing_datasource.datasource_id, experiment_id=experiment_id)
+
+    participant_id = "test_id"
+    committed_design_spec = aclient.get_experiment_for_ui(
+        datasource_id=testing_datasource.datasource_id,
+        experiment_id=experiment_id,
+    ).data.config.design_spec
+    context_inputs = (
+        [
+            ContextInput(context_id=context.context_id or "", context_value=1.0)
+            for context in committed_design_spec.contexts or []
+        ]
+        if isinstance(committed_design_spec, CMABExperimentSpec)
+        else []
+    )
+    if experiment_type == ExperimentsType.CMAB_ONLINE:
+        assignment = eclient.get_assignment_cmab(
+            api_key=testing_datasource.key,
+            body=CMABContextInputRequest(context_inputs=context_inputs),
+            experiment_id=experiment_id,
+            participant_id=participant_id,
+        ).data.assignment
+    else:
+        assignment = eclient.get_assignment(
+            api_key=testing_datasource.key,
+            experiment_id=experiment_id,
+            participant_id=participant_id,
+        ).data.assignment
+    assert assignment is not None
+
+    updated_arm = eclient.update_bandit_arm_with_participant_outcome(
+        api_key=testing_datasource.key,
+        body=UpdateBanditArmOutcomeRequest(outcome=1.0),
+        experiment_id=experiment_id,
+        participant_id=participant_id,
+    ).data
+
+    if experiment_type == ExperimentsType.CMAB_ONLINE:
+        updated_assignment = eclient.get_assignment_cmab(
+            api_key=testing_datasource.key,
+            body=CMABContextInputRequest(context_inputs=None),
+            experiment_id=experiment_id,
+            participant_id=participant_id,
+            create_if_none=False,
+        ).data.assignment
+    else:
+        updated_assignment = eclient.get_assignment(
+            api_key=testing_datasource.key,
+            experiment_id=experiment_id,
+            participant_id=participant_id,
+            create_if_none=False,
+        ).data.assignment
+    assert updated_assignment is not None
+    assert updated_assignment.outcome == 1.0
+    assert updated_assignment.observed_at is not None
+    assert updated_assignment.arm_id == assignment.arm_id
+    if experiment_type == ExperimentsType.CMAB_ONLINE:
+        assert updated_assignment.context_values == [1.0, 1.0]
+
+    stored_design_spec = aclient.get_experiment_for_ui(
+        datasource_id=testing_datasource.datasource_id,
+        experiment_id=experiment_id,
+    ).data.config.design_spec
+    stored_arm = next(arm for arm in stored_design_spec.arms if arm.arm_id == assignment.arm_id)
+    assert stored_arm == updated_arm
+
+    with pytest.raises(ExperimentsAPIClientNotDefaultStatusError) as exc:
+        eclient.update_bandit_arm_with_participant_outcome(
+            api_key=testing_datasource.key,
+            body=UpdateBanditArmOutcomeRequest(outcome=1.0),
+            experiment_id=experiment_id,
+            participant_id="missing",
+        )
+    assert exc.value.result.status == HTTPStatus.UNPROCESSABLE_CONTENT
+
+    with pytest.raises(ExperimentsAPIClientNotDefaultStatusError) as exc:
+        eclient.update_bandit_arm_with_participant_outcome(
+            api_key=testing_datasource.key,
+            body=UpdateBanditArmOutcomeRequest(outcome=1.0),
+            experiment_id=experiment_id,
+            participant_id=participant_id,
+        )
+    assert exc.value.result.status == HTTPStatus.UNPROCESSABLE_CONTENT
+
+
+async def test_create_mab_dwh_bool_target_with_normal_reward_returns_422(testing_datasource, aclient: AdminAPIClient):
+    """The API rejects an incompatible Normal reward for a boolean MAB-DWH target."""
+    request = make_create_online_bandit_experiment_request(
+        experiment_type=ExperimentsType.MAB_ONLINE_DWH,
+        prior_type=PriorTypes.NORMAL,
+        reward_type=LikelihoodTypes.NORMAL,
+        target_field_name="is_onboarded",
+    )
+    result = aclient.create_experiment(
+        datasource_id=testing_datasource.datasource_id,
+        body=request,
+        random_state=42,
+        raise_if_not_default_status=False,
+    )
+    assert result.status == HTTPStatus.UNPROCESSABLE_CONTENT
+    assert "only compatible with reward_type 'binary'" in str(result.data)
+
+
+async def test_update_bandit_arm_with_outcome_mab_dwh_numeric_target_accepts_any_float(
+    testing_datasource, aclient: AdminAPIClient, eclient: ExperimentsAPIClient
+):
+    """A MAB-DWH numeric target accepts arbitrary floats through the API."""
+    request = make_create_online_bandit_experiment_request(
+        experiment_type=ExperimentsType.MAB_ONLINE_DWH,
+        prior_type=PriorTypes.NORMAL,
+        reward_type=LikelihoodTypes.NORMAL,
+        target_field_name="current_income",
+    )
+    experiment_id = aclient.create_experiment(
+        datasource_id=testing_datasource.datasource_id, body=request, random_state=42
+    ).data.experiment_id
+    aclient.commit_experiment(datasource_id=testing_datasource.datasource_id, experiment_id=experiment_id)
+    eclient.get_assignment(api_key=testing_datasource.key, experiment_id=experiment_id, participant_id="p1")
+
+    eclient.update_bandit_arm_with_participant_outcome(
+        api_key=testing_datasource.key,
+        body=UpdateBanditArmOutcomeRequest(outcome=42.7),
+        experiment_id=experiment_id,
+        participant_id="p1",
+    )
+    assignment = eclient.get_assignment(
+        api_key=testing_datasource.key,
+        experiment_id=experiment_id,
+        participant_id="p1",
+        create_if_none=False,
+    ).data.assignment
+    assert assignment is not None
+    assert assignment.outcome == 42.7
+
+
+@pytest.mark.parametrize("experiment_type", [ExperimentsType.FREQ_ONLINE, ExperimentsType.FREQ_PREASSIGNED])
+async def test_update_bandit_arm_with_freq_experiments_returns_422(
+    testing_datasource, aclient: AdminAPIClient, eclient: ExperimentsAPIClient, experiment_type: ExperimentsType
+):
+    """Frequentist experiments reject bandit outcome updates through the API."""
+    experiment = await create_experiment(testing_datasource, aclient, experiment_type=experiment_type)
+    if experiment_type == ExperimentsType.FREQ_ONLINE:
+        assignment = eclient.get_assignment(
+            api_key=testing_datasource.key,
+            experiment_id=experiment.experiment_id,
+            participant_id="p1",
+        ).data.assignment
+    else:
+        assignments = eclient.get_experiment_assignments(
+            api_key=testing_datasource.key, experiment_id=experiment.experiment_id
+        ).data.assignments
+        assignment = assignments[0] if assignments else None
+    assert assignment is not None
+
+    with pytest.raises(ExperimentsAPIClientNotDefaultStatusError) as exc:
+        eclient.update_bandit_arm_with_participant_outcome(
+            api_key=testing_datasource.key,
+            body=UpdateBanditArmOutcomeRequest(outcome=42.7),
+            experiment_id=experiment.experiment_id,
+            participant_id=assignment.participant_id,
+        )
+    assert exc.value.result.status == HTTPStatus.UNPROCESSABLE_CONTENT
+    assert "Cannot dynamically update arms for frequentist experiments" in str(exc.value.result.data)
 
 
 async def test_normal_prior_binary_reward_fits_each_outcome_exactly_once(

--- a/src/xngin/apiserver/routers/experiments/test_experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_api.py
@@ -33,10 +33,17 @@ from xngin.apiserver.routers.common_api_types import (
     Stratum,
     UpdateBanditArmOutcomeRequest,
 )
-from xngin.apiserver.routers.common_enums import ContextType, ExperimentState, Relation, StopAssignmentReason
+from xngin.apiserver.routers.common_enums import (
+    ContextType,
+    ExperimentState,
+    Relation,
+    StopAssignmentReason,
+    UpdateTypeNormal,
+)
 from xngin.apiserver.sqla import tables
 from xngin.apiserver.testing.admin_api_client import AdminAPIClientHTTPValidationError
 from xngin.apiserver.testing.experiments_api_client import ExperimentsAPIClientNotDefaultStatusError
+from xngin.stats.bandit_sampling import update_arm
 
 if TYPE_CHECKING:
     from xngin.apiserver.testing.admin_api_client import AdminAPIClient
@@ -1166,6 +1173,107 @@ async def test_get_assignment_mab_cache_headers(
     assert response.data.assignment is not None
     assert response.data.assignment.outcome == 1.0
     assert response.response.headers["Cache-Control"] == "private, max-age=3600"
+
+
+async def test_normal_prior_binary_reward_fits_each_outcome_exactly_once(
+    testing_datasource, aclient: AdminAPIClient, eclient: ExperimentsAPIClient
+):
+    """Recording one outcome moves the arm's posterior by exactly one observation.
+
+    A Normal prior with a binary reward is the one combination whose update is a numerical fit over
+    a set of observations rather than a closed-form step, so it is the only one that can fit the
+    same outcome more than once -- which it used to, by refitting a window of past outcomes that
+    already included the one being recorded. Beta priors and Normal priors with real-valued rewards
+    take a single observation by construction, so this has to use reward_type=BERNOULLI to be
+    capable of failing at all.
+    """
+    # A single arm dimension keeps the posterior easy to read. Arms start at
+    # mu=[mu_init] and covariance=diag([sigma_init]) (storage_format_converters.py:532).
+    initial_mu = [0.0]
+    initial_covariance = [[1.0]]
+    design_spec = MABExperimentSpec(
+        experiment_type=ExperimentsType.MAB_ONLINE,
+        experiment_name="normal prior binary reward",
+        description="normal prior binary reward",
+        start_date=datetime(2024, 1, 1, tzinfo=UTC),
+        end_date=datetime.now(UTC) + timedelta(days=1),
+        arms=[
+            ArmBandit(arm_name="control", arm_description="", mu_init=initial_mu[0], sigma_init=1.0),
+            ArmBandit(arm_name="treatment", arm_description="", mu_init=initial_mu[0], sigma_init=1.0),
+        ],
+        prior_type=PriorTypes.NORMAL,
+        reward_type=LikelihoodTypes.BERNOULLI,
+        contexts=None,
+    )
+    experiment_id = aclient.create_experiment(
+        datasource_id=testing_datasource.datasource_id,
+        body=CreateExperimentRequest(design_spec=design_spec),
+    ).data.experiment_id
+    aclient.commit_experiment(datasource_id=testing_datasource.datasource_id, experiment_id=experiment_id)
+
+    eclient.get_assignment(
+        api_key=testing_datasource.key,
+        experiment_id=experiment_id,
+        participant_id="1",
+    )
+    updated_arm = eclient.update_bandit_arm_with_participant_outcome(
+        api_key=testing_datasource.key,
+        body=UpdateBanditArmOutcomeRequest(outcome=1.0),
+        experiment_id=experiment_id,
+        participant_id="1",
+    ).data
+
+    # Oracle: the same model fitted with the one outcome that was actually recorded. Using
+    # update_arm itself keeps the expectation free of any reimplementation of the math.
+    expected = update_arm(
+        experiment=tables.Experiment(
+            experiment_type=ExperimentsType.MAB_ONLINE.value,
+            prior_type=PriorTypes.NORMAL.value,
+            reward_type=LikelihoodTypes.BERNOULLI.value,
+        ),
+        arm_to_update=tables.Arm(mu=initial_mu, covariance=initial_covariance),
+        outcomes=[1.0],
+        context=None,
+    )
+    assert isinstance(expected, UpdateTypeNormal)
+
+    assert updated_arm.mu == pytest.approx(expected.mu)
+
+
+async def test_update_bandit_arm_with_outcome_rejects_non_binary_outcome_for_binary_reward(
+    testing_datasource, aclient: AdminAPIClient, eclient: ExperimentsAPIClient
+):
+    """An experiment whose reward is binary accepts only 0 or 1."""
+    experiment_id = aclient.create_experiment(
+        datasource_id=testing_datasource.datasource_id,
+        body=CreateExperimentRequest(
+            design_spec=MABExperimentSpec(
+                experiment_type=ExperimentsType.MAB_ONLINE,
+                experiment_name="binary reward",
+                description="binary reward",
+                start_date=datetime(2024, 1, 1, tzinfo=UTC),
+                end_date=datetime.now(UTC) + timedelta(days=1),
+                arms=[
+                    ArmBandit(arm_name="control", arm_description="", alpha_init=1, beta_init=1),
+                    ArmBandit(arm_name="treatment", arm_description="", alpha_init=1, beta_init=1),
+                ],
+                prior_type=PriorTypes.BETA,
+                reward_type=LikelihoodTypes.BERNOULLI,
+                contexts=None,
+            )
+        ),
+    ).data.experiment_id
+    aclient.commit_experiment(datasource_id=testing_datasource.datasource_id, experiment_id=experiment_id)
+    eclient.get_assignment(api_key=testing_datasource.key, experiment_id=experiment_id, participant_id="1")
+
+    response = eclient.client.post(
+        f"/v1/experiments/{experiment_id}/assignments/1/outcome",
+        headers={"X-API-Key": testing_datasource.key},
+        json={"outcome": 0.5},
+    )
+
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_CONTENT, response.content
+    assert "Must be 0 or 1" in response.text
 
 
 async def test_update_bandit_arm_with_outcome_rejects_non_numeric_outcome(

--- a/src/xngin/apiserver/routers/experiments/test_experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_common.py
@@ -68,7 +68,6 @@ from xngin.apiserver.routers.experiments.experiments_common import (
     get_or_create_assignment_for_participant,
     make_sample_calls,
     make_schema_from_experiment,
-    update_bandit_with_outcome_impl,
 )
 from xngin.apiserver.routers.experiments.experiments_common_csv import get_experiment_assignments_as_csv_impl
 from xngin.apiserver.sqla import tables
@@ -2645,117 +2644,6 @@ async def test_get_or_create_assignment_for_participant_without_filters(
         assert (response.assignment is not None) == has_assignment
 
 
-@pytest.mark.parametrize(
-    ("experiment_type", "prior_type", "reward_type"),
-    [
-        (ExperimentsType.MAB_ONLINE, PriorTypes.NORMAL, LikelihoodTypes.NORMAL),
-        (ExperimentsType.MAB_ONLINE, PriorTypes.BETA, LikelihoodTypes.BERNOULLI),
-        (ExperimentsType.MAB_ONLINE, PriorTypes.NORMAL, LikelihoodTypes.BERNOULLI),
-        (ExperimentsType.CMAB_ONLINE, PriorTypes.NORMAL, LikelihoodTypes.NORMAL),
-        (ExperimentsType.CMAB_ONLINE, PriorTypes.NORMAL, LikelihoodTypes.BERNOULLI),
-    ],
-)
-async def test_update_bandit_arm_with_outcome(
-    xngin_session, testing_datasource, experiment_type, prior_type, reward_type
-):
-    bandit_experiment = await insert_experiment_and_arms(
-        xngin_session,
-        testing_datasource.ds,
-        experiment_type=experiment_type,
-        prior_type=prior_type,
-        reward_type=reward_type,
-    )
-    await create_assignment_for_participant(
-        xngin_session,
-        bandit_experiment,
-        "test_id",
-        [1.0, 1.0] if experiment_type == ExperimentsType.CMAB_ONLINE else None,
-        random_state=66,
-    )
-
-    updated_arm = await update_bandit_with_outcome_impl(
-        xngin_session=xngin_session, experiment=bandit_experiment, participant_id="test_id", outcome=1.0
-    )
-
-    # Read back from the database to verify that the updated parameters are persisted on both rows.
-    draws = (
-        await xngin_session.execute(
-            select(
-                tables.Draw.outcome,
-                tables.Draw.observed_at,
-                tables.Draw.current_alpha,
-                tables.Draw.current_beta,
-                tables.Draw.current_mu,
-                tables.Draw.current_covariance,
-                tables.Draw.context_vals,
-            ).where(tables.Draw.experiment_id == bandit_experiment.id)
-        )
-    ).all()
-    assert len(draws) == 1
-    draw = draws[0]
-    assert draw.outcome == 1.0
-    assert draw.observed_at is not None
-
-    stored_arm = (
-        await xngin_session.execute(
-            select(tables.Arm.alpha, tables.Arm.beta, tables.Arm.mu, tables.Arm.covariance).where(
-                tables.Arm.id == updated_arm.id
-            )
-        )
-    ).one()
-    updated_parameters = (updated_arm.alpha, updated_arm.beta, updated_arm.mu, updated_arm.covariance)
-    assert stored_arm == updated_parameters
-    assert (draw.current_alpha, draw.current_beta, draw.current_mu, draw.current_covariance) == updated_parameters
-
-    if experiment_type == ExperimentsType.CMAB_ONLINE:
-        assert draw.context_vals == [1.0, 1.0]
-
-    # Assert that we can't update the arm with an outcome for a participant that doesn't exist
-    with pytest.raises(
-        ExperimentsAssignmentError,
-        match="Participant {participant_id} does not have an assignment for which to record an outcome.".format(
-            participant_id="some_other_id"
-        ),
-    ):
-        await update_bandit_with_outcome_impl(xngin_session, bandit_experiment, "some_other_id", 1.0)
-
-    # Assert that we can't update the arm with an outcome for a participant that already has an outcome
-    with pytest.raises(
-        ExperimentsAssignmentError,
-        match="Participant {participant_id} already has an outcome recorded.".format(participant_id="test_id"),
-    ):
-        await update_bandit_with_outcome_impl(xngin_session, bandit_experiment, "test_id", 1.0)
-
-
-async def test_update_bandit_arm_with_outcome_mab_dwh_bool_target_rejects_non_binary(xngin_session, testing_datasource):
-    """MAB-DWH with a BOOL target rejects outcomes that aren't 0 or 1, even under NORMAL reward."""
-    bandit_experiment = await insert_experiment_and_arms(
-        xngin_session,
-        testing_datasource.ds,
-        experiment_type=ExperimentsType.MAB_ONLINE_DWH,
-        prior_type=PriorTypes.NORMAL,
-        reward_type=LikelihoodTypes.NORMAL,
-        target_field_name="is_onboarded",
-    )
-    await create_assignment_for_participant(xngin_session, bandit_experiment, "p1", None, random_state=66)
-
-    with pytest.raises(LateValidationError, match="must be 0 or 1 for boolean targets"):
-        await update_bandit_with_outcome_impl(
-            xngin_session=xngin_session, experiment=bandit_experiment, participant_id="p1", outcome=0.5
-        )
-
-    # A valid binary outcome is accepted.
-    await update_bandit_with_outcome_impl(
-        xngin_session=xngin_session, experiment=bandit_experiment, participant_id="p1", outcome=1.0
-    )
-    recorded = await xngin_session.scalar(
-        select(tables.Draw.outcome).where(
-            tables.Draw.experiment_id == bandit_experiment.id, tables.Draw.participant_id == "p1"
-        )
-    )
-    assert recorded == 1.0
-
-
 async def test_read_arm_draw_state_returns_the_stored_parameters_not_the_session_copy(
     xngin_session, testing_datasource
 ):
@@ -2804,58 +2692,6 @@ async def test_read_arm_draw_state_returns_the_stored_parameters_not_the_session
     assert stale != 999.0
     assert state is not None
     assert state.arm.alpha == 999.0
-
-
-async def test_update_bandit_arm_with_outcome_mab_dwh_numeric_target_accepts_any_float(
-    xngin_session, testing_datasource
-):
-    """MAB-DWH with a numeric target accepts any float under NORMAL reward."""
-    bandit_experiment = await insert_experiment_and_arms(
-        xngin_session,
-        testing_datasource.ds,
-        experiment_type=ExperimentsType.MAB_ONLINE_DWH,
-        prior_type=PriorTypes.NORMAL,
-        reward_type=LikelihoodTypes.NORMAL,
-        target_field_name="current_income",
-    )
-    await create_assignment_for_participant(xngin_session, bandit_experiment, "p1", None, random_state=66)
-
-    await update_bandit_with_outcome_impl(
-        xngin_session=xngin_session, experiment=bandit_experiment, participant_id="p1", outcome=42.7
-    )
-    recorded = await xngin_session.scalar(
-        select(tables.Draw.outcome).where(
-            tables.Draw.experiment_id == bandit_experiment.id, tables.Draw.participant_id == "p1"
-        )
-    )
-    assert recorded == 42.7
-
-
-async def test_update_bandit_arm_with_freq_experiments_returns_422(xngin_session, testing_datasource):
-    """Freq experiments should return 422 when updating bandit arm with outcome."""
-    online_freq_experiment = await insert_experiment_and_arms(
-        xngin_session,
-        testing_datasource.ds,
-        experiment_type=ExperimentsType.FREQ_ONLINE,
-        target_field_name="current_income",
-    )
-    await create_assignment_for_participant(xngin_session, online_freq_experiment, "p1", None, random_state=66)
-
-    with pytest.raises(LateValidationError, match="Cannot dynamically update arms for frequentist experiments"):
-        await update_bandit_with_outcome_impl(
-            xngin_session=xngin_session, experiment=online_freq_experiment, participant_id="p1", outcome=42.7
-        )
-
-    pre_freq_experiment = await insert_experiment_and_arms(
-        xngin_session,
-        testing_datasource.ds,
-    )
-    await create_assignment_for_participant(xngin_session, pre_freq_experiment, "p1", None, random_state=66)
-
-    with pytest.raises(LateValidationError, match="Cannot dynamically update arms for frequentist experiments"):
-        await update_bandit_with_outcome_impl(
-            xngin_session=xngin_session, experiment=pre_freq_experiment, participant_id="p1", outcome=42.7
-        )
 
 
 async def test_analyze_experiment_freq_impl_with_no_outcomes_for_any_arms(xngin_session, testing_datasource):

--- a/src/xngin/apiserver/routers/experiments/test_experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_common.py
@@ -1,4 +1,3 @@
-import asyncio
 from collections import defaultdict
 from contextlib import AbstractContextManager
 from contextlib import nullcontext as does_not_raise
@@ -11,7 +10,7 @@ import pytest
 import sqlalchemy
 from deepdiff import DeepDiff
 from pydantic import HttpUrl, TypeAdapter
-from sqlalchemy import Boolean, Column, MetaData, String, Table, select, update
+from sqlalchemy import Boolean, Column, MetaData, String, Table, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -2757,64 +2756,6 @@ async def test_update_bandit_arm_with_outcome_mab_dwh_bool_target_rejects_non_bi
     assert recorded == 1.0
 
 
-async def test_update_bandit_arm_concurrent_outcomes_do_not_lose_contributions(xngin_session, testing_datasource):
-    """Two outcomes landing on one arm concurrently must both move its posterior.
-
-    Each update derives the arm's new parameters from the ones it read, so if both writers read
-    before either writes, they derive from the same starting point and the later write drops the
-    earlier one's contribution. What prevents that is the lock the read takes on the arm, held
-    until the reader's transaction ends.
-
-    The second writer is held until the first has read, and the first then waits before writing, so
-    the second issues its read while the lock is held. Without the lock that read returns the stale
-    parameters immediately and the arm ends up one observation short.
-    """
-    experiment = await insert_experiment_and_arms(
-        xngin_session,
-        testing_datasource.ds,
-        experiment_type=ExperimentsType.MAB_ONLINE,
-        prior_type=PriorTypes.BETA,
-        reward_type=LikelihoodTypes.BERNOULLI,
-    )
-    await create_assignment_for_participant(xngin_session, experiment, "p1", None, random_state=66)
-    await create_assignment_for_participant(xngin_session, experiment, "p2", None, random_state=67)
-
-    # Assignment picks arms by Thompson sampling; the race is only observable when both outcomes
-    # derive parameters for the same arm, so put both draws on one arm explicitly.
-    contended_arm_id = experiment.arms[0].id
-    await xngin_session.execute(
-        update(tables.Draw).where(tables.Draw.experiment_id == experiment.id).values(arm_id=contended_arm_id)
-    )
-    await xngin_session.commit()
-    design_spec = await ExperimentStorageConverter(experiment).get_design_spec()
-    alpha_before = next(arm.alpha for arm in experiment.arms if arm.id == contended_arm_id)
-
-    first_has_read = asyncio.Event()
-
-    async def record(participant_id: str, *, wait_for_first_read: bool):
-        async with database.async_session() as session:
-            if wait_for_first_read:
-                await first_has_read.wait()
-            state = await experiments_common._read_arm_draw_state(session, experiment.id, participant_id)
-            if not wait_for_first_read:
-                first_has_read.set()
-                # Hold the lock long enough for the other writer to issue its read against it.
-                await asyncio.sleep(0.25)
-            state = experiments_common._validate_outcome_update(experiment, design_spec, state, participant_id, 1)
-            planned = experiments_common._compute_update(experiment, state, 1)
-            experiments_common._apply_update_plan(planned)
-            await session.commit()
-
-    await asyncio.gather(
-        record("p1", wait_for_first_read=False),
-        record("p2", wait_for_first_read=True),
-    )
-
-    alpha_after = await xngin_session.scalar(select(tables.Arm.alpha).where(tables.Arm.id == contended_arm_id))
-    assert alpha_after is not None and alpha_before is not None
-    assert alpha_after - alpha_before == 2.0
-
-
 async def test_read_arm_draw_state_returns_the_stored_parameters_not_the_session_copy(
     xngin_session, testing_datasource
 ):
@@ -2863,66 +2804,6 @@ async def test_read_arm_draw_state_returns_the_stored_parameters_not_the_session
     assert stale != 999.0
     assert state is not None
     assert state.arm.alpha == 999.0
-
-
-async def test_update_bandit_arm_refuses_a_second_outcome_for_the_same_participant(xngin_session, testing_datasource):
-    """A second writer for one participant waits, then finds the outcome already recorded.
-
-    The read locks the draw, so what it reports cannot go stale underneath the plan: a writer that
-    arrives while another holds the lock blocks there, and when it proceeds it sees the outcome the
-    first one recorded rather than the absence it would have seen a moment earlier. That is what
-    makes recording an outcome twice impossible; nothing re-checks at write time.
-    """
-    experiment = await insert_experiment_and_arms(
-        xngin_session,
-        testing_datasource.ds,
-        experiment_type=ExperimentsType.MAB_ONLINE,
-        prior_type=PriorTypes.BETA,
-        reward_type=LikelihoodTypes.BERNOULLI,
-    )
-    await create_assignment_for_participant(xngin_session, experiment, "p1", None, random_state=66)
-    await xngin_session.commit()
-    design_spec = await ExperimentStorageConverter(experiment).get_design_spec()
-    gain_before = sum((arm.alpha or 0) - (arm.alpha_init or 0) for arm in experiment.arms)
-
-    first_has_read = asyncio.Event()
-    refusals: list[str] = []
-
-    async def record(*, wait_for_first_read: bool):
-        async with database.async_session() as session:
-            if wait_for_first_read:
-                await first_has_read.wait()
-            # The second writer blocks here until the first commits.
-            state = await experiments_common._read_arm_draw_state(session, experiment.id, "p1")
-            if not wait_for_first_read:
-                first_has_read.set()
-                # Hold the lock long enough for the other writer to reach its read.
-                await asyncio.sleep(0.25)
-            try:
-                state = experiments_common._validate_outcome_update(experiment, design_spec, state, "p1", 1)
-                planned = experiments_common._compute_update(experiment, state, 1)
-            except ExperimentsAssignmentError as exc:
-                refusals.append(str(exc))
-                return
-            experiments_common._apply_update_plan(planned)
-            await session.commit()
-
-    async with asyncio.timeout(30):
-        await asyncio.gather(
-            record(wait_for_first_read=False),
-            record(wait_for_first_read=True),
-        )
-
-    assert len(refusals) == 1
-    assert "already has an outcome recorded" in refusals[0]
-
-    # Exactly one observation landed on the arms.
-    gains = (
-        await xngin_session.execute(
-            select(tables.Arm.alpha, tables.Arm.alpha_init).where(tables.Arm.experiment_id == experiment.id)
-        )
-    ).all()
-    assert sum((alpha or 0) - (alpha_init or 0) for alpha, alpha_init in gains) - gain_before == 1.0
 
 
 async def test_update_bandit_arm_with_outcome_mab_dwh_numeric_target_accepts_any_float(

--- a/src/xngin/apiserver/routers/experiments/test_experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_common.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections import defaultdict
 from contextlib import AbstractContextManager
 from contextlib import nullcontext as does_not_raise
@@ -7,12 +8,14 @@ from typing import cast
 
 import numpy as np
 import pytest
+import sqlalchemy
 from deepdiff import DeepDiff
 from pydantic import HttpUrl, TypeAdapter
-from sqlalchemy import Boolean, Column, MetaData, String, Table, select
+from sqlalchemy import Boolean, Column, MetaData, String, Table, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from xngin.apiserver import database
 from xngin.apiserver.conftest import RowProtocolMixin
 from xngin.apiserver.dwh.dwh_session import DwhSession
 from xngin.apiserver.exceptions_common import LateValidationError
@@ -41,7 +44,13 @@ from xngin.apiserver.routers.common_api_types import (
     PriorTypes,
     Stratum,
 )
-from xngin.apiserver.routers.common_enums import DataType, ExperimentState, Relation, StopAssignmentReason
+from xngin.apiserver.routers.common_enums import (
+    DataType,
+    ExperimentState,
+    Relation,
+    StopAssignmentReason,
+)
+from xngin.apiserver.routers.experiments import experiments_common
 from xngin.apiserver.routers.experiments.experiments_common import (
     ExperimentsAssignmentError,
     analyze_experiment_freq_impl,
@@ -60,7 +69,7 @@ from xngin.apiserver.routers.experiments.experiments_common import (
     get_or_create_assignment_for_participant,
     make_sample_calls,
     make_schema_from_experiment,
-    update_bandit_arm_with_outcome_impl,
+    update_bandit_with_outcome_impl,
 )
 from xngin.apiserver.routers.experiments.experiments_common_csv import get_experiment_assignments_as_csv_impl
 from xngin.apiserver.sqla import tables
@@ -2665,26 +2674,39 @@ async def test_update_bandit_arm_with_outcome(
         random_state=66,
     )
 
-    updated_arm = await update_bandit_arm_with_outcome_impl(
+    updated_arm = await update_bandit_with_outcome_impl(
         xngin_session=xngin_session, experiment=bandit_experiment, participant_id="test_id", outcome=1.0
     )
 
-    # Refresh experiment; retrieve draws
-    await xngin_session.refresh(bandit_experiment)
-    draws = await updated_arm.awaitable_attrs.draws
-    draw = draws[0]
-
-    # Assert that the draw was updated correctly
+    # Read back from the database to verify that the updated parameters are persisted on both rows.
+    draws = (
+        await xngin_session.execute(
+            select(
+                tables.Draw.outcome,
+                tables.Draw.observed_at,
+                tables.Draw.current_alpha,
+                tables.Draw.current_beta,
+                tables.Draw.current_mu,
+                tables.Draw.current_covariance,
+                tables.Draw.context_vals,
+            ).where(tables.Draw.experiment_id == bandit_experiment.id)
+        )
+    ).all()
     assert len(draws) == 1
+    draw = draws[0]
     assert draw.outcome == 1.0
     assert draw.observed_at is not None
-    await bandit_experiment.awaitable_attrs.arms
-    await bandit_experiment.awaitable_attrs.contexts
-    bandit_arm_map = {arm.id: arm for arm in bandit_experiment.arms}
-    assert draw.current_mu == bandit_arm_map[updated_arm.id].mu
-    assert draw.current_covariance == bandit_arm_map[updated_arm.id].covariance
-    assert draw.current_alpha == bandit_arm_map[updated_arm.id].alpha
-    assert draw.current_beta == bandit_arm_map[updated_arm.id].beta
+
+    stored_arm = (
+        await xngin_session.execute(
+            select(tables.Arm.alpha, tables.Arm.beta, tables.Arm.mu, tables.Arm.covariance).where(
+                tables.Arm.id == updated_arm.id
+            )
+        )
+    ).one()
+    updated_parameters = (updated_arm.alpha, updated_arm.beta, updated_arm.mu, updated_arm.covariance)
+    assert stored_arm == updated_parameters
+    assert (draw.current_alpha, draw.current_beta, draw.current_mu, draw.current_covariance) == updated_parameters
 
     if experiment_type == ExperimentsType.CMAB_ONLINE:
         assert draw.context_vals == [1.0, 1.0]
@@ -2696,14 +2718,14 @@ async def test_update_bandit_arm_with_outcome(
             participant_id="some_other_id"
         ),
     ):
-        await update_bandit_arm_with_outcome_impl(xngin_session, bandit_experiment, "some_other_id", 1.0)
+        await update_bandit_with_outcome_impl(xngin_session, bandit_experiment, "some_other_id", 1.0)
 
     # Assert that we can't update the arm with an outcome for a participant that already has an outcome
     with pytest.raises(
         ExperimentsAssignmentError,
         match="Participant {participant_id} already has an outcome recorded.".format(participant_id="test_id"),
     ):
-        await update_bandit_arm_with_outcome_impl(xngin_session, bandit_experiment, "test_id", 1.0)
+        await update_bandit_with_outcome_impl(xngin_session, bandit_experiment, "test_id", 1.0)
 
 
 async def test_update_bandit_arm_with_outcome_mab_dwh_bool_target_rejects_non_binary(xngin_session, testing_datasource):
@@ -2719,16 +2741,188 @@ async def test_update_bandit_arm_with_outcome_mab_dwh_bool_target_rejects_non_bi
     await create_assignment_for_participant(xngin_session, bandit_experiment, "p1", None, random_state=66)
 
     with pytest.raises(LateValidationError, match="must be 0 or 1 for boolean targets"):
-        await update_bandit_arm_with_outcome_impl(
+        await update_bandit_with_outcome_impl(
             xngin_session=xngin_session, experiment=bandit_experiment, participant_id="p1", outcome=0.5
         )
 
     # A valid binary outcome is accepted.
-    updated_arm = await update_bandit_arm_with_outcome_impl(
+    await update_bandit_with_outcome_impl(
         xngin_session=xngin_session, experiment=bandit_experiment, participant_id="p1", outcome=1.0
     )
-    draws = await updated_arm.awaitable_attrs.draws
-    assert draws[0].outcome == 1.0
+    recorded = await xngin_session.scalar(
+        select(tables.Draw.outcome).where(
+            tables.Draw.experiment_id == bandit_experiment.id, tables.Draw.participant_id == "p1"
+        )
+    )
+    assert recorded == 1.0
+
+
+async def test_update_bandit_arm_concurrent_outcomes_do_not_lose_contributions(xngin_session, testing_datasource):
+    """Two outcomes landing on one arm concurrently must both move its posterior.
+
+    Each update derives the arm's new parameters from the ones it read, so if both writers read
+    before either writes, they derive from the same starting point and the later write drops the
+    earlier one's contribution. What prevents that is the lock the read takes on the arm, held
+    until the reader's transaction ends.
+
+    The second writer is held until the first has read, and the first then waits before writing, so
+    the second issues its read while the lock is held. Without the lock that read returns the stale
+    parameters immediately and the arm ends up one observation short.
+    """
+    experiment = await insert_experiment_and_arms(
+        xngin_session,
+        testing_datasource.ds,
+        experiment_type=ExperimentsType.MAB_ONLINE,
+        prior_type=PriorTypes.BETA,
+        reward_type=LikelihoodTypes.BERNOULLI,
+    )
+    await create_assignment_for_participant(xngin_session, experiment, "p1", None, random_state=66)
+    await create_assignment_for_participant(xngin_session, experiment, "p2", None, random_state=67)
+
+    # Assignment picks arms by Thompson sampling; the race is only observable when both outcomes
+    # derive parameters for the same arm, so put both draws on one arm explicitly.
+    contended_arm_id = experiment.arms[0].id
+    await xngin_session.execute(
+        update(tables.Draw).where(tables.Draw.experiment_id == experiment.id).values(arm_id=contended_arm_id)
+    )
+    await xngin_session.commit()
+    design_spec = await ExperimentStorageConverter(experiment).get_design_spec()
+    alpha_before = next(arm.alpha for arm in experiment.arms if arm.id == contended_arm_id)
+
+    first_has_read = asyncio.Event()
+
+    async def record(participant_id: str, *, wait_for_first_read: bool):
+        async with database.async_session() as session:
+            if wait_for_first_read:
+                await first_has_read.wait()
+            state = await experiments_common._read_arm_draw_state(session, experiment.id, participant_id)
+            if not wait_for_first_read:
+                first_has_read.set()
+                # Hold the lock long enough for the other writer to issue its read against it.
+                await asyncio.sleep(0.25)
+            state = experiments_common._validate_outcome_update(experiment, design_spec, state, participant_id, 1)
+            planned = experiments_common._compute_update(experiment, state, 1)
+            experiments_common._apply_update_plan(planned)
+            await session.commit()
+
+    await asyncio.gather(
+        record("p1", wait_for_first_read=False),
+        record("p2", wait_for_first_read=True),
+    )
+
+    alpha_after = await xngin_session.scalar(select(tables.Arm.alpha).where(tables.Arm.id == contended_arm_id))
+    assert alpha_after is not None and alpha_before is not None
+    assert alpha_after - alpha_before == 2.0
+
+
+async def test_read_arm_draw_state_returns_the_stored_parameters_not_the_session_copy(
+    xngin_session, testing_datasource
+):
+    """The read reports what the row holds, even when the session is already holding that row.
+
+    Callers usually have the arm loaded before the read -- the outcome endpoint's dependency loads
+    experiment.arms up front -- and a select returns instances the session already holds without
+    refreshing them by default. That would take the lock and hand back stale parameters, which is
+    the failure the lock exists to prevent.
+    """
+    experiment = await insert_experiment_and_arms(
+        xngin_session,
+        testing_datasource.ds,
+        experiment_type=ExperimentsType.MAB_ONLINE,
+        prior_type=PriorTypes.BETA,
+        reward_type=LikelihoodTypes.BERNOULLI,
+    )
+    await create_assignment_for_participant(xngin_session, experiment, "p1", None, random_state=66)
+    await xngin_session.commit()
+    arm_id = experiment.arms[0].id
+
+    async with database.async_session() as session:
+        # Load the arm into this session, as the endpoint's dependency does.
+        loaded = (
+            await session.execute(
+                select(tables.Experiment)
+                .where(tables.Experiment.id == experiment.id)
+                .options(selectinload(tables.Experiment.arms))
+            )
+        ).scalar_one()
+        stale = next(arm for arm in loaded.arms if arm.id == arm_id).alpha
+
+        # Another writer moves the arm on.
+        engine = sqlalchemy.create_engine(database.get_server_database_url().replace("+psycopg", ""))
+        try:
+            with engine.begin() as conn:
+                conn.execute(
+                    sqlalchemy.text("UPDATE arms SET alpha = :alpha WHERE id = :id"),
+                    {"alpha": 999.0, "id": arm_id},
+                )
+        finally:
+            engine.dispose()
+
+        state = await experiments_common._read_arm_draw_state(session, experiment.id, "p1")
+
+    assert stale != 999.0
+    assert state is not None
+    assert state.arm.alpha == 999.0
+
+
+async def test_update_bandit_arm_refuses_a_second_outcome_for_the_same_participant(xngin_session, testing_datasource):
+    """A second writer for one participant waits, then finds the outcome already recorded.
+
+    The read locks the draw, so what it reports cannot go stale underneath the plan: a writer that
+    arrives while another holds the lock blocks there, and when it proceeds it sees the outcome the
+    first one recorded rather than the absence it would have seen a moment earlier. That is what
+    makes recording an outcome twice impossible; nothing re-checks at write time.
+    """
+    experiment = await insert_experiment_and_arms(
+        xngin_session,
+        testing_datasource.ds,
+        experiment_type=ExperimentsType.MAB_ONLINE,
+        prior_type=PriorTypes.BETA,
+        reward_type=LikelihoodTypes.BERNOULLI,
+    )
+    await create_assignment_for_participant(xngin_session, experiment, "p1", None, random_state=66)
+    await xngin_session.commit()
+    design_spec = await ExperimentStorageConverter(experiment).get_design_spec()
+    gain_before = sum((arm.alpha or 0) - (arm.alpha_init or 0) for arm in experiment.arms)
+
+    first_has_read = asyncio.Event()
+    refusals: list[str] = []
+
+    async def record(*, wait_for_first_read: bool):
+        async with database.async_session() as session:
+            if wait_for_first_read:
+                await first_has_read.wait()
+            # The second writer blocks here until the first commits.
+            state = await experiments_common._read_arm_draw_state(session, experiment.id, "p1")
+            if not wait_for_first_read:
+                first_has_read.set()
+                # Hold the lock long enough for the other writer to reach its read.
+                await asyncio.sleep(0.25)
+            try:
+                state = experiments_common._validate_outcome_update(experiment, design_spec, state, "p1", 1)
+                planned = experiments_common._compute_update(experiment, state, 1)
+            except ExperimentsAssignmentError as exc:
+                refusals.append(str(exc))
+                return
+            experiments_common._apply_update_plan(planned)
+            await session.commit()
+
+    async with asyncio.timeout(30):
+        await asyncio.gather(
+            record(wait_for_first_read=False),
+            record(wait_for_first_read=True),
+        )
+
+    assert len(refusals) == 1
+    assert "already has an outcome recorded" in refusals[0]
+
+    # Exactly one observation landed on the arms.
+    gains = (
+        await xngin_session.execute(
+            select(tables.Arm.alpha, tables.Arm.alpha_init).where(tables.Arm.experiment_id == experiment.id)
+        )
+    ).all()
+    assert sum((alpha or 0) - (alpha_init or 0) for alpha, alpha_init in gains) - gain_before == 1.0
 
 
 async def test_update_bandit_arm_with_outcome_mab_dwh_numeric_target_accepts_any_float(
@@ -2745,11 +2939,15 @@ async def test_update_bandit_arm_with_outcome_mab_dwh_numeric_target_accepts_any
     )
     await create_assignment_for_participant(xngin_session, bandit_experiment, "p1", None, random_state=66)
 
-    updated_arm = await update_bandit_arm_with_outcome_impl(
+    await update_bandit_with_outcome_impl(
         xngin_session=xngin_session, experiment=bandit_experiment, participant_id="p1", outcome=42.7
     )
-    draws = await updated_arm.awaitable_attrs.draws
-    assert draws[0].outcome == 42.7
+    recorded = await xngin_session.scalar(
+        select(tables.Draw.outcome).where(
+            tables.Draw.experiment_id == bandit_experiment.id, tables.Draw.participant_id == "p1"
+        )
+    )
+    assert recorded == 42.7
 
 
 async def test_update_bandit_arm_with_freq_experiments_returns_422(xngin_session, testing_datasource):
@@ -2763,7 +2961,7 @@ async def test_update_bandit_arm_with_freq_experiments_returns_422(xngin_session
     await create_assignment_for_participant(xngin_session, online_freq_experiment, "p1", None, random_state=66)
 
     with pytest.raises(LateValidationError, match="Cannot dynamically update arms for frequentist experiments"):
-        await update_bandit_arm_with_outcome_impl(
+        await update_bandit_with_outcome_impl(
             xngin_session=xngin_session, experiment=online_freq_experiment, participant_id="p1", outcome=42.7
         )
 
@@ -2774,7 +2972,7 @@ async def test_update_bandit_arm_with_freq_experiments_returns_422(xngin_session
     await create_assignment_for_participant(xngin_session, pre_freq_experiment, "p1", None, random_state=66)
 
     with pytest.raises(LateValidationError, match="Cannot dynamically update arms for frequentist experiments"):
-        await update_bandit_arm_with_outcome_impl(
+        await update_bandit_with_outcome_impl(
             xngin_session=xngin_session, experiment=pre_freq_experiment, participant_id="p1", outcome=42.7
         )
 

--- a/src/xngin/apiserver/snapshots/autofail.py
+++ b/src/xngin/apiserver/snapshots/autofail.py
@@ -82,13 +82,12 @@ async def _make_one_autofail_update(
 
     try:
         async with asyncio.timeout(autofail_update_timeout):
-            await experiments_common.update_bandit_arm_with_outcome_impl(
+            await experiments_common.update_bandit_with_outcome_impl(
                 xngin_session=session,
                 experiment=draw.experiment,
                 participant_id=draw.participant_id,
                 outcome=draw.experiment.autofail_outcome_value,
                 autofailed_outcome=True,
-                commit_on_success=False,
             )
             update.status = "success"
             update.message = (

--- a/src/xngin/apiserver/snapshots/test_autofail.py
+++ b/src/xngin/apiserver/snapshots/test_autofail.py
@@ -33,7 +33,7 @@ from xngin.apiserver.testing.admin_api_client import AdminAPIClient
 from xngin.apiserver.testing.experiments_api_client import ExperimentsAPIClient
 from xngin.apiserver.testing.testing_dwh_def import TESTING_DWH_PARTICIPANT_DEF
 
-UPDATE_OUTCOME_IMPL = "xngin.apiserver.routers.experiments.experiments_common.update_bandit_arm_with_outcome_impl"
+UPDATE_OUTCOME_IMPL = "xngin.apiserver.routers.experiments.experiments_common.update_bandit_with_outcome_impl"
 
 
 async def create_autofail_experiment(
@@ -455,7 +455,7 @@ async def test_process_pending_autofail_updates_survives_a_failure(
     await age_draws(xngin_session, experiment_id, hours=2)
     await create_pending_autofail_updates()
 
-    original = experiments_common.update_bandit_arm_with_outcome_impl
+    original = experiments_common.update_bandit_with_outcome_impl
 
     async def fail_first_participant(*args, **kwargs):
         if kwargs["participant_id"] == "0":

--- a/src/xngin/stats/bandit_sampling.py
+++ b/src/xngin/stats/bandit_sampling.py
@@ -263,7 +263,7 @@ def update_arm(
     context: list[list[float]] | None = None,
 ) -> PriorUpdateType:
     """
-    Update the arm parameters based on the experiment type and reward.
+    Returns the updates to apply to arm_to_update based on the experiment and outcomes.
 
     Parameters
     ----------


### PR DESCRIPTION
## Ticket

EVE-170
EVE-171

## Description

* Moves responsibility for committing the database transaction to the handler method.
* Separates some concerns of the update_bandit_with_outcome_impl method into separate, testable methods.
* Uses Postgres row-level locking to serialize arm updates.
* Proposes a refinement on how normal/binary outcomes are computed: Instead of
  pulling the 100 most recent draws, relies on the persisted stats and updates
  it with a single outcome rather than re-processing all the outcomes.
* Migrates database-level tests to the API layer.
