### PR TITLE
Move responsibility for managing bandit update transaction to callers.

### DIFF
--- a/src/xngin/apiserver/routers/experiments/experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_api.py
@@ -20,7 +20,6 @@ from fastapi import (
 )
 from fastapi.responses import StreamingResponse
 from loguru import logger
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from xngin.apiserver import constants
@@ -51,7 +50,6 @@ from xngin.apiserver.routers.experiments.dependencies import (
     experiment_with_contexts_dependency,
 )
 from xngin.apiserver.routers.experiments.experiments_common import (
-    ExperimentsAssignmentError,
     create_assignment_for_participant,
     get_existing_assignment_for_participant,
     get_experiment_impl,
@@ -409,19 +407,13 @@ async def update_bandit_arm_with_participant_outcome(
     if experiment.experiment_type == ExperimentsType.CMAB_ONLINE.value:
         await experiment.awaitable_attrs.contexts
 
-    try:
-        updated_arm = await update_bandit_arm_with_outcome_impl(
-            xngin_session=session,
-            experiment=experiment,
-            participant_id=participant_id,
-            outcome=body.outcome,
-        )
-        await session.commit()
-    except IntegrityError as exc:
-        await session.rollback()
-        raise ExperimentsAssignmentError(
-            f"Failed to update assignment for participant '{participant_id}' with outcome {body.outcome}: {exc}"
-        ) from exc
+    updated_arm = await update_bandit_arm_with_outcome_impl(
+        xngin_session=session,
+        experiment=experiment,
+        participant_id=participant_id,
+        outcome=body.outcome,
+    )
+    await session.commit()
 
     return ArmBandit(
         arm_id=updated_arm.id,

--- a/src/xngin/apiserver/routers/experiments/experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_api.py
@@ -20,6 +20,7 @@ from fastapi import (
 )
 from fastapi.responses import StreamingResponse
 from loguru import logger
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from xngin.apiserver import constants
@@ -50,6 +51,7 @@ from xngin.apiserver.routers.experiments.dependencies import (
     experiment_with_contexts_dependency,
 )
 from xngin.apiserver.routers.experiments.experiments_common import (
+    ExperimentsAssignmentError,
     create_assignment_for_participant,
     get_existing_assignment_for_participant,
     get_experiment_impl,
@@ -407,12 +409,19 @@ async def update_bandit_arm_with_participant_outcome(
     if experiment.experiment_type == ExperimentsType.CMAB_ONLINE.value:
         await experiment.awaitable_attrs.contexts
 
-    updated_arm = await update_bandit_arm_with_outcome_impl(
-        xngin_session=session,
-        experiment=experiment,
-        participant_id=participant_id,
-        outcome=body.outcome,
-    )
+    try:
+        updated_arm = await update_bandit_arm_with_outcome_impl(
+            xngin_session=session,
+            experiment=experiment,
+            participant_id=participant_id,
+            outcome=body.outcome,
+        )
+        await session.commit()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise ExperimentsAssignmentError(
+            f"Failed to update assignment for participant '{participant_id}' with outcome {body.outcome}: {exc}"
+        ) from exc
 
     return ArmBandit(
         arm_id=updated_arm.id,

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -4,7 +4,7 @@ import io
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import assert_never
+from typing import TypedDict, assert_never
 
 import numpy as np
 import pandas as pd
@@ -1077,6 +1077,34 @@ async def _fetch_outcomes_and_context_for_arm(
     return outcomes, all_context_vals
 
 
+class PartialUpdateDrawBeta(TypedDict):
+    """Subset of fields on tables.Draw, used for type-safe partial updates."""
+
+    current_alpha: float | None
+    current_beta: float | None
+
+
+class PartialUpdateDrawNormal(TypedDict):
+    """Subset of fields on tables.Draw, used for type-safe partial updates."""
+
+    current_mu: list[float] | None
+    current_covariance: list[list[float]] | None
+
+
+class PartialUpdateArmBeta(TypedDict):
+    """Subset of fields on tables.Arm, used for type-safe partial updates."""
+
+    alpha: float | None
+    beta: float | None
+
+
+class PartialUpdateArmNormal(TypedDict):
+    """Subset of fields on tables.Arm, used for type-safe partial updates."""
+
+    mu: list[float] | None
+    covariance: list[list[float]] | None
+
+
 async def update_bandit_arm_with_outcome_impl(
     xngin_session: AsyncSession,
     experiment: tables.Experiment,
@@ -1154,30 +1182,20 @@ async def update_bandit_arm_with_outcome_impl(
     )
 
     # Update the draw record and arm with the new parameters
-    update_draw_params: dict[str, float | list[float] | list[list[float]]]
-    update_arm_params: dict[str, float | list[float] | list[list[float]]]
+    update_draw_params: PartialUpdateDrawBeta | PartialUpdateDrawNormal
+    update_arm_params: PartialUpdateArmBeta | PartialUpdateArmNormal
     match updated_parameters:
         case UpdateTypeBeta():
-            update_draw_params = {
-                "current_alpha": updated_parameters.alpha,
-                "current_beta": updated_parameters.beta,
-            }
-            update_arm_params = {
-                "alpha": updated_parameters.alpha,
-                "beta": updated_parameters.beta,
-            }
+            update_draw_params = PartialUpdateDrawBeta(
+                current_alpha=updated_parameters.alpha, current_beta=updated_parameters.beta
+            )
+            update_arm_params = PartialUpdateArmBeta(alpha=updated_parameters.alpha, beta=updated_parameters.beta)
         case UpdateTypeNormal():
-            update_draw_params = {
-                "current_mu": updated_parameters.mu,
-                "current_covariance": updated_parameters.covariance,
-            }
-            update_arm_params = {
-                "mu": updated_parameters.mu,
-                "covariance": updated_parameters.covariance,
-            }
-        case _:
-            raise ExperimentsAssignmentError(
-                f"Unsupported prior update type: {type(updated_parameters)} for prior type {experiment.prior_type}"
+            update_draw_params = PartialUpdateDrawNormal(
+                current_mu=updated_parameters.mu, current_covariance=updated_parameters.covariance
+            )
+            update_arm_params = PartialUpdateArmNormal(
+                mu=updated_parameters.mu, covariance=updated_parameters.covariance
             )
 
     await xngin_session.execute(

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -1083,9 +1083,8 @@ async def update_bandit_arm_with_outcome_impl(
     participant_id: str,
     outcome: float,
     autofailed_outcome: bool = False,
-    commit_on_success: bool = True,
 ) -> tables.Arm:
-    """Update the Draw table with the outcome for a bandit experiment."""
+    """Update a bandit draw and arm without completing the caller's transaction."""
     # Not supported for frequentist experiments
     design_spec = await ExperimentStorageConverter(experiment).get_design_spec()
 
@@ -1120,81 +1119,73 @@ async def update_bandit_arm_with_outcome_impl(
     if isinstance(design_spec, MABDwhExperimentSpec):
         _check_outcome_against_mab_dwh_target(experiment.experiment_fields, outcome)
 
-    try:
-        result = await xngin_session.execute(
-            update(tables.Draw)
-            .where(
-                tables.Draw.participant_id == participant_id,
-                tables.Draw.experiment_id == experiment.id,
-                tables.Draw.outcome.is_(None),  # guard against double-write at DB level
-            )
-            .values(observed_at=datetime.now(UTC), outcome=outcome, autofailed_outcome=autofailed_outcome)
-            .returning(tables.Draw.arm_id, tables.Draw.context_vals)
+    result = await xngin_session.execute(
+        update(tables.Draw)
+        .where(
+            tables.Draw.participant_id == participant_id,
+            tables.Draw.experiment_id == experiment.id,
+            tables.Draw.outcome.is_(None),  # guard against double-write at DB level
         )
-        draw_record = result.one_or_none()
-        if draw_record is None:
-            raise ExperimentsAssignmentError(
-                f"Participant '{participant_id}' already has a recorded outcome for this experiment.",
-            )
-
-        arm_to_update = next(arm for arm in experiment.arms if arm.id == draw_record.arm_id)
-
-        # Get all prior draws for this arm, sorted by creation date
-        outcomes, context_vals = await _fetch_outcomes_and_context_for_arm(
-            xngin_session,
-            experiment_id=experiment.id,
-            arm_id=draw_record.arm_id,
-            outcome=outcome,
-            context_vals=draw_record.context_vals,
-        )
-
-        updated_parameters = update_bandit_arm(
-            experiment=experiment,
-            arm_to_update=arm_to_update,
-            outcomes=outcomes,
-            context=context_vals,
-        )
-
-        # Update the draw record and arm with the new parameters
-        update_draw_params: dict[str, float | list[float] | list[list[float]]]
-        match updated_parameters:
-            case UpdateTypeBeta():
-                update_draw_params = {
-                    "current_alpha": updated_parameters.alpha,
-                    "current_beta": updated_parameters.beta,
-                }
-                arm_to_update.alpha = updated_parameters.alpha
-                arm_to_update.beta = updated_parameters.beta
-            case UpdateTypeNormal():
-                update_draw_params = {
-                    "current_mu": updated_parameters.mu,
-                    "current_covariance": updated_parameters.covariance,
-                }
-                arm_to_update.mu = updated_parameters.mu
-                arm_to_update.covariance = updated_parameters.covariance
-            case _:
-                raise ExperimentsAssignmentError(
-                    f"Unsupported prior update type: {type(updated_parameters)} for prior type {experiment.prior_type}"
-                )
-
-        await xngin_session.execute(
-            update(tables.Draw)
-            .where(
-                tables.Draw.participant_id == participant_id,
-                tables.Draw.experiment_id == experiment.id,
-                tables.Draw.arm_id == arm_to_update.id,
-            )
-            .values(**update_draw_params)
-        )
-        xngin_session.add(arm_to_update)
-        if commit_on_success:
-            await xngin_session.commit()
-
-    except IntegrityError as e:
-        await xngin_session.rollback()
+        .values(observed_at=datetime.now(UTC), outcome=outcome, autofailed_outcome=autofailed_outcome)
+        .returning(tables.Draw.arm_id, tables.Draw.context_vals)
+    )
+    draw_record = result.one_or_none()
+    if draw_record is None:
         raise ExperimentsAssignmentError(
-            f"Failed to update assignment for participant '{participant_id}' with outcome {outcome}: {e}"
-        ) from e
+            f"Participant '{participant_id}' already has a recorded outcome for this experiment.",
+        )
+
+    arm_to_update = next(arm for arm in experiment.arms if arm.id == draw_record.arm_id)
+
+    # Get all prior draws for this arm, sorted by creation date
+    outcomes, context_vals = await _fetch_outcomes_and_context_for_arm(
+        xngin_session,
+        experiment_id=experiment.id,
+        arm_id=draw_record.arm_id,
+        outcome=outcome,
+        context_vals=draw_record.context_vals,
+    )
+
+    updated_parameters = update_bandit_arm(
+        experiment=experiment,
+        arm_to_update=arm_to_update,
+        outcomes=outcomes,
+        context=context_vals,
+    )
+
+    # Update the draw record and arm with the new parameters
+    update_draw_params: dict[str, float | list[float] | list[list[float]]]
+    match updated_parameters:
+        case UpdateTypeBeta():
+            update_draw_params = {
+                "current_alpha": updated_parameters.alpha,
+                "current_beta": updated_parameters.beta,
+            }
+            arm_to_update.alpha = updated_parameters.alpha
+            arm_to_update.beta = updated_parameters.beta
+        case UpdateTypeNormal():
+            update_draw_params = {
+                "current_mu": updated_parameters.mu,
+                "current_covariance": updated_parameters.covariance,
+            }
+            arm_to_update.mu = updated_parameters.mu
+            arm_to_update.covariance = updated_parameters.covariance
+        case _:
+            raise ExperimentsAssignmentError(
+                f"Unsupported prior update type: {type(updated_parameters)} for prior type {experiment.prior_type}"
+            )
+
+    await xngin_session.execute(
+        update(tables.Draw)
+        .where(
+            tables.Draw.participant_id == participant_id,
+            tables.Draw.experiment_id == experiment.id,
+            tables.Draw.arm_id == arm_to_update.id,
+        )
+        .values(**update_draw_params)
+    )
+    xngin_session.add(arm_to_update)
+    await xngin_session.flush()
 
     return arm_to_update
 

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -1155,21 +1155,26 @@ async def update_bandit_arm_with_outcome_impl(
 
     # Update the draw record and arm with the new parameters
     update_draw_params: dict[str, float | list[float] | list[list[float]]]
+    update_arm_params: dict[str, float | list[float] | list[list[float]]]
     match updated_parameters:
         case UpdateTypeBeta():
             update_draw_params = {
                 "current_alpha": updated_parameters.alpha,
                 "current_beta": updated_parameters.beta,
             }
-            arm_to_update.alpha = updated_parameters.alpha
-            arm_to_update.beta = updated_parameters.beta
+            update_arm_params = {
+                "alpha": updated_parameters.alpha,
+                "beta": updated_parameters.beta,
+            }
         case UpdateTypeNormal():
             update_draw_params = {
                 "current_mu": updated_parameters.mu,
                 "current_covariance": updated_parameters.covariance,
             }
-            arm_to_update.mu = updated_parameters.mu
-            arm_to_update.covariance = updated_parameters.covariance
+            update_arm_params = {
+                "mu": updated_parameters.mu,
+                "covariance": updated_parameters.covariance,
+            }
         case _:
             raise ExperimentsAssignmentError(
                 f"Unsupported prior update type: {type(updated_parameters)} for prior type {experiment.prior_type}"
@@ -1184,8 +1189,14 @@ async def update_bandit_arm_with_outcome_impl(
         )
         .values(**update_draw_params)
     )
-    xngin_session.add(arm_to_update)
-    await xngin_session.flush()
+    await xngin_session.execute(
+        update(tables.Arm)
+        .where(
+            tables.Arm.id == arm_to_update.id,
+            tables.Arm.experiment_id == experiment.id,
+        )
+        .values(**update_arm_params)
+    )
 
     return arm_to_update
 

--- a/src/xngin/apiserver/routers/experiments/test_experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_api.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from pydantic import TypeAdapter
+from sqlalchemy.exc import IntegrityError
 
 from xngin.apiserver.conftest import DatasourceMetadata
 from xngin.apiserver.routers.common_api_types import (
@@ -49,6 +50,9 @@ from xngin.stats.bandit_sampling import update_arm
 if TYPE_CHECKING:
     from xngin.apiserver.testing.admin_api_client import AdminAPIClient
     from xngin.apiserver.testing.experiments_api_client import ExperimentsAPIClient
+
+
+UPDATE_OUTCOME_IMPL = "xngin.apiserver.routers.experiments.experiments_api.update_bandit_arm_with_outcome_impl"
 
 
 async def create_experiment(
@@ -1608,3 +1612,36 @@ async def test_update_bandit_arm_with_outcome_rejects_non_numeric_outcome(
         json={"outcome": "not-a-float"},
     )
     assert response.status_code == HTTPStatus.UNPROCESSABLE_CONTENT, response.content
+
+
+async def test_update_bandit_arm_with_outcome_handles_integrity_error(
+    testing_datasource,
+    aclient: AdminAPIClient,
+    eclient: ExperimentsAPIClient,
+    mocker,
+):
+    mab_experiment = await create_experiment(testing_datasource, aclient, experiment_type=ExperimentsType.MAB_ONLINE)
+    eclient.get_assignment(
+        api_key=testing_datasource.key,
+        experiment_id=mab_experiment.experiment_id,
+        participant_id="1",
+    )
+    update_mock = mocker.patch(
+        UPDATE_OUTCOME_IMPL,
+        side_effect=IntegrityError("UPDATE draws", {}, RuntimeError("constraint violation")),
+    )
+
+    response = eclient.client.post(
+        f"/v1/experiments/{mab_experiment.experiment_id}/assignments/1/outcome",
+        headers={"X-API-Key": testing_datasource.key},
+        json={"outcome": 1.0},
+    )
+
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_CONTENT, response.content
+    mocker.stop(update_mock)
+    eclient.update_bandit_arm_with_participant_outcome(
+        api_key=testing_datasource.key,
+        body=UpdateBanditArmOutcomeRequest(outcome=1.0),
+        experiment_id=mab_experiment.experiment_id,
+        participant_id="1",
+    )

--- a/src/xngin/apiserver/routers/experiments/test_experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_api.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 from pydantic import TypeAdapter
-from sqlalchemy.exc import IntegrityError
 
 from xngin.apiserver.conftest import DatasourceMetadata
 from xngin.apiserver.routers.common_api_types import (
@@ -50,9 +49,6 @@ from xngin.stats.bandit_sampling import update_arm
 if TYPE_CHECKING:
     from xngin.apiserver.testing.admin_api_client import AdminAPIClient
     from xngin.apiserver.testing.experiments_api_client import ExperimentsAPIClient
-
-
-UPDATE_OUTCOME_IMPL = "xngin.apiserver.routers.experiments.experiments_api.update_bandit_arm_with_outcome_impl"
 
 
 async def create_experiment(
@@ -1612,36 +1608,3 @@ async def test_update_bandit_arm_with_outcome_rejects_non_numeric_outcome(
         json={"outcome": "not-a-float"},
     )
     assert response.status_code == HTTPStatus.UNPROCESSABLE_CONTENT, response.content
-
-
-async def test_update_bandit_arm_with_outcome_handles_integrity_error(
-    testing_datasource,
-    aclient: AdminAPIClient,
-    eclient: ExperimentsAPIClient,
-    mocker,
-):
-    mab_experiment = await create_experiment(testing_datasource, aclient, experiment_type=ExperimentsType.MAB_ONLINE)
-    eclient.get_assignment(
-        api_key=testing_datasource.key,
-        experiment_id=mab_experiment.experiment_id,
-        participant_id="1",
-    )
-    update_mock = mocker.patch(
-        UPDATE_OUTCOME_IMPL,
-        side_effect=IntegrityError("UPDATE draws", {}, RuntimeError("constraint violation")),
-    )
-
-    response = eclient.client.post(
-        f"/v1/experiments/{mab_experiment.experiment_id}/assignments/1/outcome",
-        headers={"X-API-Key": testing_datasource.key},
-        json={"outcome": 1.0},
-    )
-
-    assert response.status_code == HTTPStatus.UNPROCESSABLE_CONTENT, response.content
-    mocker.stop(update_mock)
-    eclient.update_bandit_arm_with_participant_outcome(
-        api_key=testing_datasource.key,
-        body=UpdateBanditArmOutcomeRequest(outcome=1.0),
-        experiment_id=mab_experiment.experiment_id,
-        participant_id="1",
-    )

--- a/src/xngin/apiserver/routers/experiments/test_experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_api.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, TypeIs
 
 import pytest
 from pydantic import TypeAdapter
-from sqlalchemy.exc import IntegrityError
 
 from xngin.apiserver.conftest import DatasourceMetadata
 from xngin.apiserver.routers.common_api_types import (
@@ -54,9 +53,6 @@ from xngin.stats.bandit_sampling import update_arm
 if TYPE_CHECKING:
     from xngin.apiserver.testing.admin_api_client import AdminAPIClient
     from xngin.apiserver.testing.experiments_api_client import ExperimentsAPIClient
-
-
-UPDATE_OUTCOME_IMPL = "xngin.apiserver.routers.experiments.experiments_api.update_bandit_arm_with_outcome_impl"
 
 
 async def create_experiment(
@@ -1625,36 +1621,3 @@ async def test_update_bandit_arm_with_outcome_rejects_non_numeric_outcome(
         json={"outcome": "not-a-float"},
     )
     assert response.status_code == HTTPStatus.UNPROCESSABLE_CONTENT, response.content
-
-
-async def test_update_bandit_arm_with_outcome_handles_integrity_error(
-    testing_datasource,
-    aclient: AdminAPIClient,
-    eclient: ExperimentsAPIClient,
-    mocker,
-):
-    mab_experiment = await create_experiment(testing_datasource, aclient, experiment_type=ExperimentsType.MAB_ONLINE)
-    eclient.get_assignment(
-        api_key=testing_datasource.key,
-        experiment_id=mab_experiment.experiment_id,
-        participant_id="1",
-    )
-    update_mock = mocker.patch(
-        UPDATE_OUTCOME_IMPL,
-        side_effect=IntegrityError("UPDATE draws", {}, RuntimeError("constraint violation")),
-    )
-
-    response = eclient.client.post(
-        f"/v1/experiments/{mab_experiment.experiment_id}/assignments/1/outcome",
-        headers={"X-API-Key": testing_datasource.key},
-        json={"outcome": 1.0},
-    )
-
-    assert response.status_code == HTTPStatus.UNPROCESSABLE_CONTENT, response.content
-    mocker.stop(update_mock)
-    eclient.update_bandit_arm_with_participant_outcome(
-        api_key=testing_datasource.key,
-        body=UpdateBanditArmOutcomeRequest(outcome=1.0),
-        experiment_id=mab_experiment.experiment_id,
-        participant_id="1",
-    )

--- a/src/xngin/apiserver/routers/experiments/test_experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_api.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, TypeIs
 
 import pytest
 from pydantic import TypeAdapter
+from sqlalchemy.exc import IntegrityError
 
 from xngin.apiserver.conftest import DatasourceMetadata
 from xngin.apiserver.routers.common_api_types import (
@@ -53,6 +54,9 @@ from xngin.stats.bandit_sampling import update_arm
 if TYPE_CHECKING:
     from xngin.apiserver.testing.admin_api_client import AdminAPIClient
     from xngin.apiserver.testing.experiments_api_client import ExperimentsAPIClient
+
+
+UPDATE_OUTCOME_IMPL = "xngin.apiserver.routers.experiments.experiments_api.update_bandit_arm_with_outcome_impl"
 
 
 async def create_experiment(
@@ -1621,3 +1625,36 @@ async def test_update_bandit_arm_with_outcome_rejects_non_numeric_outcome(
         json={"outcome": "not-a-float"},
     )
     assert response.status_code == HTTPStatus.UNPROCESSABLE_CONTENT, response.content
+
+
+async def test_update_bandit_arm_with_outcome_handles_integrity_error(
+    testing_datasource,
+    aclient: AdminAPIClient,
+    eclient: ExperimentsAPIClient,
+    mocker,
+):
+    mab_experiment = await create_experiment(testing_datasource, aclient, experiment_type=ExperimentsType.MAB_ONLINE)
+    eclient.get_assignment(
+        api_key=testing_datasource.key,
+        experiment_id=mab_experiment.experiment_id,
+        participant_id="1",
+    )
+    update_mock = mocker.patch(
+        UPDATE_OUTCOME_IMPL,
+        side_effect=IntegrityError("UPDATE draws", {}, RuntimeError("constraint violation")),
+    )
+
+    response = eclient.client.post(
+        f"/v1/experiments/{mab_experiment.experiment_id}/assignments/1/outcome",
+        headers={"X-API-Key": testing_datasource.key},
+        json={"outcome": 1.0},
+    )
+
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_CONTENT, response.content
+    mocker.stop(update_mock)
+    eclient.update_bandit_arm_with_participant_outcome(
+        api_key=testing_datasource.key,
+        body=UpdateBanditArmOutcomeRequest(outcome=1.0),
+        experiment_id=mab_experiment.experiment_id,
+        participant_id="1",
+    )

--- a/src/xngin/apiserver/routers/experiments/test_experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_common.py
@@ -60,6 +60,7 @@ from xngin.apiserver.routers.experiments.experiments_common import (
     get_or_create_assignment_for_participant,
     make_sample_calls,
     make_schema_from_experiment,
+    update_bandit_arm_with_outcome_impl,
 )
 from xngin.apiserver.routers.experiments.experiments_common_csv import get_experiment_assignments_as_csv_impl
 from xngin.apiserver.sqla import tables
@@ -2634,6 +2635,44 @@ async def test_get_or_create_assignment_for_participant_without_filters(
         assert response.experiment_id == experiment.id
         assert response.participant_id == "user_id"
         assert (response.assignment is not None) == has_assignment
+
+
+async def test_update_bandit_arm_with_outcome_multiple_times_in_one_transaction(xngin_session, testing_datasource):
+    bandit_experiment = await insert_experiment_and_arms(
+        xngin_session,
+        testing_datasource.ds,
+        experiment_type=ExperimentsType.MAB_ONLINE,
+        prior_type=PriorTypes.BETA,
+        reward_type=LikelihoodTypes.BERNOULLI,
+    )
+    for participant_id in ("participant-1", "participant-2"):
+        await create_assignment_for_participant(
+            xngin_session,
+            bandit_experiment,
+            participant_id,
+            random_state=66,
+        )
+
+    for participant_id, outcome in (("participant-1", 1.0), ("participant-2", 0.0)):
+        await update_bandit_arm_with_outcome_impl(
+            xngin_session=xngin_session,
+            experiment=bandit_experiment,
+            participant_id=participant_id,
+            outcome=outcome,
+        )
+
+    assert xngin_session.in_transaction()
+    await xngin_session.commit()
+    recorded_outcomes = dict(
+        (
+            await xngin_session.execute(
+                select(tables.Draw.participant_id, tables.Draw.outcome).where(
+                    tables.Draw.experiment_id == bandit_experiment.id
+                )
+            )
+        ).all()
+    )
+    assert recorded_outcomes == {"participant-1": 1.0, "participant-2": 0.0}
 
 
 async def test_analyze_experiment_freq_impl_with_no_outcomes_for_any_arms(xngin_session, testing_datasource):

--- a/src/xngin/apiserver/routers/experiments/test_experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_common.py
@@ -2645,13 +2645,24 @@ async def test_update_bandit_arm_with_outcome_multiple_times_in_one_transaction(
         prior_type=PriorTypes.BETA,
         reward_type=LikelihoodTypes.BERNOULLI,
     )
+    assignments = []
     for participant_id in ("participant-1", "participant-2"):
-        await create_assignment_for_participant(
+        assignment = await create_assignment_for_participant(
             xngin_session,
             bandit_experiment,
             participant_id,
             random_state=66,
         )
+        assert assignment is not None
+        assignments.append(assignment)
+
+    assigned_arm_ids = {assignment.arm_id for assignment in assignments}
+    assert len(assigned_arm_ids) == 1
+    assigned_arm = next(arm for arm in bandit_experiment.arms if arm.id in assigned_arm_ids)
+    assert assigned_arm.alpha is not None
+    assert assigned_arm.beta is not None
+    initial_alpha = assigned_arm.alpha
+    initial_beta = assigned_arm.beta
 
     for participant_id, outcome in (("participant-1", 1.0), ("participant-2", 0.0)):
         await update_bandit_arm_with_outcome_impl(
@@ -2662,6 +2673,8 @@ async def test_update_bandit_arm_with_outcome_multiple_times_in_one_transaction(
         )
 
     assert xngin_session.in_transaction()
+    assert assigned_arm.alpha == initial_alpha + 1
+    assert assigned_arm.beta == initial_beta + 1
     await xngin_session.commit()
     recorded_outcomes = dict(
         (
@@ -2673,6 +2686,11 @@ async def test_update_bandit_arm_with_outcome_multiple_times_in_one_transaction(
         ).all()
     )
     assert recorded_outcomes == {"participant-1": 1.0, "participant-2": 0.0}
+    persisted_alpha, persisted_beta = (
+        await xngin_session.execute(select(tables.Arm.alpha, tables.Arm.beta).where(tables.Arm.id == assigned_arm.id))
+    ).one()
+    assert persisted_alpha == initial_alpha + 1
+    assert persisted_beta == initial_beta + 1
 
 
 async def test_analyze_experiment_freq_impl_with_no_outcomes_for_any_arms(xngin_session, testing_datasource):

--- a/src/xngin/apiserver/snapshots/autofail.py
+++ b/src/xngin/apiserver/snapshots/autofail.py
@@ -79,33 +79,36 @@ async def _make_one_autofail_update(
     e.g., in a loop or by a scheduler. It checks for any pending autofail updates and processes
     one of them by updating the corresponding draw's outcome to "autofailed".
     """
+    experiment = draw.experiment
+    experiment_id = draw.experiment_id
+    participant_id = draw.participant_id
+    outcome = experiment.autofail_outcome_value
 
     try:
         async with asyncio.timeout(autofail_update_timeout):
-            await experiments_common.update_bandit_arm_with_outcome_impl(
-                xngin_session=session,
-                experiment=draw.experiment,
-                participant_id=draw.participant_id,
-                outcome=draw.experiment.autofail_outcome_value,
-                autofailed_outcome=True,
-                commit_on_success=False,
-            )
+            async with session.begin_nested():
+                await experiments_common.update_bandit_arm_with_outcome_impl(
+                    xngin_session=session,
+                    experiment=experiment,
+                    participant_id=participant_id,
+                    outcome=outcome,
+                    autofailed_outcome=True,
+                )
             update.status = "success"
             update.message = (
-                f"Autofail processed successfully. Participant {draw.participant_id} "
-                f"recorded outcome {draw.experiment.autofail_outcome_value}."
+                f"Autofail processed successfully. Participant {participant_id} recorded outcome {outcome}."
             )
 
     except Exception as exc:
         logger.opt(exception=exc).error(
-            f"Failed to process autofail update for experiment {draw.experiment_id} and "
-            f"participant {draw.participant_id}: {exc!s}"
+            f"Failed to process autofail update for experiment {experiment_id} and participant {participant_id}: "
+            f"{exc!s}"
         )
         sentry_sdk.capture_exception(exc)
         sentry_sdk.metrics.count(
             "autofail_update.failed",
             1,
-            attributes={"experiment_id": draw.experiment_id, "participant_id": draw.participant_id},
+            attributes={"experiment_id": experiment_id, "participant_id": participant_id},
         )
         update.status = "failed"
         update.message = f"{type(exc).__name__}: {exc}"
@@ -113,9 +116,9 @@ async def _make_one_autofail_update(
     sentry_sdk.metrics.count(
         "autofail_update.finished",
         1,
-        attributes={"experiment_id": draw.experiment_id, "participant_id": draw.participant_id},
+        attributes={"experiment_id": experiment_id, "participant_id": participant_id},
     )
-    logger.info(f"Autofail update for experiment {draw.experiment_id} and participant {draw.participant_id}: done")
+    logger.info(f"Autofail update for experiment {experiment_id} and participant {participant_id}: done")
 
 
 async def process_pending_autofail_updates(autofail_update_timeout: int, *, max_jitter_secs: float = 2):

--- a/src/xngin/apiserver/snapshots/test_autofail.py
+++ b/src/xngin/apiserver/snapshots/test_autofail.py
@@ -459,6 +459,7 @@ async def test_process_pending_autofail_updates_survives_a_failure(
 
     async def fail_first_participant(*args, **kwargs):
         if kwargs["participant_id"] == "0":
+            await original(*args, **kwargs)
             raise RuntimeError("boom")
         return await original(*args, **kwargs)
 
@@ -468,6 +469,12 @@ async def test_process_pending_autofail_updates_survives_a_failure(
 
     updates = await get_autofail_updates(xngin_session)
     assert [(u.participant_id, u.status) for u in updates] == [("0", "failed"), ("1", "success")]
+    draws = (
+        await xngin_session.execute(
+            select(tables.Draw).where(tables.Draw.experiment_id == experiment_id).order_by(tables.Draw.participant_id)
+        )
+    ).scalars()
+    assert [(draw.participant_id, draw.outcome) for draw in draws] == [("0", None), ("1", 0.0)]
 
 
 async def test_autofail_acollect_creates_then_processes(mocker):


### PR DESCRIPTION
## Ticket

EVE-180

## Description

Instead of having transactions committed or operations flushed per-bandit
update, we moves responsibility for calling .commit()/.flush() to the API
endpoint and autofailer.

This paves the way to refactor the bandit updater to be invoked multiple times
in a single database transaction. Also, it is generally helpful to couple the
API implementation to the transaction lifecycle, moreso than it is to have deep
methods run .commit(), because the latter increases the chance that we might
experience an error between the .commit() and when we compose the API response,
leading to misleading representation of our state.

We also replace some ORM mutations with a direct update() call. This is
equivalent behavior today, but later we can defer the arm updates to minimize
contention. 
