### PR TITLE
Compute cluster ICC/CV from per-cluster sufficient statistics in SQL

### DIFF
--- a/src/xngin/apiserver/dwh/queries.py
+++ b/src/xngin/apiserver/dwh/queries.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 import sqlalchemy
 from sqlalchemy import (
@@ -151,22 +151,26 @@ def get_stats_on_filters(
     return [query(col_name, ptype_fd) for col_name, ptype_fd in filter_schema.items() if db_schema.get(col_name)]
 
 
-def get_cluster_outcome_data(
+def get_cluster_sufficient_stats(
     session: Session,
     sa_table: Table,
     cluster_column_name: str,
     outcome_column_names: Sequence[str],
     filters: list[Filter],
+    outcome_shifts: Mapping[str, float] | None = None,
 ) -> Sequence[RowMapping]:
-    """Fetch cluster and outcome data for cluster power statistics in a single query.
+    """Fetch per-cluster sufficient statistics for cluster power calculations.
 
-    Each row returned is a SQLAlchemy ``RowMapping`` (by column name; same keys as
-    ``cluster_column_name`` / ``outcome_column_names``). Outcomes are SQL-cast to Float.
+    Returns one ``RowMapping`` per cluster with ``rows__count`` (all rows, including rows
+    whose outcomes are null: metrics are outcomes that may be filled in as the experiment
+    runs, so cluster-size statistics must count the full population) and, per outcome,
+    ``{name}__count``, ``{name}__sum``, and ``{name}__sumsq`` over that outcome's non-null
+    values. ICC and cluster-size statistics can be computed exactly from these without
+    fetching individual rows. Outcomes are SQL-cast to Float.
 
-    Rows are restricted to non-null cluster keys, but rows where an outcome is null are
-    included (with a None value): metrics are outcomes that may be filled in as the
-    experiment runs, so cluster-size statistics must count the full population, while ICC
-    calculations drop each outcome's nulls individually.
+    ``outcome_shifts`` optionally maps outcome names to a constant subtracted from each
+    value before summing (e.g. the metric's approximate mean). ICC is shift-invariant, and
+    centered sums avoid the precision loss of summing squares of large raw values.
     """
     if cluster_column_name not in sa_table.c:
         raise LateValidationError(f"Cluster column '{cluster_column_name}' not found in table")
@@ -177,7 +181,7 @@ def get_cluster_outcome_data(
     cluster_col = sa_table.c[cluster_column_name]
     filters_expr = create_query_filters(sa_table, filters)
 
-    outcome_cols = []
+    select_columns: list[Label] = [func.count().label("rows__count")]
     for outcome_column_name in outcome_column_names:
         outcome_col = sa_table.c[outcome_column_name]
         # PostgreSQL cannot cast BOOLEAN directly to FLOAT; go through INTEGER first.
@@ -185,11 +189,16 @@ def get_cluster_outcome_data(
             cast_outcome = cast(cast(outcome_col, Integer), Float)
         else:
             cast_outcome = cast(outcome_col, Float)
-        outcome_cols.append(cast_outcome.label(outcome_column_name))
+        shift = (outcome_shifts or {}).get(outcome_column_name, 0.0)
+        shifted = cast_outcome - shift
+        select_columns.extend((
+            func.count(outcome_col).label(f"{outcome_column_name}__count"),
+            func.sum(shifted).label(f"{outcome_column_name}__sum"),
+            func.sum(shifted * shifted).label(f"{outcome_column_name}__sumsq"),
+        ))
 
-    query = select(cluster_col, *outcome_cols).where(cluster_col.is_not(None), *filters_expr)
+    query = select(*select_columns).where(cluster_col.is_not(None), *filters_expr).group_by(cluster_col)
 
-    # Explicitly ask for dict-like RowMapping objects for downstream use of each row as a dict.
     results = session.execute(query).mappings().fetchall()
 
     if not results:

--- a/src/xngin/apiserver/routers/admin/admin_api.py
+++ b/src/xngin/apiserver/routers/admin/admin_api.py
@@ -2290,6 +2290,13 @@ async def power_check(
                 for metric_stat in metric_stats
                 if request_metrics_by_name[metric_stat.field_name].icc is None
             ]
+            # Shifting each metric by its mean keeps the sums of squares in the
+            # sufficient-statistics query numerically stable.
+            outcome_shifts = {
+                metric_stat.field_name: metric_stat.metric_baseline
+                for metric_stat in metric_stats
+                if metric_stat.field_name in db_derived_metrics and metric_stat.metric_baseline is not None
+            }
             db_cluster_stats = (
                 await asyncio.to_thread(
                     calculate_cluster_stats_from_database,
@@ -2298,6 +2305,7 @@ async def power_check(
                     cluster_key,
                     db_derived_metrics,
                     filters,
+                    outcome_shifts,
                 )
                 if db_derived_metrics
                 else {}

--- a/src/xngin/apiserver/routers/power_adapters.py
+++ b/src/xngin/apiserver/routers/power_adapters.py
@@ -1,15 +1,15 @@
 """Bridges database queries with cluster power / ICC stats functions."""
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
-import pandas as pd
+import numpy as np
 from sqlalchemy import Table
 from sqlalchemy.orm import Session
 
-from xngin.apiserver.dwh.queries import get_cluster_outcome_data
+from xngin.apiserver.dwh.queries import get_cluster_sufficient_stats
 from xngin.apiserver.exceptions_common import LateValidationError
 from xngin.apiserver.routers.common_api_types import Filter
-from xngin.stats.cluster_icc import calculate_icc_from_dataframe
+from xngin.stats.cluster_icc import calculate_icc_from_sufficient_stats
 from xngin.stats.stats_errors import StatsPowerError
 
 
@@ -19,13 +19,13 @@ def calculate_cluster_stats_from_database(
     cluster_column: str,
     outcome_columns: Sequence[str],
     filters: list[Filter],
+    outcome_shifts: Mapping[str, float] | None = None,
 ) -> dict[str, dict[str, float]]:
     """
     Calculate ICC and cluster statistics for one or more metrics from a DWH table.
 
-    Fetches all metrics' outcome data in a single DWH query, then computes the stats in
-    pandas. Orchestrates DWH queries with stats calculations, keeping the stats layer
-    free of SQLAlchemy dependencies.
+    Fetches per-cluster sufficient statistics for all metrics in a single DWH query, then
+    computes the stats in pure Python: only the query touches the database session.
 
     Args:
         session: SQLAlchemy session for the DWH
@@ -33,34 +33,40 @@ def calculate_cluster_stats_from_database(
         cluster_column: Column name containing cluster IDs
         outcome_columns: Column names containing outcome values
         filters: List of filters to apply
+        outcome_shifts: Optional per-outcome constants (e.g. approximate means) subtracted
+            in SQL before summing, to keep the sums of squares numerically stable
 
     Returns:
         dict keyed by outcome column name, each value a dict with keys:
         icc, avg_cluster_size, cv
     """
-    data = get_cluster_outcome_data(session, sa_table, cluster_column, outcome_columns, filters)
-    df = pd.DataFrame(data)
+    rows = get_cluster_sufficient_stats(session, sa_table, cluster_column, outcome_columns, filters, outcome_shifts)
 
     # Cluster sizes and CV are computed over every row with a cluster key, including rows
     # whose outcome values are null: metrics are outcomes that may be filled in as the
     # experiment runs, so the analysis-time cluster size is the full-population size.
     # Do not narrow this to each outcome's non-null rows.
-    sizes = df.groupby(cluster_column).size()
+    sizes = np.array([row["rows__count"] for row in rows], dtype=np.float64)
     avg_cluster_size = float(sizes.mean())
-    # ddof=0 is the population stddev, matching the SQL stddev_pop this replaced.
-    cv = float(sizes.std(ddof=0) / sizes.mean())
+    # np.std defaults to the population stddev, matching the SQL stddev_pop this replaced.
+    cv = float(sizes.std() / sizes.mean())
 
     stats_by_outcome: dict[str, dict[str, float]] = {}
     for outcome_column in outcome_columns:
-        # ICC uses only rows with a value for this outcome, mirroring the per-metric
+        # ICC uses only clusters with values for this outcome, mirroring the per-metric
         # "outcome IS NOT NULL" filter used when each metric was queried separately.
-        outcome_df = df[[cluster_column, outcome_column]].dropna(subset=[outcome_column])
-        if outcome_df.empty:
+        counts = np.array([row[f"{outcome_column}__count"] for row in rows], dtype=np.float64)
+        has_values = counts > 0
+        if not has_values.any():
             raise LateValidationError(
                 f"No data found for cluster column '{cluster_column}' and outcome '{outcome_column}'"
             )
         try:
-            icc = calculate_icc_from_dataframe(outcome_df, cluster_column=cluster_column, outcome_column=outcome_column)
+            icc = calculate_icc_from_sufficient_stats(
+                counts=counts[has_values],
+                sums=np.array([row[f"{outcome_column}__sum"] for row in rows], dtype=np.float64)[has_values],
+                sumsqs=np.array([row[f"{outcome_column}__sumsq"] for row in rows], dtype=np.float64)[has_values],
+            )
         except ValueError as verr:
             raise StatsPowerError.from_error(verr, outcome_column) from verr
         stats_by_outcome[outcome_column] = {

--- a/src/xngin/apiserver/routers/test_power_adapters.py
+++ b/src/xngin/apiserver/routers/test_power_adapters.py
@@ -168,6 +168,23 @@ def test_batched_matches_individual_queries(clustered_dwh_session, sa_table):
         assert batched[outcome_column]["cv"] == pytest.approx(individual["cv"])
 
 
+def test_outcome_shifts_do_not_change_results(clustered_dwh_session, sa_table):
+    """Shifting outcomes by a constant in SQL leaves ICC and cluster stats unchanged."""
+    kwargs = {
+        "session": clustered_dwh_session,
+        "sa_table": sa_table,
+        "cluster_column": "cluster_moderate",
+        "outcome_columns": ["income", "converted"],
+        "filters": [],
+    }
+    unshifted = calculate_cluster_stats_from_database(**kwargs)
+    shifted = calculate_cluster_stats_from_database(**kwargs, outcome_shifts={"income": 50000.0, "converted": 0.5})
+
+    for outcome_column, stats in unshifted.items():
+        for key, value in stats.items():
+            assert shifted[outcome_column][key] == pytest.approx(value), f"{outcome_column}.{key}"
+
+
 def test_null_outcomes_dropped_per_metric_but_counted_in_cluster_sizes(clustered_dwh_session, wide_dwh_sa_table):
     """Null outcome values are dropped from ICC but still counted in cluster sizes.
 

--- a/src/xngin/stats/cluster_icc.py
+++ b/src/xngin/stats/cluster_icc.py
@@ -5,8 +5,13 @@ These functions accept dataframes rather than database sessions, following the p
 established in analysis.py. The API layer is responsible for fetching data from the DWH.
 """
 
+from collections.abc import Sequence
+
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
+
+type _FloatArray = Sequence[float] | npt.NDArray[np.float64]
 
 
 def _icc_one_way_random_intercept(df: pd.DataFrame, *, cluster_column: str, outcome_column: str) -> float:
@@ -50,6 +55,70 @@ def _icc_one_way_random_intercept(df: pd.DataFrame, *, cluster_column: str, outc
 
     # 4. Final calculation of ICC as the ratio of between-cluster variance to total variance.
     # If MSB < MSW, the point estimate for sigma_b is 0 (prevents negative ICC)
+    var_between = max(0.0, (msb - msw) / n0)
+    var_within = msw
+    total_var = var_between + var_within
+    if total_var == 0:
+        return 0.0
+
+    return float(np.clip(var_between / total_var, 0.0, 1.0))
+
+
+def calculate_icc_from_sufficient_stats(
+    *,
+    counts: _FloatArray,
+    sums: _FloatArray,
+    sumsqs: _FloatArray,
+) -> float:
+    """
+    Calculate intraclass correlation (ICC) from per-cluster sufficient statistics.
+
+    Computes the same one-way random-effects ANOVA estimator as
+    calculate_icc_from_dataframe, but from one (count, sum, sum-of-squares) triple per
+    cluster instead of individual observations. The sums may be over values shifted by
+    any per-metric constant (ICC is shift-invariant); all three arrays must describe the
+    same non-null observations and use the same shift.
+
+    Args:
+        counts: Number of non-null observations in each cluster; all must be > 0
+        sums: Sum of the observations in each cluster
+        sumsqs: Sum of the squared observations in each cluster
+
+    Returns:
+        ICC value between 0 and 1
+
+    Raises:
+        ValueError: If there are fewer than 2 clusters or insufficient observations
+    """
+    n = np.asarray(counts, dtype=np.float64)
+    s = np.asarray(sums, dtype=np.float64)
+    q = np.asarray(sumsqs, dtype=np.float64)
+    if not (len(n) == len(s) == len(q)):
+        raise ValueError("counts, sums, and sumsqs must have the same length")
+    if np.any(n <= 0):
+        raise ValueError("counts must all be positive; drop clusters without observations")
+
+    k = len(n)
+    if k < 2:
+        raise ValueError("Need at least 2 clusters to calculate ICC")
+    n_total = float(n.sum())
+    df_b = k - 1
+    df_w = n_total - k
+    if df_w < 1:
+        raise ValueError("Insufficient within-cluster data (need N > clusters)")
+
+    # ANOVA sums of squares via the identity sum((x - mean)^2) = sum(x^2) - sum(x)^2 / n.
+    # Each term is a sum of squares, so clamp tiny negative floating-point results to 0.
+    between_terms = s**2 / n
+    ssw = max(0.0, float(q.sum() - between_terms.sum()))
+    ssb = max(0.0, float(between_terms.sum() - s.sum() ** 2 / n_total))
+    msb = ssb / df_b
+    msw = ssw / df_w
+
+    # n0 is the "effective cluster size" adjustment for unequal cluster sizes.
+    n0 = (n_total - float((n**2).sum()) / n_total) / df_b
+
+    # If MSB < MSW, the point estimate for sigma_b is 0 (prevents negative ICC).
     var_between = max(0.0, (msb - msw) / n0)
     var_within = msw
     total_var = var_between + var_within

--- a/src/xngin/stats/test_cluster_icc.py
+++ b/src/xngin/stats/test_cluster_icc.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from xngin.stats.cluster_icc import calculate_icc_from_dataframe
+from xngin.stats.cluster_icc import calculate_icc_from_dataframe, calculate_icc_from_sufficient_stats
 
 
 class TestICCFromDataFrame:
@@ -102,3 +102,92 @@ class TestICCFromDataFrame:
         icc = calculate_icc_from_dataframe(df, cluster_column="id", outcome_column="_y")
         assert 0.0 <= icc <= 1.0
         assert icc == pytest.approx(0.8571, abs=1e-4)
+
+
+def _sufficient_stats(
+    cluster_ids: np.ndarray, y: np.ndarray, shift: float = 0.0
+) -> tuple[list[float], list[float], list[float]]:
+    """Per-cluster (count, sum, sumsq) triples, as get_cluster_sufficient_stats returns them."""
+    shifted = y - shift
+    counts, sums, sumsqs = [], [], []
+    for cluster_id in np.unique(cluster_ids):
+        values = shifted[cluster_ids == cluster_id]
+        counts.append(float(len(values)))
+        sums.append(float(values.sum()))
+        sumsqs.append(float((values**2).sum()))
+    return counts, sums, sumsqs
+
+
+def test_sufficient_stats_matches_dataframe_icc():
+    """The sufficient-statistics estimator equals the per-observation one, shifted or not."""
+    rng = np.random.default_rng(7)
+    cluster_sizes = rng.integers(2, 30, size=50)
+    cluster_ids = np.repeat(np.arange(len(cluster_sizes)), cluster_sizes)
+    cluster_means = rng.normal(loc=100, scale=10, size=len(cluster_sizes))
+    y = np.repeat(cluster_means, cluster_sizes) + rng.normal(0, 20, size=len(cluster_ids))
+
+    expected = calculate_icc_from_dataframe(
+        pd.DataFrame({"id": cluster_ids, "y": y}), cluster_column="id", outcome_column="y"
+    )
+    for shift in (0.0, float(y.mean())):
+        counts, sums, sumsqs = _sufficient_stats(cluster_ids, y, shift)
+        icc = calculate_icc_from_sufficient_stats(counts=counts, sums=sums, sumsqs=sumsqs)
+        assert icc == pytest.approx(expected, rel=1e-9)
+
+
+def test_sufficient_stats_matches_dataframe_icc_binary():
+    """Equivalence also holds for 0/1 outcomes, where sumsq equals sum."""
+    rng = np.random.default_rng(11)
+    cluster_ids = np.repeat(np.arange(40), 25)
+    p_by_cluster = rng.uniform(0.2, 0.8, size=40)
+    y = (rng.uniform(size=len(cluster_ids)) < np.repeat(p_by_cluster, 25)).astype(np.float64)
+
+    expected = calculate_icc_from_dataframe(
+        pd.DataFrame({"id": cluster_ids, "y": y}), cluster_column="id", outcome_column="y"
+    )
+    counts, sums, sumsqs = _sufficient_stats(cluster_ids, y)
+    assert sumsqs == sums
+    icc = calculate_icc_from_sufficient_stats(counts=counts, sums=sums, sumsqs=sumsqs)
+    assert icc == pytest.approx(expected, rel=1e-9)
+
+
+def test_sufficient_stats_shift_restores_precision_for_large_means():
+    """Raw sums of squares lose precision when the mean dwarfs the variance; shifting fixes it."""
+    rng = np.random.default_rng(3)
+    cluster_ids = np.repeat(np.arange(30), 20)
+    y = 1e9 + np.repeat(rng.normal(0, 1, size=30), 20) + rng.normal(0, 2, size=len(cluster_ids))
+
+    expected = calculate_icc_from_dataframe(
+        pd.DataFrame({"id": cluster_ids, "y": y}), cluster_column="id", outcome_column="y"
+    )
+    counts, sums, sumsqs = _sufficient_stats(cluster_ids, y, shift=1e9)
+    icc = calculate_icc_from_sufficient_stats(counts=counts, sums=sums, sumsqs=sumsqs)
+    assert icc == pytest.approx(expected, rel=1e-6)
+
+
+def test_sufficient_stats_perfect_and_zero_clustering():
+    assert calculate_icc_from_sufficient_stats(
+        counts=[3, 3, 3],
+        sums=[30, 60, 90],  # constant within cluster: 10s, 20s, 30s
+        sumsqs=[300, 1200, 2700],
+    ) == pytest.approx(1.0)
+    assert calculate_icc_from_sufficient_stats(
+        counts=[3, 3, 3],
+        sums=[60, 60, 60],  # identical clusters: 10, 20, 30 in each
+        sumsqs=[1400, 1400, 1400],
+    ) == pytest.approx(0.0, abs=0.01)
+
+
+def test_sufficient_stats_constant_outcome_returns_zero():
+    assert calculate_icc_from_sufficient_stats(counts=[2, 2], sums=[10, 10], sumsqs=[50, 50]) == 0.0
+
+
+def test_sufficient_stats_validation_errors():
+    with pytest.raises(ValueError, match="Need at least 2 clusters"):
+        calculate_icc_from_sufficient_stats(counts=[3], sums=[30], sumsqs=[300])
+    with pytest.raises(ValueError, match="Insufficient within-cluster data"):
+        calculate_icc_from_sufficient_stats(counts=[1, 1], sums=[10, 20], sumsqs=[100, 400])
+    with pytest.raises(ValueError, match="same length"):
+        calculate_icc_from_sufficient_stats(counts=[2, 2], sums=[10], sumsqs=[50, 50])
+    with pytest.raises(ValueError, match="counts must all be positive"):
+        calculate_icc_from_sufficient_stats(counts=[2, 0], sums=[10, 0], sumsqs=[50, 0])


### PR DESCRIPTION
Compute cluster ICC/CV from per-cluster sufficient statistics in SQL instead of shipping every row to Python.

**Stacked on #321** — the first commit here belongs to that PR; only the last
commit is under review. The diff collapses to just this change once #321 merges.

## What changed

- `get_cluster_outcome_data` is replaced by `get_cluster_sufficient_stats`: one
  `GROUP BY cluster` query returning `count(*)` per cluster plus
  `count/sum/sumsq` per metric. One row per cluster crosses the wire instead of
  one per participant.
- New pure function `calculate_icc_from_sufficient_stats` reconstructs the same
  one-way ANOVA ICC exactly from those triples. The query and the math are now
  fully decoupled: only the fetch touches the DWH session.
- pandas is no longer needed in `power_adapters.py`.
- Null semantics are unchanged: cluster sizes/CV count all rows (`count(*)`),
  ICC uses each metric's non-null values (`count(x)`/`sum(x)` skip nulls).

## Numerical stability

`sum(x*x)` loses precision when a metric's mean dwarfs its variance. Each
metric's mean (already fetched by `get_stats_on_metrics`) is passed as a shift
subtracted in SQL before summing; ICC is shift-invariant, so results are
unchanged (covered by tests, including a mean-1e9 case).

## Tests

- Equivalence tests: the sufficient-stats estimator matches
  `calculate_icc_from_dataframe` on unequal clusters, binary outcomes, and
  shifted data.
- All pre-existing `test_power_adapters.py` tests pass unchanged against
  Postgres, including the exact-value null-handling test.