### PR TITLE
Phase 3: DWH Pulling Logic

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -308,6 +308,12 @@ tasks:
       DATABASE_URL: "{{.XNGIN_DEVAPP_DSN}}"
     cmd: |
       uv run xngin-cli add-user {{.CLI_ARGS}}
+  start-dwh-pull:
+    desc: "Reads bandit outcomes from organizations' data warehouses."
+    interactive: true
+    env:
+      DATABASE_URL: "{{.XNGIN_DEVAPP_DSN}}"
+    cmd: uv run xngin-dwh-pull {{.CLI_ARGS}}
   start-snapshotter:
     desc: "Starts the snapshot collector."
     interactive: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ build-backend = "uv_build"
 xngin-apiserver-dev = "xngin.apiserver.main:main_dev"
 xngin-apiserver-live = "xngin.apiserver.main:main_live"
 xngin-cli = "xngin.cli.main:app"
+xngin-dwh-pull = "xngin.apiserver.dwhpull.cli:app"
 xngin-snapshotter = "xngin.apiserver.snapshots.cli:app"
 xngin-tq = "xngin.tq.cli:app"
 

--- a/src/xngin/apiserver/dwhpull/cli.py
+++ b/src/xngin/apiserver/dwhpull/cli.py
@@ -1,0 +1,60 @@
+"""dwh-pull reads bandit outcomes from organizations' data warehouses."""
+
+import asyncio
+import os
+from typing import Annotated
+
+import typer
+from loguru import logger
+from sentry_sdk.crons import monitor
+
+from xngin.apiserver import customlogging, database
+from xngin.apiserver.dwhpull import dwhpull
+from xngin.ops import sentry
+from xngin.xsecrets import secretservice
+
+ENV_CRONJOB_MONITOR_SLUG = "CRONJOB_MONITOR_SLUG"
+
+customlogging.setup()
+sentry.setup()
+
+app = typer.Typer(help="Reads bandit outcomes from organizations' data warehouses.")
+
+
+async def apull(pull_timeout: int):
+    """Pulls outcomes (async wrapper)."""
+    async with database.setup():
+        await dwhpull.pull_all_experiments(pull_timeout)
+
+
+@app.command()
+def pull(
+    pull_timeout: Annotated[
+        int,
+        typer.Option(
+            "--max-time",
+            min=1,
+            help="Maximum duration of one experiment's pull (in seconds). An experiment that takes "
+            "longer than this is abandoned for this run and reported as a failure.",
+        ),
+    ] = dwhpull.PULL_TIMEOUT_SECS,
+):
+    """Read outcomes from the data warehouse for every experiment that needs them.
+
+    MAB-DWH experiments have their outcomes read from the organization's data warehouse rather than
+    pushed to the API, so this job is what moves those experiments forward: every outcome it applies
+    updates the arm's posterior, and later assignments draw on the updated arms.
+
+    This job pulls on every invocation, so the interval between invocations is how quickly an
+    outcome that lands in the warehouse reaches the bandit. Outcomes that have not landed yet are
+    re-read on the next run, so a missed invocation costs latency and nothing else.
+    """
+    secretservice.setup()
+
+    cronjob_monitor_slug = os.environ.get(ENV_CRONJOB_MONITOR_SLUG, "")
+    if cronjob_monitor_slug:
+        with monitor(monitor_slug=cronjob_monitor_slug):
+            asyncio.run(apull(pull_timeout))
+    else:
+        asyncio.run(apull(pull_timeout))
+    logger.info("pull() finished successfully.")

--- a/src/xngin/apiserver/dwhpull/dwhpull.py
+++ b/src/xngin/apiserver/dwhpull/dwhpull.py
@@ -1,0 +1,206 @@
+"""Reads bandit outcomes from an organization's data warehouse.
+
+MAB_ONLINE_DWH experiments have no outcomes pushed to the API. For those, this module finds draws
+that still have no outcome, reads the experiment's target column for those participants, and applies
+each value through the same per-outcome update the push API uses.
+"""
+
+import asyncio
+from dataclasses import dataclass
+
+import sentry_sdk
+from loguru import logger
+from sqlalchemy import func, select, text
+from sqlalchemy.orm import selectinload
+
+from xngin.apiserver import database
+from xngin.apiserver.dwh.dwh_session import DwhSession
+from xngin.apiserver.dwh.participant_metrics_queries import get_participant_metrics
+from xngin.apiserver.exceptions_common import LateValidationError
+from xngin.apiserver.routers.common_api_types import DesignSpecMetricRequest
+from xngin.apiserver.routers.common_enums import ExperimentState, ExperimentsType
+from xngin.apiserver.routers.experiments.experiments_common import (
+    ExperimentsAssignmentError,
+    MismatchedExperimentTypeError,
+    update_bandit_arm_with_outcome_impl,
+)
+from xngin.apiserver.sqla import tables
+
+# The amount of time one experiment's pull may run before it is abandoned. The pull job can specify a
+# different timeout via command line flags.
+PULL_TIMEOUT_SECS = 90
+
+
+@dataclass(slots=True)
+class PullReport:
+    """Counts from one experiment's pull."""
+
+    ingested: int = 0
+    invalid: int = 0
+    pending: int = 0
+
+    def summary(self) -> str:
+        return f"ingested={self.ingested} invalid={self.invalid} pending={self.pending}"
+
+
+async def select_experiments_to_pull() -> list[str]:
+    """Return the ids of the experiments whose outcomes we read from a data warehouse.
+
+    Covers committed MAB-DWH experiments that are running, start tomorrow, or ended yesterday. The
+    day either side gives outcomes that land late a chance to arrive.
+
+    This method establishes its own database connection.
+    """
+    buffer = text("interval '1 day'")
+    async with database.async_session() as session:
+        return list(
+            (
+                await session.execute(
+                    select(tables.Experiment.id)
+                    .where(
+                        tables.Experiment.experiment_type == ExperimentsType.MAB_ONLINE_DWH.value,
+                        tables.Experiment.state == ExperimentState.COMMITTED.value,
+                        func.now().between(
+                            func.date_trunc("minute", tables.Experiment.start_date - buffer),
+                            func.date_trunc("minute", tables.Experiment.end_date + buffer),
+                        ),
+                    )
+                    .order_by(tables.Experiment.id)
+                )
+            ).scalars()
+        )
+
+
+async def pull_one_experiment(experiment_id: str) -> PullReport:
+    """Read newly landed outcomes for one MAB_ONLINE_DWH experiment and apply them.
+
+    Opens its own database sessions so that each outcome commits independently of any transaction
+    held by the caller.
+
+    An interrupted run keeps the outcomes already committed; the next run picks up the remainder
+    because this selects only draws that still have no outcome.
+    """
+    experiment_query = (
+        select(tables.Experiment)
+        .where(tables.Experiment.id == experiment_id)
+        .options(
+            selectinload(tables.Experiment.arms),
+            selectinload(tables.Experiment.contexts),
+            selectinload(tables.Experiment.datasource),
+            selectinload(tables.Experiment.experiment_fields),
+        )
+    )
+
+    async with database.async_session() as session:
+        experiment = (await session.execute(experiment_query)).scalar_one()
+        if ExperimentsType(experiment.experiment_type) != ExperimentsType.MAB_ONLINE_DWH:
+            raise MismatchedExperimentTypeError(f"Cannot pull outcomes for a {experiment.experiment_type} experiment.")
+        unique_id_field = experiment.unique_id_field()
+        target_field = next((ef for ef in experiment.experiment_fields if ef.is_target), None)
+        if experiment.datasource_table is None or unique_id_field is None or target_field is None:
+            raise LateValidationError(
+                "MAB-DWH experiment is missing its datasource table, unique id field, or target field."
+            )
+        dsconfig = experiment.datasource.get_config()
+        table_name = experiment.datasource_table
+        unique_id_field_name = unique_id_field.field_name
+        target_field_name = target_field.field_name
+
+        pending_ids = list(
+            (
+                await session.execute(
+                    select(tables.Draw.participant_id)
+                    .where(
+                        tables.Draw.experiment_id == experiment_id,
+                        tables.Draw.outcome.is_(None),
+                    )
+                    .order_by(tables.Draw.created_at)
+                )
+            ).scalars()
+        )
+    if not pending_ids:
+        return PullReport()
+
+    async with DwhSession(dsconfig.dwh) as dwh:
+        sa_table = await dwh.inspect_table(table_name)
+        # model_construct: get_participant_metrics only reads field_name; the power-analysis fields
+        # the validator demands (metric_pct_change/metric_target) don't apply here.
+        target_metric = DesignSpecMetricRequest.model_construct(field_name=target_field_name)
+        participant_outcomes = await asyncio.to_thread(
+            get_participant_metrics,
+            dwh.session,
+            sa_table,
+            [target_metric],
+            unique_id_field_name,
+            pending_ids,
+        )
+
+    values_by_participant: dict[str, float | None] = {
+        po.participant_id: next(
+            (mv.metric_value for mv in po.metric_values if mv.metric_name == target_field_name),
+            None,
+        )
+        for po in participant_outcomes
+    }
+
+    async with database.async_session() as session:
+        report = PullReport()
+        experiment = (await session.execute(experiment_query)).scalar_one()
+        for participant_id in pending_ids:
+            value = values_by_participant.get(participant_id)
+            if value is None:
+                # Not in the DWH yet, or the target column is still NULL: re-read on a later run.
+                report.pending += 1
+                continue
+            try:
+                await update_bandit_arm_with_outcome_impl(
+                    xngin_session=session,
+                    experiment=experiment,
+                    participant_id=participant_id,
+                    outcome=value,
+                )
+                # The update leaves the transaction open for its caller. Commit per outcome so an
+                # interrupted run keeps what it already applied.
+                await session.commit()
+                report.ingested += 1
+            except (ExperimentsAssignmentError, LateValidationError) as exc:
+                # Value failed the reward/target validation (or a concurrent writer already recorded
+                # an outcome). Rejected draws keep outcome=NULL, so a corrected DWH value is picked
+                # up on a later run.
+                await session.rollback()
+                logger.info(f"{experiment_id}: skipping outcome for participant '{participant_id}': {exc}")
+                report.invalid += 1
+                # rollback() expires every object in the session; reload so later iterations don't
+                # trigger sync lazy loads on expired attributes.
+                experiment = (await session.execute(experiment_query)).scalar_one()
+    return report
+
+
+async def pull_all_experiments(pull_timeout: int) -> None:
+    """Pull outcomes for every experiment that needs them, one experiment at a time.
+
+    A failure on one experiment is reported and does not stop the others.
+    """
+    experiment_ids = await select_experiments_to_pull()
+    logger.info(f"Pulling outcomes for {len(experiment_ids)} experiments.")
+    sentry_sdk.metrics.count("dwh_pull.experiments", len(experiment_ids))
+
+    failures = 0
+    for experiment_id in experiment_ids:
+        with logger.contextualize(experiment_id=experiment_id):
+            try:
+                async with asyncio.timeout(pull_timeout):
+                    report = await pull_one_experiment(experiment_id)
+            except Exception as exc:
+                failures += 1
+                logger.opt(exception=exc).error(f"{experiment_id}: pull failed")
+                sentry_sdk.capture_exception(exc)
+                sentry_sdk.metrics.count("dwh_pull.failed", 1, attributes={"experiment_id": experiment_id})
+                continue
+            logger.info(f"{experiment_id}: {report.summary()}")
+            attributes = {"experiment_id": experiment_id}
+            sentry_sdk.metrics.count("dwh_pull.ingested", report.ingested, attributes=attributes)
+            sentry_sdk.metrics.count("dwh_pull.invalid", report.invalid, attributes=attributes)
+            sentry_sdk.metrics.count("dwh_pull.pending", report.pending, attributes=attributes)
+
+    logger.info(f"Pulled outcomes for {len(experiment_ids) - failures} experiments, {failures} failed.")

--- a/src/xngin/apiserver/dwhpull/dwhpull.py
+++ b/src/xngin/apiserver/dwhpull/dwhpull.py
@@ -3,6 +3,9 @@
 MAB_ONLINE_DWH experiments have no outcomes pushed to the API. For those, this module finds draws
 that still have no outcome, reads the experiment's target column for those participants, and applies
 each value through the same per-outcome update the push API uses.
+
+Each experiment's outcomes are applied in a single transaction, so an experiment either pulls or it
+does not. A run that dies partway leaves the experiment untouched and the next run repeats it.
 """
 
 import asyncio
@@ -20,7 +23,6 @@ from xngin.apiserver.exceptions_common import LateValidationError
 from xngin.apiserver.routers.common_api_types import DesignSpecMetricRequest
 from xngin.apiserver.routers.common_enums import ExperimentState, ExperimentsType
 from xngin.apiserver.routers.experiments.experiments_common import (
-    ExperimentsAssignmentError,
     MismatchedExperimentTypeError,
     update_bandit_arm_with_outcome_impl,
 )
@@ -74,11 +76,15 @@ async def select_experiments_to_pull() -> list[str]:
 async def pull_one_experiment(experiment_id: str) -> PullReport:
     """Read newly landed outcomes for one MAB_ONLINE_DWH experiment and apply them.
 
-    Opens its own database sessions so that each outcome commits independently of any transaction
-    held by the caller.
+    Runs in three contained phases so that no application-database transaction is held open across the call to
+    the organization's warehouse:
+    1. Read what the warehouse query needs,
+    2. Read the warehouse,
+    3. Compute + apply the values.
 
-    An interrupted run keeps the outcomes already committed; the next run picks up the remainder
-    because this selects only draws that still have no outcome.
+    The third phase is one transaction. Either every valid outcome lands or none does, so a failure
+    never leaves an experiment half pulled. Values the warehouse has not filled in yet, and values
+    that fail validation, stay NULL and are re-read on a later run.
     """
     experiment_query = (
         select(tables.Experiment)
@@ -91,6 +97,8 @@ async def pull_one_experiment(experiment_id: str) -> PullReport:
         )
     )
 
+    # 1. Read what the warehouse query needs: the datasource config, the target and unique-id
+    # columns, and the draws that still have no outcome.
     async with database.async_session() as session:
         experiment = (await session.execute(experiment_query)).scalar_one()
         if ExperimentsType(experiment.experiment_type) != ExperimentsType.MAB_ONLINE_DWH:
@@ -121,6 +129,8 @@ async def pull_one_experiment(experiment_id: str) -> PullReport:
     if not pending_ids:
         return PullReport()
 
+    # 2. Read the warehouse. The session above has closed, so no application-database transaction
+    # is held open across this call.
     async with DwhSession(dsconfig.dwh) as dwh:
         sa_table = await dwh.inspect_table(table_name)
         # model_construct: get_participant_metrics only reads field_name; the power-analysis fields
@@ -135,6 +145,7 @@ async def pull_one_experiment(experiment_id: str) -> PullReport:
             pending_ids,
         )
 
+    # 3. Compute the value per participant, then apply them all in one transaction.
     values_by_participant: dict[str, float | None] = {
         po.participant_id: next(
             (mv.metric_value for mv in po.metric_values if mv.metric_name == target_field_name),
@@ -143,13 +154,30 @@ async def pull_one_experiment(experiment_id: str) -> PullReport:
         for po in participant_outcomes
     }
 
-    async with database.async_session() as session:
-        report = PullReport()
+    async with database.async_session() as session, session.begin():
         experiment = (await session.execute(experiment_query)).scalar_one()
+        # FOR NO KEY UPDATE leaves foreign keys referencing these draws
+        # readable, and it excludes a concurrent writer from filling one behind us.
+        locked = set(
+            (
+                await session.execute(
+                    select(tables.Draw.participant_id)
+                    .where(
+                        tables.Draw.experiment_id == experiment_id,
+                        tables.Draw.outcome.is_(None),
+                        tables.Draw.participant_id.in_(values_by_participant.keys()),
+                    )
+                    .with_for_update(of=tables.Draw, key_share=True)
+                )
+            ).scalars()
+        )
+
+        report = PullReport()
         for participant_id in pending_ids:
             value = values_by_participant.get(participant_id)
-            if value is None:
-                # Not in the DWH yet, or the target column is still NULL: re-read on a later run.
+            if value is None or participant_id not in locked:
+                # Not in the warehouse yet, the target column is still NULL, or another writer
+                # resolved the draw between phases. Re-read on a later run.
                 report.pending += 1
                 continue
             try:
@@ -159,20 +187,13 @@ async def pull_one_experiment(experiment_id: str) -> PullReport:
                     participant_id=participant_id,
                     outcome=value,
                 )
-                # The update leaves the transaction open for its caller. Commit per outcome so an
-                # interrupted run keeps what it already applied.
-                await session.commit()
                 report.ingested += 1
-            except (ExperimentsAssignmentError, LateValidationError) as exc:
-                # Value failed the reward/target validation (or a concurrent writer already recorded
-                # an outcome). Rejected draws keep outcome=NULL, so a corrected DWH value is picked
-                # up on a later run.
-                await session.rollback()
+            except LateValidationError as exc:
+                # The reward and target guards reject the value before writing anything, so the
+                # transaction stays usable and one bad warehouse value does not block the rest of
+                # the experiment. The draw keeps outcome=NULL and a corrected value lands later.
                 logger.info(f"{experiment_id}: skipping outcome for participant '{participant_id}': {exc}")
                 report.invalid += 1
-                # rollback() expires every object in the session; reload so later iterations don't
-                # trigger sync lazy loads on expired attributes.
-                experiment = (await session.execute(experiment_query)).scalar_one()
     return report
 
 

--- a/src/xngin/apiserver/dwhpull/dwhpull.py
+++ b/src/xngin/apiserver/dwhpull/dwhpull.py
@@ -76,15 +76,16 @@ async def select_experiments_to_pull() -> list[str]:
 async def pull_one_experiment(experiment_id: str) -> PullReport:
     """Read newly landed outcomes for one MAB_ONLINE_DWH experiment and apply them.
 
-    Runs in three contained phases so that no application-database transaction is held open across the call to
-    the organization's warehouse:
-    1. Read what the warehouse query needs,
+    Runs as one transaction covering all three phases:
+    1. Read what the warehouse query needs, and lock the draws we intend to fill,
     2. Read the warehouse,
     3. Compute + apply the values.
 
-    The third phase is one transaction. Either every valid outcome lands or none does, so a failure
-    never leaves an experiment half pulled. Values the warehouse has not filled in yet, and values
-    that fail validation, stay NULL and are re-read on a later run.
+    Either every valid outcome lands or none does, so a failure never leaves an experiment half
+    pulled. Values the warehouse has not filled in yet, and values that fail validation, stay NULL
+    and are re-read on a later run.
+
+    The locks taken in phase 1 are held until the transaction ends.
     """
     experiment_query = (
         select(tables.Experiment)
@@ -97,9 +98,9 @@ async def pull_one_experiment(experiment_id: str) -> PullReport:
         )
     )
 
-    # 1. Read what the warehouse query needs: the datasource config, the target and unique-id
-    # columns, and the draws that still have no outcome.
-    async with database.async_session() as session:
+    async with database.async_session() as session, session.begin():
+        # 1. Read what the warehouse query needs: the datasource config, the target and unique-id
+        # columns, and the draws that still have no outcome.
         experiment = (await session.execute(experiment_query)).scalar_one()
         if ExperimentsType(experiment.experiment_type) != ExperimentsType.MAB_ONLINE_DWH:
             raise MismatchedExperimentTypeError(f"Cannot pull outcomes for a {experiment.experiment_type} experiment.")
@@ -114,6 +115,9 @@ async def pull_one_experiment(experiment_id: str) -> PullReport:
         unique_id_field_name = unique_id_field.field_name
         target_field_name = target_field.field_name
 
+        # FOR NO KEY UPDATE holds these draws for the rest of the transaction while still letting
+        # foreign keys reference them. Taking the lock here, before the warehouse read, is what
+        # keeps autofail off them for the whole pull.
         pending_ids = list(
             (
                 await session.execute(
@@ -123,61 +127,43 @@ async def pull_one_experiment(experiment_id: str) -> PullReport:
                         tables.Draw.outcome.is_(None),
                     )
                     .order_by(tables.Draw.created_at)
-                )
-            ).scalars()
-        )
-    if not pending_ids:
-        return PullReport()
-
-    # 2. Read the warehouse. The session above has closed, so no application-database transaction
-    # is held open across this call.
-    async with DwhSession(dsconfig.dwh) as dwh:
-        sa_table = await dwh.inspect_table(table_name)
-        # model_construct: get_participant_metrics only reads field_name; the power-analysis fields
-        # the validator demands (metric_pct_change/metric_target) don't apply here.
-        target_metric = DesignSpecMetricRequest.model_construct(field_name=target_field_name)
-        participant_outcomes = await asyncio.to_thread(
-            get_participant_metrics,
-            dwh.session,
-            sa_table,
-            [target_metric],
-            unique_id_field_name,
-            pending_ids,
-        )
-
-    # 3. Compute the value per participant, then apply them all in one transaction.
-    values_by_participant: dict[str, float | None] = {
-        po.participant_id: next(
-            (mv.metric_value for mv in po.metric_values if mv.metric_name == target_field_name),
-            None,
-        )
-        for po in participant_outcomes
-    }
-
-    async with database.async_session() as session, session.begin():
-        experiment = (await session.execute(experiment_query)).scalar_one()
-        # FOR NO KEY UPDATE leaves foreign keys referencing these draws
-        # readable, and it excludes a concurrent writer from filling one behind us.
-        locked = set(
-            (
-                await session.execute(
-                    select(tables.Draw.participant_id)
-                    .where(
-                        tables.Draw.experiment_id == experiment_id,
-                        tables.Draw.outcome.is_(None),
-                        tables.Draw.participant_id.in_(values_by_participant.keys()),
-                    )
                     .with_for_update(of=tables.Draw, key_share=True)
                 )
             ).scalars()
         )
+        if not pending_ids:
+            return PullReport()
+
+        # 2. Read the external DWH.
+        async with DwhSession(dsconfig.dwh) as dwh:
+            sa_table = await dwh.inspect_table(table_name)
+            # model_construct: get_participant_metrics only reads field_name; the power-analysis
+            # fields the validator demands (metric_pct_change/metric_target) don't apply here.
+            target_metric = DesignSpecMetricRequest.model_construct(field_name=target_field_name)
+            participant_outcomes = await asyncio.to_thread(
+                get_participant_metrics,
+                dwh.session,
+                sa_table,
+                [target_metric],
+                unique_id_field_name,
+                pending_ids,
+            )
+
+        # 3. Compute the value per participant, then apply them.
+        values_by_participant: dict[str, float | None] = {
+            po.participant_id: next(
+                (mv.metric_value for mv in po.metric_values if mv.metric_name == target_field_name),
+                None,
+            )
+            for po in participant_outcomes
+        }
 
         report = PullReport()
         for participant_id in pending_ids:
             value = values_by_participant.get(participant_id)
-            if value is None or participant_id not in locked:
-                # Not in the warehouse yet, the target column is still NULL, or another writer
-                # resolved the draw between phases. Re-read on a later run.
+            if value is None:
+                # Not in the warehouse yet, or the target column is still NULL. The draw keeps
+                # outcome=NULL and is re-read on a later run.
                 report.pending += 1
                 continue
             try:
@@ -197,7 +183,7 @@ async def pull_one_experiment(experiment_id: str) -> PullReport:
     return report
 
 
-async def pull_all_experiments(pull_timeout: int) -> None:
+async def pull_all_experiments(pull_timeout: float) -> None:
     """Pull outcomes for every experiment that needs them, one experiment at a time.
 
     A failure on one experiment is reported and does not stop the others.

--- a/src/xngin/apiserver/dwhpull/test_dwhpull.py
+++ b/src/xngin/apiserver/dwhpull/test_dwhpull.py
@@ -5,6 +5,7 @@ import pytest
 from sqlalchemy import select
 
 from xngin.apiserver.dwhpull import cli
+from xngin.apiserver.dwhpull import dwhpull as dwhpull_mod
 from xngin.apiserver.dwhpull.dwhpull import (
     PULL_TIMEOUT_SECS,
     pull_all_experiments,
@@ -134,8 +135,7 @@ async def test_pull_one_experiment_invalid_value_skipped_and_left_null(xngin_ses
 
 
 async def test_pull_one_experiment_continues_after_a_rejected_value(xngin_session, testing_datasource):
-    """Rejecting a value rolls back, which expires the session's objects; later participants in the
-    same run must still be processed."""
+    """A rejected value must not stop the participants after it in the same run."""
     experiment = await make_mab_dwh_experiment(
         xngin_session,
         testing_datasource.ds,
@@ -149,6 +149,31 @@ async def test_pull_one_experiment_continues_after_a_rejected_value(xngin_sessio
 
     # invalid=2 means the loop reached the second participant after rolling back the first.
     assert (report.ingested, report.invalid, report.pending) == (0, 2, 0)
+
+
+async def test_pull_one_experiment_applies_all_outcomes_or_none(xngin_session, testing_datasource, mocker):
+    """A failure partway through leaves the experiment untouched, so a rerun repeats it cleanly."""
+    experiment = await make_mab_dwh_experiment(xngin_session, testing_datasource.ds, target_field_name="is_onboarded")
+    await create_assignment_for_participant(xngin_session, experiment, "1", None, random_state=66)
+    await create_assignment_for_participant(xngin_session, experiment, "2", None, random_state=67)
+
+    real_update = dwhpull_mod.update_bandit_arm_with_outcome_impl
+    seen = []
+
+    async def fail_on_the_second(**kwargs):
+        seen.append(kwargs["participant_id"])
+        if len(seen) == 2:
+            raise RuntimeError("warehouse pull interrupted")
+        return await real_update(**kwargs)
+
+    mocker.patch.object(dwhpull_mod, "update_bandit_arm_with_outcome_impl", side_effect=fail_on_the_second)
+
+    with pytest.raises(RuntimeError):
+        await pull_one_experiment(experiment.id)
+
+    # The first outcome applied in memory but never committed, so neither draw is resolved.
+    assert len(seen) == 2
+    assert await read_outcomes(xngin_session, experiment.id) == {"1": None, "2": None}
 
 
 async def test_pull_one_experiment_rejects_non_dwh_experiment(xngin_session, testing_datasource):

--- a/src/xngin/apiserver/dwhpull/test_dwhpull.py
+++ b/src/xngin/apiserver/dwhpull/test_dwhpull.py
@@ -1,9 +1,11 @@
+import asyncio
 import contextlib
 from datetime import UTC, datetime, timedelta
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, update
 
+from xngin.apiserver.dwh.dwh_session import DwhSession
 from xngin.apiserver.dwhpull import cli
 from xngin.apiserver.dwhpull import dwhpull as dwhpull_mod
 from xngin.apiserver.dwhpull.dwhpull import (
@@ -149,6 +151,56 @@ async def test_pull_one_experiment_continues_after_a_rejected_value(xngin_sessio
 
     # invalid=2 means the loop reached the second participant after rolling back the first.
     assert (report.ingested, report.invalid, report.pending) == (0, 2, 0)
+
+
+async def test_pull_one_experiment_leaves_resolved_draws_alone(xngin_session, testing_datasource):
+    """A draw another writer already resolved, autofail included, is not overwritten by a pull.
+
+    The pull holds FOR NO KEY UPDATE on its draws for the whole run precisely so autofail cannot
+    resolve one mid-pull. This covers the other side of that: whatever is already resolved stays.
+    """
+    experiment = await make_mab_dwh_experiment(xngin_session, testing_datasource.ds, target_field_name="is_onboarded")
+    await create_assignment_for_participant(xngin_session, experiment, "1", None, random_state=66)
+    await create_assignment_for_participant(xngin_session, experiment, "2", None, random_state=67)
+
+    # Stand in for autofail having already closed out participant 1 with its 0.0.
+    await xngin_session.execute(
+        update(tables.Draw)
+        .where(tables.Draw.experiment_id == experiment.id, tables.Draw.participant_id == "1")
+        .values(outcome=0.0, observed_at=datetime.now(UTC), autofailed_outcome=True)
+    )
+    await xngin_session.commit()
+
+    report = await pull_one_experiment(experiment.id)
+
+    # Only participant 2 was outstanding. Participant 1 keeps the autofailed 0.0, even though the
+    # warehouse says is_onboarded=false for them anyway.
+    assert (report.ingested, report.invalid, report.pending) == (1, 0, 0)
+    assert await read_outcomes(xngin_session, experiment.id) == {"1": 0.0, "2": 1.0}
+
+
+async def test_pull_all_experiments_abandons_an_experiment_that_exceeds_its_timeout(
+    xngin_session, testing_datasource, mocker
+):
+    """A warehouse that hangs must not hold the transaction open indefinitely.
+
+    Holding an application-database transaction across the warehouse read is only safe because
+    pull_all_experiments bounds each experiment. Uses a tiny budget against a stalled read, so the
+    test cancels immediately rather than waiting.
+    """
+    experiment = await make_mab_dwh_experiment(xngin_session, testing_datasource.ds, target_field_name="is_onboarded")
+    await create_assignment_for_participant(xngin_session, experiment, "2", None, random_state=67)
+
+    async def never_returns(self, table_name):
+        await asyncio.sleep(30)
+
+    mocker.patch.object(DwhSession, "inspect_table", never_returns)
+
+    # Reported as a failure. One warehouse does not stop the other experiments.
+    await pull_all_experiments(pull_timeout=0.05)
+
+    # The transaction rolled back, so the draw is untouched and the next run retries it.
+    assert await read_outcomes(xngin_session, experiment.id) == {"2": None}
 
 
 async def test_pull_one_experiment_applies_all_outcomes_or_none(xngin_session, testing_datasource, mocker):

--- a/src/xngin/apiserver/dwhpull/test_dwhpull.py
+++ b/src/xngin/apiserver/dwhpull/test_dwhpull.py
@@ -1,0 +1,234 @@
+import contextlib
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+from typer.testing import CliRunner
+
+from xngin.apiserver.dwhpull import cli
+from xngin.apiserver.dwhpull.dwhpull import (
+    PULL_TIMEOUT_SECS,
+    pull_all_experiments,
+    pull_one_experiment,
+    select_experiments_to_pull,
+)
+from xngin.apiserver.routers.common_api_types import ExperimentsType, LikelihoodTypes, PriorTypes
+from xngin.apiserver.routers.common_enums import ExperimentState
+from xngin.apiserver.routers.experiments.experiments_common import (
+    MismatchedExperimentTypeError,
+    create_assignment_for_participant,
+)
+from xngin.apiserver.routers.experiments.test_experiments_common import insert_experiment_and_arms
+from xngin.apiserver.sqla import tables
+
+
+async def make_mab_dwh_experiment(xngin_session, datasource, **kwargs) -> tables.Experiment:
+    return await insert_experiment_and_arms(
+        xngin_session,
+        datasource,
+        experiment_type=ExperimentsType.MAB_ONLINE_DWH,
+        prior_type=PriorTypes.BETA,
+        reward_type=LikelihoodTypes.BERNOULLI,
+        **kwargs,
+    )
+
+
+async def read_outcomes(xngin_session, experiment_id: str) -> dict[str, float | None]:
+    rows = await xngin_session.execute(
+        select(tables.Draw.participant_id, tables.Draw.outcome).where(tables.Draw.experiment_id == experiment_id)
+    )
+    return dict(rows.all())
+
+
+async def test_pull_one_experiment_boolean_target(xngin_session, testing_datasource):
+    """A pull reads target values for outcome-less draws, applies them, and reports counts."""
+    experiment = await make_mab_dwh_experiment(xngin_session, testing_datasource.ds, target_field_name="is_onboarded")
+    # Testing DWH: id=1 has is_onboarded=false, id=2 has is_onboarded=true.
+    await create_assignment_for_participant(xngin_session, experiment, "1", None, random_state=66)
+    await create_assignment_for_participant(xngin_session, experiment, "2", None, random_state=67)
+    # Not present in the testing DWH.
+    await create_assignment_for_participant(xngin_session, experiment, "99999999999", None, random_state=68)
+
+    report = await pull_one_experiment(experiment.id)
+    assert (report.ingested, report.invalid, report.pending) == (2, 0, 1)
+    assert await read_outcomes(xngin_session, experiment.id) == {"1": 0.0, "2": 1.0, "99999999999": None}
+
+    # The posteriors moved: one success adds 1 to an arm's alpha, one failure adds 1 to a beta.
+    alpha_gain = 0.0
+    beta_gain = 0.0
+    for arm in experiment.arms:
+        await xngin_session.refresh(arm)
+        assert arm.alpha is not None and arm.alpha_init is not None
+        assert arm.beta is not None and arm.beta_init is not None
+        alpha_gain += arm.alpha - arm.alpha_init
+        beta_gain += arm.beta - arm.beta_init
+    assert (alpha_gain, beta_gain) == (1.0, 1.0)
+
+    # Re-running ingests nothing new: filled draws no longer match the outcome-less query.
+    report = await pull_one_experiment(experiment.id)
+    assert (report.ingested, report.invalid, report.pending) == (0, 0, 1)
+
+
+async def test_pull_one_experiment_with_no_outcomeless_draws_skips_the_warehouse(xngin_session, testing_datasource):
+    """The common case: nothing to read, so the run does not touch the data warehouse at all."""
+    experiment = await make_mab_dwh_experiment(xngin_session, testing_datasource.ds)
+
+    report = await pull_one_experiment(experiment.id)
+
+    assert (report.ingested, report.invalid, report.pending) == (0, 0, 0)
+
+
+async def test_pull_one_experiment_numeric_target_accepts_any_float(xngin_session, testing_datasource):
+    """A numeric target under a Normal reward takes arbitrary float values, not just 0/1.
+
+    Moved here from the outcome API, which no longer accepts pushes for this type.
+    """
+    experiment = await insert_experiment_and_arms(
+        xngin_session,
+        testing_datasource.ds,
+        experiment_type=ExperimentsType.MAB_ONLINE_DWH,
+        prior_type=PriorTypes.NORMAL,
+        reward_type=LikelihoodTypes.NORMAL,
+        target_field_name="current_income",
+    )
+    await create_assignment_for_participant(xngin_session, experiment, "1", None, random_state=66)
+
+    report = await pull_one_experiment(experiment.id)
+
+    assert (report.ingested, report.invalid, report.pending) == (1, 0, 0)
+    outcomes = await read_outcomes(xngin_session, experiment.id)
+    assert outcomes["1"] == 29912.0
+
+
+async def test_pull_one_experiment_null_target_value_stays_pending(xngin_session, testing_datasource):
+    """A row whose target column is NULL is left pending, to be re-read on a later run."""
+    experiment = await make_mab_dwh_experiment(
+        xngin_session,
+        testing_datasource.ds,
+        # NULL for low ids in the testing DWH.
+        target_field_name="is_onboarded_onetime",
+    )
+    await create_assignment_for_participant(xngin_session, experiment, "1", None, random_state=66)
+
+    report = await pull_one_experiment(experiment.id)
+    assert (report.ingested, report.invalid, report.pending) == (0, 0, 1)
+
+
+async def test_pull_one_experiment_invalid_value_skipped_and_left_null(xngin_session, testing_datasource):
+    """A pulled value that fails validation is skipped and the draw stays NULL, so a corrected
+    warehouse value is picked up on a later run."""
+    experiment = await make_mab_dwh_experiment(
+        xngin_session,
+        testing_datasource.ds,
+        # id=1's current_income is 29912.0, which fails the Bernoulli 0/1 guard.
+        target_field_name="current_income",
+    )
+    await create_assignment_for_participant(xngin_session, experiment, "1", None, random_state=66)
+
+    report = await pull_one_experiment(experiment.id)
+    assert (report.ingested, report.invalid, report.pending) == (0, 1, 0)
+    assert await read_outcomes(xngin_session, experiment.id) == {"1": None}
+    for arm in experiment.arms:
+        await xngin_session.refresh(arm)
+        assert arm.alpha == arm.alpha_init
+        assert arm.beta == arm.beta_init
+
+
+async def test_pull_one_experiment_continues_after_a_rejected_value(xngin_session, testing_datasource):
+    """Rejecting a value rolls back, which expires the session's objects; later participants in the
+    same run must still be processed."""
+    experiment = await make_mab_dwh_experiment(
+        xngin_session,
+        testing_datasource.ds,
+        # No current_income in the testing DWH is 0 or 1, so every value fails the Bernoulli guard.
+        target_field_name="current_income",
+    )
+    await create_assignment_for_participant(xngin_session, experiment, "1", None, random_state=66)
+    await create_assignment_for_participant(xngin_session, experiment, "3", None, random_state=67)
+
+    report = await pull_one_experiment(experiment.id)
+
+    # invalid=2 means the loop reached the second participant after rolling back the first.
+    assert (report.ingested, report.invalid, report.pending) == (0, 2, 0)
+
+
+async def test_pull_one_experiment_rejects_non_dwh_experiment(xngin_session, testing_datasource):
+    experiment = await insert_experiment_and_arms(
+        xngin_session,
+        testing_datasource.ds,
+        experiment_type=ExperimentsType.MAB_ONLINE,
+        prior_type=PriorTypes.BETA,
+        reward_type=LikelihoodTypes.BERNOULLI,
+    )
+    with pytest.raises(MismatchedExperimentTypeError):
+        await pull_one_experiment(experiment.id)
+
+
+async def test_select_experiments_to_pull_skips_other_types_and_states(xngin_session, testing_datasource):
+    due = await make_mab_dwh_experiment(xngin_session, testing_datasource.ds)
+    await make_mab_dwh_experiment(xngin_session, testing_datasource.ds, state=ExperimentState.ASSIGNED)
+    await make_mab_dwh_experiment(
+        xngin_session,
+        testing_datasource.ds,
+        end_date=datetime.now(UTC) - timedelta(days=30),
+    )
+    await insert_experiment_and_arms(
+        xngin_session,
+        testing_datasource.ds,
+        experiment_type=ExperimentsType.MAB_ONLINE,
+        prior_type=PriorTypes.BETA,
+        reward_type=LikelihoodTypes.BERNOULLI,
+    )
+
+    assert await select_experiments_to_pull() == [due.id]
+
+
+async def test_pull_all_experiments_isolates_a_failing_experiment(xngin_session, testing_datasource):
+    """One experiment that cannot be read must not stop the others in the same run."""
+    broken = await make_mab_dwh_experiment(xngin_session, testing_datasource.ds, target_field_name="is_onboarded")
+    broken.datasource_table = "no_such_table"
+    healthy = await make_mab_dwh_experiment(xngin_session, testing_datasource.ds, target_field_name="is_onboarded")
+    await xngin_session.commit()
+    await create_assignment_for_participant(xngin_session, broken, "1", None, random_state=66)
+    await create_assignment_for_participant(xngin_session, healthy, "2", None, random_state=67)
+
+    await pull_all_experiments(PULL_TIMEOUT_SECS)
+
+    assert await read_outcomes(xngin_session, broken.id) == {"1": None}
+    assert await read_outcomes(xngin_session, healthy.id) == {"2": 1.0}
+
+
+async def test_pull_all_experiments_covers_every_due_experiment(xngin_session, testing_datasource):
+    first = await make_mab_dwh_experiment(xngin_session, testing_datasource.ds, target_field_name="is_onboarded")
+    second = await make_mab_dwh_experiment(xngin_session, testing_datasource.ds, target_field_name="is_onboarded")
+    await create_assignment_for_participant(xngin_session, first, "1", None, random_state=66)
+    await create_assignment_for_participant(xngin_session, second, "2", None, random_state=67)
+
+    await pull_all_experiments(PULL_TIMEOUT_SECS)
+
+    assert await read_outcomes(xngin_session, first.id) == {"1": 0.0}
+    assert await read_outcomes(xngin_session, second.id) == {"2": 1.0}
+
+
+async def test_apull_runs_within_a_database_session(mocker):
+    @contextlib.asynccontextmanager
+    async def noop_setup():
+        yield
+
+    mocker.patch("xngin.apiserver.dwhpull.cli.database.setup", noop_setup)
+    pull_mock = mocker.patch("xngin.apiserver.dwhpull.cli.dwhpull.pull_all_experiments")
+
+    await cli.apull(pull_timeout=42)
+
+    pull_mock.assert_awaited_once_with(42)
+
+
+def test_pull_command_passes_max_time_flag(mocker):
+    """The Typer wiring reaches the async entrypoint with the parsed flag."""
+    mocker.patch("xngin.apiserver.dwhpull.cli.secretservice.setup")
+    apull_mock = mocker.patch("xngin.apiserver.dwhpull.cli.apull")
+
+    result = CliRunner().invoke(cli.app, ["--max-time", "7"])
+
+    assert result.exit_code == 0, result.output
+    apull_mock.assert_called_once_with(7)

--- a/src/xngin/apiserver/dwhpull/test_dwhpull.py
+++ b/src/xngin/apiserver/dwhpull/test_dwhpull.py
@@ -3,7 +3,6 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 from sqlalchemy import select
-from typer.testing import CliRunner
 
 from xngin.apiserver.dwhpull import cli
 from xngin.apiserver.dwhpull.dwhpull import (
@@ -221,14 +220,3 @@ async def test_apull_runs_within_a_database_session(mocker):
     await cli.apull(pull_timeout=42)
 
     pull_mock.assert_awaited_once_with(42)
-
-
-def test_pull_command_passes_max_time_flag(mocker):
-    """The Typer wiring reaches the async entrypoint with the parsed flag."""
-    mocker.patch("xngin.apiserver.dwhpull.cli.secretservice.setup")
-    apull_mock = mocker.patch("xngin.apiserver.dwhpull.cli.apull")
-
-    result = CliRunner().invoke(cli.app, ["--max-time", "7"])
-
-    assert result.exit_code == 0, result.output
-    apull_mock.assert_called_once_with(7)

--- a/src/xngin/apiserver/routers/admin/test_admin_api.py
+++ b/src/xngin/apiserver/routers/admin/test_admin_api.py
@@ -93,7 +93,10 @@ from xngin.apiserver.routers.experiments.test_experiments_common import (
 )
 from xngin.apiserver.settings import Dsn
 from xngin.apiserver.testing.admin_api_client import AdminAPIClient
-from xngin.apiserver.testing.experiments_api_client import ExperimentsAPIClient
+from xngin.apiserver.testing.experiments_api_client import (
+    ExperimentsAPIClient,
+    ExperimentsAPIClientNotDefaultStatusError,
+)
 from xngin.apiserver.testing.testing_dwh_def import TESTING_DWH_PARTICIPANT_DEF
 from xngin.apiserver.testing.wide_dwh_def import WIDE_DWH_PARTICIPANT_DEF
 
@@ -2572,13 +2575,14 @@ def test_cmab_experiments_analyze(testing_bandit_experiment, aclient: AdminAPICl
         assert analysis.post_pred_stdev is not None
 
 
-async def test_create_and_update_outcome_mab_dwh_happy_path(
+async def test_create_and_assign_mab_dwh_rejects_pushed_outcome(
     testing_datasource,
     aclient: AdminAPIClient,
     eclient: ExperimentsAPIClient,
 ):
-    """End-to-end happy path for a MAB-DWH experiment through the public APIs: create it via the
-    admin client, assign a participant, push an outcome, and read the outcome back."""
+    """End-to-end path for a MAB-DWH experiment through the public APIs: create it via the admin
+    client and assign a participant. Outcomes arrive from the organization's data warehouse via
+    xngin-dwh-pull, so the push endpoint rejects them and the draw stays unresolved."""
     experiment = await make_bandit_online_experiment(
         aclient,
         testing_datasource.datasource_id,
@@ -2599,14 +2603,16 @@ async def test_create_and_update_outcome_mab_dwh_happy_path(
     assert assignment is not None
     assert assignment.outcome is None
 
-    # Push an outcome. The default target column ("is_onboarded") is boolean, so the outcome must be 0 or 1.
-    eclient.update_bandit_arm_with_participant_outcome(
-        api_key=testing_datasource.key,
-        body=UpdateBanditArmOutcomeRequest(outcome=1.0),
-        experiment_id=experiment_id,
-        participant_id="p1",
-    )
+    with pytest.raises(ExperimentsAPIClientNotDefaultStatusError) as exc:
+        eclient.update_bandit_arm_with_participant_outcome(
+            api_key=testing_datasource.key,
+            body=UpdateBanditArmOutcomeRequest(outcome=1.0),
+            experiment_id=experiment_id,
+            participant_id="p1",
+        )
+    assert exc.value.result.status == HTTPStatus.UNPROCESSABLE_CONTENT, exc.value.result.data
 
+    # The rejected push leaves the draw untouched, so a later pull can still fill it.
     updated = eclient.get_assignment(
         api_key=testing_datasource.key,
         experiment_id=experiment_id,
@@ -2614,8 +2620,8 @@ async def test_create_and_update_outcome_mab_dwh_happy_path(
         create_if_none=False,
     ).data.assignment
     assert updated is not None
-    assert updated.outcome == 1.0
-    assert updated.observed_at is not None
+    assert updated.outcome is None
+    assert updated.observed_at is None
 
 
 async def test_mab_experiments_analyze_ignores_unobserved_draws_with_single_outcome(

--- a/src/xngin/apiserver/routers/admin_integrations/admin_integrations_api.py
+++ b/src/xngin/apiserver/routers/admin_integrations/admin_integrations_api.py
@@ -568,6 +568,6 @@ async def get_experiment_sample_calls(
         session,
         ds,
         experiment_id,
-        preload=[tables.Experiment.experiment_fields, tables.Experiment.experiment_filters],
+        preload=[tables.Experiment.experiment_filters],
     )
     return make_sample_calls(experiment)

--- a/src/xngin/apiserver/routers/experiments/experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_api.py
@@ -389,6 +389,8 @@ async def get_assignment_cmab(
     Used only for bandit experiments.
 
     Prerequisites:
+    - The experiment must record outcomes through this API. Experiments of type `mab_online_dwh`
+      read their outcomes from a connected data warehouse instead, and reject this call.
     - The participant must already have an assignment. Create one with the GET assignment endpoint
       first.
     - The participant must not already have a recorded outcome. Use the GET assignment endpoint to
@@ -403,6 +405,12 @@ async def update_bandit_arm_with_participant_outcome(
     experiment: Annotated[tables.Experiment, Depends(experiment_and_datasource_dependency)],
     session: Annotated[AsyncSession, Depends(xngin_db_session)],
 ) -> ArmBandit:
+    if experiment.experiment_type == ExperimentsType.MAB_ONLINE_DWH.value:
+        raise LateValidationError(
+            "Cannot record an outcome for this experiment because it reads outcomes from a connected "
+            "data warehouse. Remove this call from your integration."
+        )
+
     # Update the arm with the outcome
     if experiment.experiment_type == ExperimentsType.CMAB_ONLINE.value:
         await experiment.awaitable_attrs.contexts

--- a/src/xngin/apiserver/routers/experiments/experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/experiments_common.py
@@ -939,8 +939,10 @@ def make_sample_calls(experiment: tables.Experiment) -> SampleCalls | None:
     experiment types that have no meaningful example yet (currently CMAB, whose assignment needs a
     context vector).
 
-    Requires experiment.arms to be loaded (experiment.experiment_fields for MAB_ONLINE_DWH
-    experiments, and experiment.experiment_filters for FREQ_ONLINE experiments).
+    MAB_ONLINE_DWH gets no outcome example because the outcome API rejects that type.
+
+    Requires experiment.arms to be loaded (experiment.experiment_filters for FREQ_ONLINE
+    experiments).
     """
     experiment_type = ExperimentsType(experiment.experiment_type)
     if experiment_type.is_cmab():
@@ -981,17 +983,12 @@ def make_sample_calls(experiment: tables.Experiment) -> SampleCalls | None:
         ),
     ]
 
-    if is_bandit and experiment.reward_type is not None:
-        # Pick a type-correct example outcome: 0/1 for a Bernoulli reward or a boolean DWH target
-        # column, otherwise an illustrative number.
+    if is_bandit and experiment.reward_type is not None and experiment_type != ExperimentsType.MAB_ONLINE_DWH:
+        # Pick a type-correct example outcome: 0/1 for a Bernoulli reward, otherwise an illustrative
+        # number.
         outcome_example: float = 1.5
         if LikelihoodTypes(experiment.reward_type) == LikelihoodTypes.BERNOULLI:
             outcome_example = 1
-        elif experiment_type == ExperimentsType.MAB_ONLINE_DWH:
-            # MAB-DWH always has an is_target field (target_field_name is required at create time).
-            target_field = next(ef for ef in experiment.experiment_fields if ef.is_target)
-            if DataType(target_field.data_type).storage_class() is DataTypeStorageClass.BOOLEAN:
-                outcome_example = 1
         outcome_request = UpdateBanditArmOutcomeRequest(outcome=outcome_example)
         outcome_response = ArmBandit(arm_id=arm_id_example, arm_name=arm_name_example)
         calls.append(

--- a/src/xngin/apiserver/routers/experiments/test_experiments_api.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_api.py
@@ -43,7 +43,7 @@ from xngin.apiserver.routers.common_enums import (
     StopAssignmentReason,
     UpdateTypeNormal,
 )
-from xngin.apiserver.routers.experiments.test_experiments_common import make_create_online_bandit_experiment_request
+from xngin.apiserver.routers.experiments.test_experiments_common import insert_experiment_and_arms
 from xngin.apiserver.sqla import tables
 from xngin.apiserver.testing.admin_api_client import AdminAPIClientHTTPValidationError
 from xngin.apiserver.testing.experiments_api_client import ExperimentsAPIClientNotDefaultStatusError
@@ -1202,9 +1202,8 @@ async def test_get_assignment_bandit_cache_headers(
         (ExperimentsType.MAB_ONLINE, PriorTypes.BETA, LikelihoodTypes.BERNOULLI),
         (ExperimentsType.MAB_ONLINE, PriorTypes.NORMAL, LikelihoodTypes.NORMAL),
         (ExperimentsType.MAB_ONLINE, PriorTypes.NORMAL, LikelihoodTypes.BERNOULLI),
-        (ExperimentsType.MAB_ONLINE_DWH, PriorTypes.BETA, LikelihoodTypes.BERNOULLI),
-        (ExperimentsType.MAB_ONLINE_DWH, PriorTypes.NORMAL, LikelihoodTypes.BERNOULLI),
-        (ExperimentsType.MAB_ONLINE_DWH, PriorTypes.NORMAL, LikelihoodTypes.NORMAL),
+        # MAB_ONLINE_DWH is absent: it reads outcomes from the warehouse and rejects this endpoint.
+        # See test_update_bandit_arm_with_outcome_rejected_for_mab_dwh.
         (ExperimentsType.CMAB_ONLINE, PriorTypes.NORMAL, LikelihoodTypes.NORMAL),
         (ExperimentsType.CMAB_ONLINE, PriorTypes.NORMAL, LikelihoodTypes.BERNOULLI),
     ],
@@ -1456,39 +1455,6 @@ async def test_update_bandit_arm_with_outcome(
     assert exc.value.result.status == HTTPStatus.UNPROCESSABLE_CONTENT
 
 
-async def test_update_bandit_arm_with_outcome_mab_dwh_numeric_target_accepts_any_float(
-    testing_datasource, aclient: AdminAPIClient, eclient: ExperimentsAPIClient
-):
-    """A MAB-DWH numeric target accepts arbitrary floats through the API."""
-    request = make_create_online_bandit_experiment_request(
-        experiment_type=ExperimentsType.MAB_ONLINE_DWH,
-        prior_type=PriorTypes.NORMAL,
-        reward_type=LikelihoodTypes.NORMAL,
-        target_field_name="current_income",
-    )
-    experiment_id = aclient.create_experiment(
-        datasource_id=testing_datasource.datasource_id, body=request, random_state=42
-    ).data.experiment_id
-    aclient.commit_experiment(datasource_id=testing_datasource.datasource_id, experiment_id=experiment_id)
-    eclient.get_assignment(api_key=testing_datasource.key, experiment_id=experiment_id, participant_id="p1")
-
-    eclient.update_bandit_arm_with_participant_outcome(
-        api_key=testing_datasource.key,
-        body=UpdateBanditArmOutcomeRequest(outcome=42.7),
-        experiment_id=experiment_id,
-        participant_id="p1",
-    )
-    assignment = eclient.get_assignment(
-        api_key=testing_datasource.key,
-        experiment_id=experiment_id,
-        participant_id="p1",
-        create_if_none=False,
-    ).data.assignment
-    assert assignment is not None
-    assert assignment.outcome == 42.7
-    assert assignment.observed_at is not None
-
-
 @pytest.mark.parametrize("experiment_type", [ExperimentsType.FREQ_ONLINE, ExperimentsType.FREQ_PREASSIGNED])
 async def test_update_bandit_arm_with_freq_experiments_returns_422(
     testing_datasource, aclient: AdminAPIClient, eclient: ExperimentsAPIClient, experiment_type: ExperimentsType
@@ -1621,3 +1587,21 @@ async def test_update_bandit_arm_with_outcome_rejects_non_numeric_outcome(
         json={"outcome": "not-a-float"},
     )
     assert response.status_code == HTTPStatus.UNPROCESSABLE_CONTENT, response.content
+
+
+async def test_update_bandit_arm_with_outcome_rejected_for_mab_dwh(
+    xngin_session, testing_datasource, eclient: ExperimentsAPIClient
+):
+    """MAB-DWH outcomes are read from the org's DWH; the push endpoint rejects the type."""
+    experiment = await insert_experiment_and_arms(
+        xngin_session,
+        testing_datasource.ds,
+        experiment_type=ExperimentsType.MAB_ONLINE_DWH,
+    )
+    response = eclient.client.post(
+        f"/v1/experiments/{experiment.id}/assignments/1/outcome",
+        headers={"X-API-Key": testing_datasource.key},
+        json={"outcome": 1.0},
+    )
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_CONTENT, response.content
+    assert "reads outcomes from a connected data warehouse" in response.text

--- a/src/xngin/apiserver/routers/experiments/test_experiments_common.py
+++ b/src/xngin/apiserver/routers/experiments/test_experiments_common.py
@@ -2825,41 +2825,37 @@ async def test_arm_population_counter(xngin_session, testing_datasource):
 def _in_memory_experiment(
     experiment_type: ExperimentsType,
     reward_type: LikelihoodTypes = LikelihoodTypes.NORMAL,
-    target_data_type: DataType | None = None,
     arms: list[tables.Arm] | None = None,
 ) -> tables.Experiment:
     """An in-memory (unpersisted) experiment with just the attributes make_sample_calls reads."""
-    fields = []
-    if target_data_type is not None:
-        fields = [tables.ExperimentField(field_name="target_col", data_type=target_data_type.value, is_target=True)]
     return tables.Experiment(
         id="exp_abc123",
         experiment_type=experiment_type.value,
         reward_type=reward_type.value,
-        experiment_fields=fields,
         arms=arms or [],
     )
 
 
 @pytest.mark.parametrize(
-    ("reward_type", "target_data_type", "expected_outcome"),
+    ("reward_type", "expected_outcome"),
     [
-        (LikelihoodTypes.BERNOULLI, None, 1),  # bernoulli MAB => binary
-        (LikelihoodTypes.NORMAL, None, 1.5),  # normal MAB => real
-        (LikelihoodTypes.NORMAL, DataType.BOOLEAN, 1),  # dwh boolean target => binary even under normal reward
-        (LikelihoodTypes.NORMAL, DataType.NUMERIC, 1.5),  # dwh numeric target => real
-        (LikelihoodTypes.BERNOULLI, DataType.NUMERIC, 1),  # bernoulli still forces binary
+        (LikelihoodTypes.BERNOULLI, 1),  # bernoulli MAB => binary
+        (LikelihoodTypes.NORMAL, 1.5),  # normal MAB => real
     ],
 )
-def test_make_sample_calls_outcome_example_value(reward_type, target_data_type, expected_outcome):
-    experiment_type = ExperimentsType.MAB_ONLINE_DWH if target_data_type is not None else ExperimentsType.MAB_ONLINE
-    calls = make_sample_calls(
-        _in_memory_experiment(experiment_type, reward_type=reward_type, target_data_type=target_data_type)
-    )
+def test_make_sample_calls_outcome_example_value(reward_type, expected_outcome):
+    calls = make_sample_calls(_in_memory_experiment(ExperimentsType.MAB_ONLINE, reward_type=reward_type))
     assert calls is not None
     assert calls.calls[1].body == {"outcome": expected_outcome}
     assert calls.calls[1].example_response is not None
     assert calls.calls[1].example_response["arm_id"] == "<arm_id>"
+
+
+def test_make_sample_calls_mab_dwh_get_assignment_only():
+    # The outcome API rejects MAB-DWH, so no outcome example is emitted.
+    calls = make_sample_calls(_in_memory_experiment(ExperimentsType.MAB_ONLINE_DWH))
+    assert calls is not None
+    assert [c.label for c in calls.calls] == ["Get assignment"]
 
 
 def test_make_sample_calls_freq_online_without_filters_get_assignment_only():


### PR DESCRIPTION
## Ticket

[EVE-31 — DWH Native bandits](https://idinsight.atlassian.net/browse/EVE-31)

## Description

MAB-DWH experiments read outcomes from the organization's data warehouse rather than having them pushed. (now-closed) #312 did this inside the snapshotter, which coupled two schedules with different requirements. 

This replaces it with a standalone service, `xngin-dwh-pull` (`src/xngin/apiserver/dwhpull/`), modelled on `apiserver/snapshots/`: find committed MAB-DWH experiments in their active window, read the target column for draws with no outcome, and apply each value through `update_bandit_arm_with_outcome_impl` so push and pull share one update path. Per-experiment failures are isolated and reported to Sentry.

NBs:
1. All phases run in one transaction, with draws locked.
2. The push endpoint now returns 422 for `mab_online_dwh`. 
3. No new tables, columns or migrations. 
4. Other experiment types are unchanged. 
5. Railway deployment is deliberately excluded for this PR.

## Future Tasks (optional)
- Railway deployment.
- Thinking about scale / batching - ties in with other debates / PRs already floating around the team atm.
- Probably an update to the documentation once we roll out with Railway (we should document this as clearly as poss! maybe even have a demo video?)

## How has this been tested?

New tests added - all pass.

## Checklist

  - [x] I have updated the automated tests
  - [ ] I have updated affected documentation
  - [ ] I have updated the CI/CD scripts in `.github/workflows/`