### PR TITLE
Migrate frontend-impact CI to pnpm/setup.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -405,14 +405,11 @@ jobs:
           ref: main
           path: evidential-fe
           persist-credentials: false
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          package_json_file: evidential-fe/package.json
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version-file: 'evidential-fe/.nvmrc'
-          cache: 'pnpm'
-          cache-dependency-path: 'evidential-fe/pnpm-lock.yaml'
+          working-directory: evidential-fe
+          cache: true
+          install: false
       - uses: go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44 # v2.0.0
         with:
           version: 3.x


### PR DESCRIPTION
## Ticket

EVE-202

## Description

Updates the backend frontend-impact CI job to respect the pnpm and Node updates being applied to evidential-fe.
