### PR TITLE
Reuse client-provided metric baseline stats in power checks, skipping the dwh when possible

### DIFF
--- a/src/xngin/apiserver/routers/admin/admin_api.py
+++ b/src/xngin/apiserver/routers/admin/admin_api.py
@@ -2248,7 +2248,13 @@ async def power_check(
     user: Annotated[tables.User, Depends(require_user_from_token)],
     body: PowerRequest,
 ) -> PowerResponse:
-    """Performs a power check for the specified datasource."""
+    """Performs a power check for the specified datasource.
+
+    Metrics carrying baseline stats (e.g. echoed back from a prior power check response) are used
+    as-is rather than re-queried from the data warehouse. When no metric needs the warehouse — every
+    metric has baseline stats, and cluster stats for cluster-randomized designs — the warehouse is
+    not contacted at all, so the design spec is not validated against the participants table.
+    """
     design_spec = body.design_spec
     ds = await get_datasource_or_raise(session, user, datasource_id)
     if isinstance(ds.config, NoDwh):
@@ -2258,62 +2264,77 @@ async def power_check(
         )
     dsconfig = ds.get_config()
 
-    async with DwhSession(dsconfig.dwh) as dwh:
-        sa_table = await dwh.inspect_table(design_spec.table_name)
-        # Validate the fields used in the design spec are present in the table and that filter values are valid.
-        _ = convert_table_to_fields_or_raise(sa_table, design_spec)
+    filters = design_spec.filters
+    cluster_key = None
+    desired_n_clusters = None
+    if isinstance(design_spec, PreassignedFrequentistExperimentSpec):
+        cluster_key = design_spec.cluster_key
+        desired_n_clusters = design_spec.desired_n_clusters
+    # Exclude rows without a valid cluster key.
+    if cluster_key is not None:
+        filters = [*filters, Filter(field_name=cluster_key, relation=Relation.EXCLUDES, value=[None])]
 
-        filters = design_spec.filters
-        cluster_key = None
-        desired_n_clusters = None
-        if isinstance(design_spec, PreassignedFrequentistExperimentSpec):
-            cluster_key = design_spec.cluster_key
-            desired_n_clusters = design_spec.desired_n_clusters
-        # Exclude rows without a valid cluster key.
-        if cluster_key is not None:
-            filters = [*filters, Filter(field_name=cluster_key, relation=Relation.EXCLUDES, value=[None])]
+    metrics_missing_stats = [m for m in design_spec.metrics if not m.has_baseline_stats]
+    needs_cluster_stats = cluster_key is not None and any(m.icc is None for m in design_spec.metrics)
 
-        metric_stats = await asyncio.to_thread(
-            get_stats_on_metrics,
-            dwh.session,
-            sa_table,
-            design_spec.metrics,
-            filters,
-        )
+    if not metrics_missing_stats and not needs_cluster_stats:
+        metric_stats = [m.to_design_spec_metric() for m in design_spec.metrics]
+    else:
+        async with DwhSession(dsconfig.dwh) as dwh:
+            sa_table = await dwh.inspect_table(design_spec.table_name)
+            # Validate the fields used in the design spec are present in the table and that filter values are valid.
+            _ = convert_table_to_fields_or_raise(sa_table, design_spec)
 
-        # Augment with cluster-level stats if this is a cluster-randomized design.
-        if cluster_key is not None:
-            request_metrics_by_name = {m.field_name: m for m in design_spec.metrics}
-            # Derive stats from the dwh only for metrics without user-provided ICC, in one query.
-            db_derived_metrics = [
-                metric_stat.field_name
-                for metric_stat in metric_stats
-                if request_metrics_by_name[metric_stat.field_name].icc is None
-            ]
-            db_cluster_stats = (
+            queried_stats = (
                 await asyncio.to_thread(
-                    calculate_cluster_stats_from_database,
+                    get_stats_on_metrics,
                     dwh.session,
                     sa_table,
-                    cluster_key,
-                    db_derived_metrics,
+                    metrics_missing_stats,
                     filters,
                 )
-                if db_derived_metrics
-                else {}
+                if metrics_missing_stats
+                else []
             )
-            for metric_stat in metric_stats:
-                req_metric = request_metrics_by_name[metric_stat.field_name]
-                # If the user provided ICC, avg_cluster_size, and cv, use them instead of deriving from the dwh.
-                if req_metric.icc is not None:
-                    metric_stat.icc = req_metric.icc
-                    metric_stat.avg_cluster_size = req_metric.avg_cluster_size
-                    metric_stat.cv = req_metric.cv
-                else:
-                    cluster_stats = db_cluster_stats[metric_stat.field_name]
-                    metric_stat.icc = cluster_stats["icc"]
-                    metric_stat.avg_cluster_size = cluster_stats["avg_cluster_size"]
-                    metric_stat.cv = cluster_stats["cv"]
+            queried_stats_by_name = {m.field_name: m for m in queried_stats}
+            metric_stats = [
+                m.to_design_spec_metric() if m.has_baseline_stats else queried_stats_by_name[m.field_name]
+                for m in design_spec.metrics
+            ]
+
+            # Augment with cluster-level stats if this is a cluster-randomized design.
+            if cluster_key is not None:
+                request_metrics_by_name = {m.field_name: m for m in design_spec.metrics}
+                # Derive stats from the dwh only for metrics without user-provided ICC, in one query.
+                db_derived_metrics = [
+                    metric_stat.field_name
+                    for metric_stat in metric_stats
+                    if request_metrics_by_name[metric_stat.field_name].icc is None
+                ]
+                db_cluster_stats = (
+                    await asyncio.to_thread(
+                        calculate_cluster_stats_from_database,
+                        dwh.session,
+                        sa_table,
+                        cluster_key,
+                        db_derived_metrics,
+                        filters,
+                    )
+                    if db_derived_metrics
+                    else {}
+                )
+                for metric_stat in metric_stats:
+                    req_metric = request_metrics_by_name[metric_stat.field_name]
+                    # If the user provided ICC, avg_cluster_size, and cv, use them instead of deriving from the dwh.
+                    if req_metric.icc is not None:
+                        metric_stat.icc = req_metric.icc
+                        metric_stat.avg_cluster_size = req_metric.avg_cluster_size
+                        metric_stat.cv = req_metric.cv
+                    else:
+                        cluster_stats = db_cluster_stats[metric_stat.field_name]
+                        metric_stat.icc = cluster_stats["icc"]
+                        metric_stat.avg_cluster_size = cluster_stats["avg_cluster_size"]
+                        metric_stat.cv = cluster_stats["cv"]
 
     arm_weights = design_spec.get_validated_arm_weights()
 

--- a/src/xngin/apiserver/routers/admin/test_admin_api.py
+++ b/src/xngin/apiserver/routers/admin/test_admin_api.py
@@ -62,6 +62,7 @@ from xngin.apiserver.routers.common_api_types import (
     CreateExperimentRequest,
     CreateExperimentResponse,
     DataType,
+    DesignSpecMetric,
     DesignSpecMetricRequest,
     ExperimentConfig,
     ExperimentsType,
@@ -4191,6 +4192,150 @@ async def test_power_check_with_desired_n_clusters(testing_datasource, aclient: 
     )
     both_analysis = both_result.data.analyses[0]
     assert both_analysis.pct_change_with_desired_n == clusters_analysis.pct_change_with_desired_n
+
+
+def echo_metric_request(spec: DesignSpecMetric) -> DesignSpecMetricRequest:
+    """Builds a follow-up power check metric from a prior response's metric_spec, as the frontend would."""
+    return DesignSpecMetricRequest(
+        field_name=spec.field_name,
+        metric_pct_change=spec.metric_pct_change,
+        icc=spec.icc,
+        avg_cluster_size=spec.avg_cluster_size,
+        cv=spec.cv,
+        metric_type=spec.metric_type,
+        metric_baseline=spec.metric_baseline,
+        metric_stddev=spec.metric_stddev,
+        available_nonnull_n=spec.available_nonnull_n,
+        available_n=spec.available_n,
+    )
+
+
+async def test_power_check_reuses_provided_baseline_stats_without_dwh(testing_datasource, aclient: AdminAPIClient):
+    """Metrics carrying baseline stats are analyzed without querying the dwh at all."""
+    design_spec = PreassignedFrequentistExperimentSpec(
+        experiment_type=ExperimentsType.FREQ_PREASSIGNED,
+        experiment_name="test power check stats reuse",
+        description="Baseline stats from a prior response are reused instead of re-queried.",
+        table_name="dwh",
+        primary_key="id",
+        start_date=datetime(2024, 1, 1, tzinfo=UTC),
+        end_date=datetime.now(UTC) + timedelta(days=1),
+        arms=[
+            Arm(arm_name="control", arm_description="Control group"),
+            Arm(arm_name="treatment", arm_description="Treatment group"),
+        ],
+        metrics=[DesignSpecMetricRequest(field_name="current_income", metric_pct_change=0.1)],
+        strata=[],
+        filters=[],
+        desired_n=500,
+    )
+    first_analysis = aclient.power_check(
+        datasource_id=testing_datasource.datasource_id,
+        body=PowerRequest(design_spec=design_spec),
+    ).data.analyses[0]
+    assert first_analysis.metric_spec.metric_baseline is not None
+
+    # Echo the returned stats back. The bogus table name proves the dwh is not contacted:
+    # inspecting it would fail.
+    reuse_spec = design_spec.model_copy(
+        update={
+            "table_name": "no_such_table",
+            "metrics": [echo_metric_request(first_analysis.metric_spec)],
+        }
+    )
+    reuse_analysis = aclient.power_check(
+        datasource_id=testing_datasource.datasource_id,
+        body=PowerRequest(design_spec=reuse_spec),
+    ).data.analyses[0]
+    assert reuse_analysis == first_analysis
+
+
+async def test_power_check_queries_only_metrics_missing_baseline_stats(testing_datasource, aclient: AdminAPIClient):
+    """Metrics with and without provided baseline stats can be mixed in one power check."""
+
+    def make_design_spec(metrics: list[DesignSpecMetricRequest]) -> PreassignedFrequentistExperimentSpec:
+        return PreassignedFrequentistExperimentSpec(
+            experiment_type=ExperimentsType.FREQ_PREASSIGNED,
+            experiment_name="test power check partial stats reuse",
+            description="Only metrics without provided baseline stats are queried from the dwh.",
+            table_name="dwh",
+            primary_key="id",
+            start_date=datetime(2024, 1, 1, tzinfo=UTC),
+            end_date=datetime.now(UTC) + timedelta(days=1),
+            arms=[
+                Arm(arm_name="control", arm_description="Control group"),
+                Arm(arm_name="treatment", arm_description="Treatment group"),
+            ],
+            metrics=metrics,
+            strata=[],
+            filters=[],
+        )
+
+    both_queried = aclient.power_check(
+        datasource_id=testing_datasource.datasource_id,
+        body=PowerRequest(
+            design_spec=make_design_spec([
+                DesignSpecMetricRequest(field_name="current_income", metric_pct_change=0.1),
+                DesignSpecMetricRequest(field_name="is_engaged", metric_pct_change=0.1),
+            ])
+        ),
+    ).data.analyses
+
+    # Re-issue with stats provided for one metric only; results must match the fully queried run.
+    mixed = aclient.power_check(
+        datasource_id=testing_datasource.datasource_id,
+        body=PowerRequest(
+            design_spec=make_design_spec([
+                echo_metric_request(both_queried[0].metric_spec),
+                DesignSpecMetricRequest(field_name="is_engaged", metric_pct_change=0.1),
+            ])
+        ),
+    ).data.analyses
+    assert mixed == both_queried
+
+
+async def test_power_check_reuses_provided_cluster_stats_without_dwh(testing_datasource, aclient: AdminAPIClient):
+    """A cluster design with baseline stats and ICC provided for every metric skips the dwh."""
+    design_spec = PreassignedFrequentistExperimentSpec(
+        experiment_type=ExperimentsType.FREQ_PREASSIGNED,
+        experiment_name="test cluster power stats reuse",
+        description="Cluster power check with fully provided stats skips the dwh.",
+        start_date=datetime(2024, 1, 1, tzinfo=UTC),
+        end_date=datetime.now(UTC) + timedelta(days=1),
+        table_name=WIDE_DWH_PARTICIPANT_DEF.table_name,
+        primary_key="id",
+        arms=[Arm(arm_name="control", arm_description="C"), Arm(arm_name="treatment", arm_description="T")],
+        metrics=[
+            DesignSpecMetricRequest(
+                field_name="household_income",
+                metric_pct_change=0.1,
+                icc=0.015,
+                avg_cluster_size=10,
+                cv=0.1,
+            )
+        ],
+        strata=[],
+        filters=[],
+        cluster_key="age",
+        desired_n_clusters=40,
+    )
+    first_analysis = aclient.power_check(
+        datasource_id=testing_datasource.datasource_id,
+        body=PowerRequest(design_spec=design_spec),
+    ).data.analyses[0]
+    assert first_analysis.pct_change_with_desired_n is not None
+
+    reuse_spec = design_spec.model_copy(
+        update={
+            "table_name": "no_such_table",
+            "metrics": [echo_metric_request(first_analysis.metric_spec)],
+        }
+    )
+    reuse_analysis = aclient.power_check(
+        datasource_id=testing_datasource.datasource_id,
+        body=PowerRequest(design_spec=reuse_spec),
+    ).data.analyses[0]
+    assert reuse_analysis == first_analysis
 
 
 async def test_power_check_with_db_derived_icc_and_nulls_in_cluster_key(testing_datasource, aclient: AdminAPIClient):

--- a/src/xngin/apiserver/routers/common_api_types.py
+++ b/src/xngin/apiserver/routers/common_api_types.py
@@ -147,10 +147,12 @@ class DesignSpecMetric(DesignSpecMetricBase):
 
 
 class DesignSpecMetricRequest(DesignSpecMetricBase):
-    """Defines a request to look up baseline stats for a metric to measure in an experiment."""
+    """Defines a request to look up baseline stats for a metric to measure in an experiment.
 
-    # TODO: consider supporting {metric_baseline, metric_stddev, available_n} as inputs when the metric may not exist or
-    # be usable yet in the dwh, so that it it can be used as a general power/sizing calculator.
+    Baseline stats may optionally be supplied (e.g. echoed back from a prior power check's
+    `MetricPowerAnalysis.metric_spec`), in which case the server reuses them instead of
+    re-querying the data warehouse.
+    """
 
     # Override the descriptions from above:
     metric_pct_change: Annotated[
@@ -168,6 +170,33 @@ class DesignSpecMetricRequest(DesignSpecMetricBase):
         ),
     ] = None
 
+    # Optional baseline stats, mirroring the fields of DesignSpecMetric. When all are provided
+    # (metric_stddev only for NUMERIC metrics), the server skips the dwh stats query for this metric.
+    metric_type: Annotated[
+        MetricType | None,
+        Field(description="Type of the metric. Set together with the other baseline stats to reuse them."),
+    ] = None
+    metric_baseline: Annotated[
+        float | None,
+        Field(description="Mean of the tracked metric, e.g. from a prior power check response."),
+    ] = None
+    metric_stddev: Annotated[
+        float | None,
+        Field(description="Standard deviation of the tracked metric. Only valid for MetricType.NUMERIC metrics."),
+    ] = None
+    available_nonnull_n: Annotated[
+        int | None,
+        Field(
+            description=(
+                "The number of participants who meet the filtering criteria and have a non-null value for this metric."
+            )
+        ),
+    ] = None
+    available_n: Annotated[
+        int | None,
+        Field(description="The number of participants who meet the filtering criteria."),
+    ] = None
+
     @model_validator(mode="after")
     def check_has_only_one_of_pct_change_or_target(self) -> Self:
         if self.metric_pct_change is not None and self.metric_target is not None:
@@ -175,6 +204,41 @@ class DesignSpecMetricRequest(DesignSpecMetricBase):
         if self.metric_pct_change is None and self.metric_target is None:
             raise ValueError("Must set one of metric_pct_change or metric_target")
         return self
+
+    @model_validator(mode="after")
+    def check_baseline_stats(self) -> Self:
+        """Enforce that baseline stats are either all set or all unset, so that a power calculation
+        never mixes supplied stats with dwh-derived ones for the same metric."""
+        stats_fields = (self.metric_type, self.metric_baseline, self.available_nonnull_n, self.available_n)
+        if any(f is not None for f in stats_fields) and any(f is None for f in stats_fields):
+            raise ValueError(
+                "metric_type, metric_baseline, available_nonnull_n, and available_n must all be set "
+                "together or all be None"
+            )
+        if self.metric_stddev is not None and self.metric_type is not MetricType.NUMERIC:
+            raise ValueError("metric_stddev may only be set for NUMERIC metrics")
+        return self
+
+    @property
+    def has_baseline_stats(self) -> bool:
+        """True when this request carries the baseline stats needed to skip the dwh stats query."""
+        return self.metric_baseline is not None
+
+    def to_design_spec_metric(self) -> DesignSpecMetric:
+        """Converts a request carrying baseline stats into the equivalent dwh-derived metric."""
+        return DesignSpecMetric(
+            field_name=self.field_name,
+            metric_pct_change=self.metric_pct_change,
+            metric_target=self.metric_target,
+            icc=self.icc,
+            avg_cluster_size=self.avg_cluster_size,
+            cv=self.cv,
+            metric_type=self.metric_type,
+            metric_baseline=self.metric_baseline,
+            metric_stddev=self.metric_stddev,
+            available_nonnull_n=self.available_nonnull_n,
+            available_n=self.available_n,
+        )
 
 
 class ParticipantProperty(ApiBaseModel):

--- a/src/xngin/apiserver/routers/common_api_types.py
+++ b/src/xngin/apiserver/routers/common_api_types.py
@@ -94,18 +94,8 @@ class DesignSpecMetricBase(ApiBaseModel):
         Field(description="Coefficient of variation in cluster sizes (0 = equal sizes)."),
     ] = None
 
-    @model_validator(mode="after")
-    def cluster_fields_check(self) -> Self:
-        """Enforce that cluster fields are either all set or all unset."""
-        cluster_fields = (self.icc, self.avg_cluster_size, self.cv)
-        if any(f is not None for f in cluster_fields) and any(f is None for f in cluster_fields):
-            raise ValueError("icc, avg_cluster_size, and cv must all be set together or all be None")
-        return self
-
-
-class DesignSpecMetric(DesignSpecMetricBase):
-    """Defines a metric to measure in an experiment with its baseline stats."""
-
+    # Baseline stats. On responses (DesignSpecMetric) the server fills these in from the dwh; on
+    # requests (DesignSpecMetricRequest) they may be supplied to reuse stats from a prior response.
     metric_type: Annotated[MetricType | None, Field(description="Inferred from the data warehouse column type.")] = None
     metric_baseline: Annotated[float | None, Field(description="Mean of the tracked metric.")] = None
     metric_stddev: Annotated[
@@ -138,6 +128,18 @@ class DesignSpecMetric(DesignSpecMetricBase):
     ] = None
 
     @model_validator(mode="after")
+    def cluster_fields_check(self) -> Self:
+        """Enforce that cluster fields are either all set or all unset."""
+        cluster_fields = (self.icc, self.avg_cluster_size, self.cv)
+        if any(f is not None for f in cluster_fields) and any(f is None for f in cluster_fields):
+            raise ValueError("icc, avg_cluster_size, and cv must all be set together or all be None")
+        return self
+
+
+class DesignSpecMetric(DesignSpecMetricBase):
+    """Defines a metric to measure in an experiment with its baseline stats."""
+
+    @model_validator(mode="after")
     def stddev_check(self):
         """Enforce that metric_stddev is empty for non-NUMERICs. The frontend handles numerics without a
         stddev (the all-null case)."""
@@ -168,33 +170,6 @@ class DesignSpecMetricRequest(DesignSpecMetricBase):
             description="The absolute value you want to be able to detect. Cannot be set together with "
             "metric_pct_change."
         ),
-    ] = None
-
-    # Optional baseline stats, mirroring the fields of DesignSpecMetric. When all are provided
-    # (metric_stddev only for NUMERIC metrics), the server skips the dwh stats query for this metric.
-    metric_type: Annotated[
-        MetricType | None,
-        Field(description="Type of the metric. Set together with the other baseline stats to reuse them."),
-    ] = None
-    metric_baseline: Annotated[
-        float | None,
-        Field(description="Mean of the tracked metric, e.g. from a prior power check response."),
-    ] = None
-    metric_stddev: Annotated[
-        float | None,
-        Field(description="Standard deviation of the tracked metric. Only valid for MetricType.NUMERIC metrics."),
-    ] = None
-    available_nonnull_n: Annotated[
-        int | None,
-        Field(
-            description=(
-                "The number of participants who meet the filtering criteria and have a non-null value for this metric."
-            )
-        ),
-    ] = None
-    available_n: Annotated[
-        int | None,
-        Field(description="The number of participants who meet the filtering criteria."),
     ] = None
 
     @model_validator(mode="after")

--- a/src/xngin/apiserver/routers/test_common_api_types.py
+++ b/src/xngin/apiserver/routers/test_common_api_types.py
@@ -3,13 +3,15 @@ from pydantic import ValidationError
 
 from xngin.apiserver.routers.common_api_types import (
     CreateExperimentRequest,
+    DesignSpecMetric,
+    DesignSpecMetricRequest,
     Filter,
     MABDwhExperimentSpec,
     PreassignedFrequentistExperimentSpec,
     SampleCall,
     SampleCalls,
 )
-from xngin.apiserver.routers.common_enums import Relation
+from xngin.apiserver.routers.common_enums import MetricType, Relation
 
 VALID_COLUMN_NAMES = [
     "column_name",
@@ -334,3 +336,70 @@ def test_sample_calls_labels_must_be_unique():
     # Duplicate labels are rejected (the FE keys its rendered list on them).
     with pytest.raises(ValidationError, match="calls must have unique labels"):
         SampleCalls(calls=[call("Get assignment"), call("Get assignment")])
+
+
+def test_design_spec_metric_request_baseline_stats_all_or_none():
+    # No baseline stats is valid.
+    no_stats = DesignSpecMetricRequest(field_name="metric1", metric_pct_change=0.1)
+    assert no_stats.has_baseline_stats is False
+
+    # All baseline stats together is valid.
+    full_stats = DesignSpecMetricRequest(
+        field_name="metric1",
+        metric_pct_change=0.1,
+        metric_type=MetricType.NUMERIC,
+        metric_baseline=100.0,
+        metric_stddev=15.0,
+        available_nonnull_n=900,
+        available_n=1000,
+    )
+    assert full_stats.has_baseline_stats is True
+
+    # A partial set of baseline stats is rejected.
+    with pytest.raises(ValidationError, match="must all be set together"):
+        DesignSpecMetricRequest(
+            field_name="metric1",
+            metric_pct_change=0.1,
+            metric_baseline=100.0,
+        )
+
+
+def test_design_spec_metric_request_stddev_requires_numeric():
+    with pytest.raises(ValidationError, match="metric_stddev may only be set for NUMERIC metrics"):
+        DesignSpecMetricRequest(
+            field_name="metric1",
+            metric_pct_change=0.1,
+            metric_type=MetricType.BINARY,
+            metric_baseline=0.4,
+            metric_stddev=0.2,
+            available_nonnull_n=900,
+            available_n=1000,
+        )
+
+
+def test_design_spec_metric_request_to_design_spec_metric():
+    request = DesignSpecMetricRequest(
+        field_name="metric1",
+        metric_pct_change=0.1,
+        icc=0.05,
+        avg_cluster_size=20.0,
+        cv=0.3,
+        metric_type=MetricType.NUMERIC,
+        metric_baseline=100.0,
+        metric_stddev=15.0,
+        available_nonnull_n=900,
+        available_n=1000,
+    )
+    metric = request.to_design_spec_metric()
+    assert metric == DesignSpecMetric(
+        field_name="metric1",
+        metric_pct_change=0.1,
+        icc=0.05,
+        avg_cluster_size=20.0,
+        cv=0.3,
+        metric_type=MetricType.NUMERIC,
+        metric_baseline=100.0,
+        metric_stddev=15.0,
+        available_nonnull_n=900,
+        available_n=1000,
+    )


### PR DESCRIPTION
Implements the following task: when a power check request already carries the
baseline stats about its metrics (as returned by a previous power check), reuse them instead of
re-querying the data warehouse.

**Stacked on #322** — the first commit here belongs to that PR; only the last commit
(`a898e34b`) is under review. The diff collapses to just this change once #322 merges.

## API change

`DesignSpecMetricRequest` gains five optional fields mirroring `DesignSpecMetric`:
`metric_type`, `metric_baseline`, `metric_stddev`, `available_n`, `available_nonnull_n`.
This resolves the existing TODO in `common_api_types.py` about accepting stats as inputs so the
endpoint can act as a general power calculator.

- A validator enforces the stats are all-or-none per metric (`metric_stddev` only for NUMERIC
  metrics), so a calculation never mixes supplied and dwh-derived numbers for one metric.
- The change is backward compatible: requests without the new fields behave exactly as before.

## Endpoint behavior

`power_check` now partitions metrics:

- Metrics carrying baseline stats are used as-is; only the rest are queried
  (`get_stats_on_metrics` gets the narrowed list).
- For cluster designs, the existing per-metric rule is unchanged: user-supplied ICC/CV/avg
  cluster size are used when present, otherwise derived from the dwh.
- When nothing needs the warehouse, every metric has baseline stats, plus ICC for cluster
  designs, the `DwhSession` is never opened. Note this also skips validating the design spec
  against the participants table (intentional: it makes the endpoint usable as a pure
  calculator, and the caller supplied the numbers being computed on).

The caller is responsible for echoing stats that match the request's filters; stale or
mismatched stats produce a power result for the stats given, as with manual ICC today.

## Tests

- Model-level: all-or-none validation, stddev-requires-NUMERIC, faithful request→metric
  conversion.
- Endpoint-level: echoing stats back with a nonexistent `table_name` succeeds and returns
  analyses identical to the queried run (proving the dwh was untouched), for both individual
  and cluster (`desired_n_clusters`) designs; a mixed request (one metric with stats, one
  without) matches a fully-queried run.

## Follow-ups

- FE: send the stats from the initial power response back on desired-size re-checks
  (`convertToFrequentistDesignSpec`).
- Merge note: overlaps with #321 in `power_check`'s cluster block; whichever lands second
  needs a trivial rebase.
