### PR TITLE
Separate DWH queries from stats computation in power_check

### DIFF
--- a/src/xngin/apiserver/dwh/queries.py
+++ b/src/xngin/apiserver/dwh/queries.py
@@ -19,7 +19,6 @@ from xngin.apiserver.dwh.inspection_types import FieldDescriptor
 from xngin.apiserver.dwh.query_constructors import create_query_filters
 from xngin.apiserver.exceptions_common import LateValidationError
 from xngin.apiserver.routers.common_api_types import (
-    DesignSpecMetric,
     DesignSpecMetricRequest,
     Filter,
     GetFiltersResponseDiscrete,
@@ -29,26 +28,30 @@ from xngin.apiserver.routers.common_api_types import (
 from xngin.apiserver.routers.common_enums import FilterClass, MetricType
 
 
-def get_stats_on_metrics(
-    session,
+def get_raw_metric_stats(
+    session: Session,
     sa_table: Table,
     metrics: list[DesignSpecMetricRequest],
     filters: list[Filter],
-) -> list[DesignSpecMetric]:
+) -> RowMapping:
+    """Fetch aggregate metric statistics in a single query.
+
+    Returns one row with ``rows__count`` (total rows matching the filters) and, per
+    metric, ``{name}__mean``, ``{name}__stddev``, and ``{name}__count`` over its non-null
+    values. Use build_metric_stats to turn the row into DesignSpecMetric objects.
+    """
     missing_metrics = {m.field_name for m in metrics if m.field_name not in sa_table.c}
     if len(missing_metrics) > 0:
         raise LateValidationError(f"Missing metrics (check your Datasource configuration): {missing_metrics}")
 
-    # build our query
-    metric_types = [MetricType.from_python_type(sa_table.c[m.field_name].type.python_type) for m in metrics]
     # Include in our list of stats a total count of rows targeted by the audience filters,
     # whereas the individual aggregate functions per metric ignore NULLs by default.
     select_columns: list[Label] = [func.count().label("rows__count")]
-    for metric, metric_type in zip(metrics, metric_types, strict=False):
+    for metric in metrics:
         field_name = metric.field_name
         col = sa_table.c[field_name]
         # Coerce everything to Float to avoid Decimal/Integer/Boolean issues across backends.
-        if metric_type is MetricType.NUMERIC:
+        if MetricType.from_python_type(col.type.python_type) is MetricType.NUMERIC:
             cast_column = cast(col, Float)
         else:  # re: avg(boolean) doesn't work on pg-like backends
             cast_column = cast(cast(col, Integer), Float)
@@ -59,27 +62,7 @@ def get_stats_on_metrics(
         ))
     filters_expr = create_query_filters(sa_table, filters)
     query = select(*select_columns).where(*filters_expr)
-    stats = session.execute(query).mappings().fetchone()
-
-    # finally backfill with the stats
-    metrics_to_return = []
-    for metric, metric_type in zip(metrics, metric_types, strict=False):
-        field_name = metric.field_name
-        metrics_to_return.append(
-            DesignSpecMetric(
-                field_name=metric.field_name,
-                metric_pct_change=metric.metric_pct_change,
-                metric_target=metric.metric_target,
-                metric_type=metric_type,
-                metric_baseline=stats[f"{field_name}__mean"],
-                metric_stddev=stats[f"{field_name}__stddev"] if metric_type is MetricType.NUMERIC else None,
-                available_nonnull_n=stats[f"{field_name}__count"],
-                # This value is the same across all metrics, but we replicate for convenience:
-                available_n=stats["rows__count"],
-            )
-        )
-
-    return metrics_to_return
+    return session.execute(query).mappings().one()
 
 
 def get_stats_on_filters(

--- a/src/xngin/apiserver/dwh/queries.py
+++ b/src/xngin/apiserver/dwh/queries.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 import sqlalchemy
 from sqlalchemy import (
@@ -151,22 +151,26 @@ def get_stats_on_filters(
     return [query(col_name, ptype_fd) for col_name, ptype_fd in filter_schema.items() if db_schema.get(col_name)]
 
 
-def get_cluster_outcome_data(
+def get_cluster_sufficient_stats(
     session: Session,
     sa_table: Table,
     cluster_column_name: str,
     outcome_column_names: Sequence[str],
     filters: list[Filter],
+    outcome_shifts: Mapping[str, float] | None = None,
 ) -> Sequence[RowMapping]:
-    """Fetch cluster and outcome data for cluster power statistics in a single query.
+    """Fetch per-cluster sufficient statistics for cluster power calculations.
 
-    Each row returned is a SQLAlchemy ``RowMapping`` (by column name; same keys as
-    ``cluster_column_name`` / ``outcome_column_names``). Outcomes are SQL-cast to Float.
+    Returns one ``RowMapping`` per cluster with ``rows__count`` (all rows, including rows
+    whose outcomes are null: metrics are outcomes that may be filled in as the experiment
+    runs, so cluster-size statistics must count the full population) and, per outcome,
+    ``{name}__count``, ``{name}__sum``, and ``{name}__sumsq`` over that outcome's non-null
+    values. ICC and cluster-size statistics can be computed exactly from these without
+    fetching individual rows. Outcomes are SQL-cast to Float.
 
-    Rows are restricted to non-null cluster keys, but rows where an outcome is null are
-    included (with a None value): metrics are outcomes that may be filled in as the
-    experiment runs, so cluster-size statistics must count the full population, while ICC
-    calculations drop each outcome's nulls individually.
+    ``outcome_shifts`` optionally maps outcome names to a constant subtracted from each
+    value before summing (e.g. the metric's approximate mean). ICC is shift-invariant, and
+    centered sums avoid the precision loss of summing squares of large raw values.
     """
     if cluster_column_name not in sa_table.c:
         raise LateValidationError(f"Cluster column '{cluster_column_name}' not found in table")
@@ -177,7 +181,7 @@ def get_cluster_outcome_data(
     cluster_col = sa_table.c[cluster_column_name]
     filters_expr = create_query_filters(sa_table, filters)
 
-    outcome_cols = []
+    select_columns: list[Label] = [func.count().label("rows__count")]
     for outcome_column_name in outcome_column_names:
         outcome_col = sa_table.c[outcome_column_name]
         # PostgreSQL cannot cast BOOLEAN directly to FLOAT; go through INTEGER first.
@@ -185,11 +189,16 @@ def get_cluster_outcome_data(
             cast_outcome = cast(cast(outcome_col, Integer), Float)
         else:
             cast_outcome = cast(outcome_col, Float)
-        outcome_cols.append(cast_outcome.label(outcome_column_name))
+        shift = (outcome_shifts or {}).get(outcome_column_name, 0.0)
+        shifted = cast_outcome - shift
+        select_columns.extend((
+            func.count(outcome_col).label(f"{outcome_column_name}__count"),
+            func.sum(shifted).label(f"{outcome_column_name}__sum"),
+            func.sum(shifted * shifted).label(f"{outcome_column_name}__sumsq"),
+        ))
 
-    query = select(cluster_col, *outcome_cols).where(cluster_col.is_not(None), *filters_expr)
+    query = select(*select_columns).where(cluster_col.is_not(None), *filters_expr).group_by(cluster_col)
 
-    # Explicitly ask for dict-like RowMapping objects for downstream use of each row as a dict.
     results = session.execute(query).mappings().fetchall()
 
     if not results:

--- a/src/xngin/apiserver/dwh/test_queries.py
+++ b/src/xngin/apiserver/dwh/test_queries.py
@@ -3,18 +3,30 @@
 import asyncio
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import Table, text
 from sqlalchemy.exc import DataError
+from sqlalchemy.orm import Session
 
 from xngin.apiserver.conftest import DbType, get_queries_test_uri
 from xngin.apiserver.dwh.dwh_session import DwhSession
-from xngin.apiserver.dwh.queries import get_stats_on_metrics
+from xngin.apiserver.dwh.queries import get_raw_metric_stats
 from xngin.apiserver.exceptions_common import LateValidationError
-from xngin.apiserver.routers.common_api_types import DesignSpecMetric, DesignSpecMetricRequest
+from xngin.apiserver.routers.common_api_types import DesignSpecMetric, DesignSpecMetricRequest, Filter
 from xngin.apiserver.routers.common_enums import MetricType
+from xngin.apiserver.routers.power_adapters import build_metric_stats
 from xngin.apiserver.settings import Dsn
 
 pytest_plugins = ("xngin.apiserver.dwh.dwh_test_support",)
+
+
+def get_stats_on_metrics(
+    session: Session,
+    sa_table: Table,
+    metrics: list[DesignSpecMetricRequest],
+    filters: list[Filter],
+) -> list[DesignSpecMetric]:
+    """Compose the query and the pure computation, as power_check does."""
+    return build_metric_stats(get_raw_metric_stats(session, sa_table, metrics, filters), sa_table, metrics)
 
 
 def test_get_stats_on_missing_metric_raises_error(queries_dwh_session, shared_sample_tables):

--- a/src/xngin/apiserver/routers/admin/admin_api.py
+++ b/src/xngin/apiserver/routers/admin/admin_api.py
@@ -2290,6 +2290,13 @@ async def power_check(
                 for metric_stat in metric_stats
                 if request_metrics_by_name[metric_stat.field_name].icc is None
             ]
+            # Shifting each metric by its mean keeps the sums of squares in the
+            # sufficient-statistics query numerically stable.
+            outcome_shifts = {
+                metric_stat.field_name: metric_stat.metric_baseline
+                for metric_stat in metric_stats
+                if metric_stat.field_name in db_derived_metrics and metric_stat.metric_baseline is not None
+            }
             db_cluster_stats = (
                 await asyncio.to_thread(
                     calculate_cluster_stats_from_database,
@@ -2298,6 +2305,7 @@ async def power_check(
                     cluster_key,
                     db_derived_metrics,
                     filters,
+                    outcome_shifts,
                 )
                 if db_derived_metrics
                 else {}

--- a/src/xngin/apiserver/routers/admin/admin_api.py
+++ b/src/xngin/apiserver/routers/admin/admin_api.py
@@ -40,8 +40,9 @@ from xngin.apiserver.dwh.inspections import (
     dehydrate_participants,
 )
 from xngin.apiserver.dwh.queries import (
+    get_cluster_sufficient_stats,
+    get_raw_metric_stats,
     get_stats_on_filters,
-    get_stats_on_metrics,
 )
 from xngin.apiserver.exceptionhandlers import XHTTPValidationError
 from xngin.apiserver.exceptions_common import LateValidationError
@@ -147,7 +148,7 @@ from xngin.apiserver.routers.experiments.experiments_common import (
     make_schema_from_experiment,
 )
 from xngin.apiserver.routers.experiments.experiments_common_csv import CsvStreamingResponse
-from xngin.apiserver.routers.power_adapters import calculate_cluster_stats_from_database
+from xngin.apiserver.routers.power_adapters import build_metric_stats, calculate_cluster_stats
 from xngin.apiserver.settings import (
     NoDwh,
     ParticipantsDef,
@@ -2273,55 +2274,61 @@ async def power_check(
         if cluster_key is not None:
             filters = [*filters, Filter(field_name=cluster_key, relation=Relation.EXCLUDES, value=[None])]
 
-        metric_stats = await asyncio.to_thread(
-            get_stats_on_metrics,
+        # Only queries run inside this block; stats are computed from the raw rows after
+        # the DWH connection is closed.
+        raw_metric_stats = await asyncio.to_thread(
+            get_raw_metric_stats,
             dwh.session,
             sa_table,
             design_spec.metrics,
             filters,
         )
 
-        # Augment with cluster-level stats if this is a cluster-randomized design.
-        if cluster_key is not None:
-            request_metrics_by_name = {m.field_name: m for m in design_spec.metrics}
-            # Derive stats from the dwh only for metrics without user-provided ICC, in one query.
-            db_derived_metrics = [
-                metric_stat.field_name
-                for metric_stat in metric_stats
-                if request_metrics_by_name[metric_stat.field_name].icc is None
-            ]
+        # Derive cluster stats from the dwh only for metrics without user-provided ICC, in one query.
+        db_derived_metrics = (
+            [m.field_name for m in design_spec.metrics if m.icc is None] if cluster_key is not None else []
+        )
+        raw_cluster_stats = None
+        if cluster_key is not None and db_derived_metrics:
             # Shifting each metric by its mean keeps the sums of squares in the
             # sufficient-statistics query numerically stable.
             outcome_shifts = {
-                metric_stat.field_name: metric_stat.metric_baseline
-                for metric_stat in metric_stats
-                if metric_stat.field_name in db_derived_metrics and metric_stat.metric_baseline is not None
+                field_name: raw_metric_stats[f"{field_name}__mean"]
+                for field_name in db_derived_metrics
+                if raw_metric_stats[f"{field_name}__mean"] is not None
             }
-            db_cluster_stats = (
-                await asyncio.to_thread(
-                    calculate_cluster_stats_from_database,
-                    dwh.session,
-                    sa_table,
-                    cluster_key,
-                    db_derived_metrics,
-                    filters,
-                    outcome_shifts,
-                )
-                if db_derived_metrics
-                else {}
+            raw_cluster_stats = await asyncio.to_thread(
+                get_cluster_sufficient_stats,
+                dwh.session,
+                sa_table,
+                cluster_key,
+                db_derived_metrics,
+                filters,
+                outcome_shifts,
             )
-            for metric_stat in metric_stats:
-                req_metric = request_metrics_by_name[metric_stat.field_name]
-                # If the user provided ICC, avg_cluster_size, and cv, use them instead of deriving from the dwh.
-                if req_metric.icc is not None:
-                    metric_stat.icc = req_metric.icc
-                    metric_stat.avg_cluster_size = req_metric.avg_cluster_size
-                    metric_stat.cv = req_metric.cv
-                else:
-                    cluster_stats = db_cluster_stats[metric_stat.field_name]
-                    metric_stat.icc = cluster_stats["icc"]
-                    metric_stat.avg_cluster_size = cluster_stats["avg_cluster_size"]
-                    metric_stat.cv = cluster_stats["cv"]
+
+    metric_stats = build_metric_stats(raw_metric_stats, sa_table, design_spec.metrics)
+
+    # Augment with cluster-level stats if this is a cluster-randomized design.
+    if cluster_key is not None:
+        db_cluster_stats = (
+            calculate_cluster_stats(raw_cluster_stats, cluster_key, db_derived_metrics)
+            if raw_cluster_stats is not None
+            else {}
+        )
+        request_metrics_by_name = {m.field_name: m for m in design_spec.metrics}
+        for metric_stat in metric_stats:
+            req_metric = request_metrics_by_name[metric_stat.field_name]
+            # If the user provided ICC, avg_cluster_size, and cv, use them instead of deriving from the dwh.
+            if req_metric.icc is not None:
+                metric_stat.icc = req_metric.icc
+                metric_stat.avg_cluster_size = req_metric.avg_cluster_size
+                metric_stat.cv = req_metric.cv
+            else:
+                cluster_stats = db_cluster_stats[metric_stat.field_name]
+                metric_stat.icc = cluster_stats["icc"]
+                metric_stat.avg_cluster_size = cluster_stats["avg_cluster_size"]
+                metric_stat.cv = cluster_stats["cv"]
 
     arm_weights = design_spec.get_validated_arm_weights()
 

--- a/src/xngin/apiserver/routers/power_adapters.py
+++ b/src/xngin/apiserver/routers/power_adapters.py
@@ -1,52 +1,74 @@
-"""Bridges database queries with cluster power / ICC stats functions."""
+"""Pure computations turning raw DWH query rows into power / ICC stats.
+
+These functions take the rows fetched by the queries in dwh/queries.py and never touch a
+database session, so callers can run them after the DwhSession block has closed.
+"""
 
 from collections.abc import Mapping, Sequence
+from typing import Any
 
 import numpy as np
 from sqlalchemy import Table
-from sqlalchemy.orm import Session
+from sqlalchemy.engine.row import RowMapping
 
-from xngin.apiserver.dwh.queries import get_cluster_sufficient_stats
 from xngin.apiserver.exceptions_common import LateValidationError
-from xngin.apiserver.routers.common_api_types import Filter
+from xngin.apiserver.routers.common_api_types import DesignSpecMetric, DesignSpecMetricRequest
+from xngin.apiserver.routers.common_enums import MetricType
 from xngin.stats.cluster_icc import calculate_icc_from_sufficient_stats
 from xngin.stats.stats_errors import StatsPowerError
 
 
-def calculate_cluster_stats_from_database(
-    session: Session,
+def build_metric_stats(
+    raw_stats: Mapping[str, Any] | RowMapping,
     sa_table: Table,
+    metrics: list[DesignSpecMetricRequest],
+) -> list[DesignSpecMetric]:
+    """Build DesignSpecMetric objects from the row returned by get_raw_metric_stats."""
+    metrics_to_return = []
+    for metric in metrics:
+        field_name = metric.field_name
+        metric_type = MetricType.from_python_type(sa_table.c[field_name].type.python_type)
+        metrics_to_return.append(
+            DesignSpecMetric(
+                field_name=field_name,
+                metric_pct_change=metric.metric_pct_change,
+                metric_target=metric.metric_target,
+                metric_type=metric_type,
+                metric_baseline=raw_stats[f"{field_name}__mean"],
+                metric_stddev=raw_stats[f"{field_name}__stddev"] if metric_type is MetricType.NUMERIC else None,
+                available_nonnull_n=raw_stats[f"{field_name}__count"],
+                # This value is the same across all metrics, but we replicate for convenience:
+                available_n=raw_stats["rows__count"],
+            )
+        )
+
+    return metrics_to_return
+
+
+def calculate_cluster_stats(
+    cluster_rows: Sequence[Mapping[str, Any] | RowMapping],
     cluster_column: str,
     outcome_columns: Sequence[str],
-    filters: list[Filter],
-    outcome_shifts: Mapping[str, float] | None = None,
 ) -> dict[str, dict[str, float]]:
     """
-    Calculate ICC and cluster statistics for one or more metrics from a DWH table.
-
-    Fetches per-cluster sufficient statistics for all metrics in a single DWH query, then
-    computes the stats in pure Python: only the query touches the database session.
+    Calculate ICC and cluster statistics for one or more metrics from per-cluster
+    sufficient statistics, as returned by get_cluster_sufficient_stats.
 
     Args:
-        session: SQLAlchemy session for the DWH
-        sa_table: SQLAlchemy Table object
-        cluster_column: Column name containing cluster IDs
+        cluster_rows: One mapping per cluster with rows__count and per-outcome
+            {name}__count / {name}__sum / {name}__sumsq keys
+        cluster_column: Cluster column name, used in error messages
         outcome_columns: Column names containing outcome values
-        filters: List of filters to apply
-        outcome_shifts: Optional per-outcome constants (e.g. approximate means) subtracted
-            in SQL before summing, to keep the sums of squares numerically stable
 
     Returns:
         dict keyed by outcome column name, each value a dict with keys:
         icc, avg_cluster_size, cv
     """
-    rows = get_cluster_sufficient_stats(session, sa_table, cluster_column, outcome_columns, filters, outcome_shifts)
-
     # Cluster sizes and CV are computed over every row with a cluster key, including rows
     # whose outcome values are null: metrics are outcomes that may be filled in as the
     # experiment runs, so the analysis-time cluster size is the full-population size.
     # Do not narrow this to each outcome's non-null rows.
-    sizes = np.array([row["rows__count"] for row in rows], dtype=np.float64)
+    sizes = np.array([row["rows__count"] for row in cluster_rows], dtype=np.float64)
     avg_cluster_size = float(sizes.mean())
     # np.std defaults to the population stddev, matching the SQL stddev_pop this replaced.
     cv = float(sizes.std() / sizes.mean())
@@ -55,7 +77,7 @@ def calculate_cluster_stats_from_database(
     for outcome_column in outcome_columns:
         # ICC uses only clusters with values for this outcome, mirroring the per-metric
         # "outcome IS NOT NULL" filter used when each metric was queried separately.
-        counts = np.array([row[f"{outcome_column}__count"] for row in rows], dtype=np.float64)
+        counts = np.array([row[f"{outcome_column}__count"] for row in cluster_rows], dtype=np.float64)
         has_values = counts > 0
         if not has_values.any():
             raise LateValidationError(
@@ -64,8 +86,10 @@ def calculate_cluster_stats_from_database(
         try:
             icc = calculate_icc_from_sufficient_stats(
                 counts=counts[has_values],
-                sums=np.array([row[f"{outcome_column}__sum"] for row in rows], dtype=np.float64)[has_values],
-                sumsqs=np.array([row[f"{outcome_column}__sumsq"] for row in rows], dtype=np.float64)[has_values],
+                sums=np.array([row[f"{outcome_column}__sum"] for row in cluster_rows], dtype=np.float64)[has_values],
+                sumsqs=np.array([row[f"{outcome_column}__sumsq"] for row in cluster_rows], dtype=np.float64)[
+                    has_values
+                ],
             )
         except ValueError as verr:
             raise StatsPowerError.from_error(verr, outcome_column) from verr

--- a/src/xngin/apiserver/routers/power_adapters.py
+++ b/src/xngin/apiserver/routers/power_adapters.py
@@ -1,15 +1,15 @@
 """Bridges database queries with cluster power / ICC stats functions."""
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
-import pandas as pd
+import numpy as np
 from sqlalchemy import Table
 from sqlalchemy.orm import Session
 
-from xngin.apiserver.dwh.queries import get_cluster_outcome_data
+from xngin.apiserver.dwh.queries import get_cluster_sufficient_stats
 from xngin.apiserver.exceptions_common import LateValidationError
 from xngin.apiserver.routers.common_api_types import Filter
-from xngin.stats.cluster_icc import calculate_icc_from_dataframe
+from xngin.stats.cluster_icc import calculate_icc_from_sufficient_stats
 from xngin.stats.stats_errors import StatsPowerError
 
 
@@ -19,13 +19,13 @@ def calculate_cluster_stats_from_database(
     cluster_column: str,
     outcome_columns: Sequence[str],
     filters: list[Filter],
+    outcome_shifts: Mapping[str, float] | None = None,
 ) -> dict[str, dict[str, float]]:
     """
     Calculate ICC and cluster statistics for one or more metrics from a DWH table.
 
-    Fetches all metrics' outcome data in a single DWH query, then computes the stats in
-    pandas. Orchestrates DWH queries with stats calculations, keeping the stats layer
-    free of SQLAlchemy dependencies.
+    Fetches per-cluster sufficient statistics for all metrics in a single DWH query, then
+    computes the stats in pure Python: only the query touches the database session.
 
     Args:
         session: SQLAlchemy session for the DWH
@@ -33,34 +33,40 @@ def calculate_cluster_stats_from_database(
         cluster_column: Column name containing cluster IDs
         outcome_columns: Column names containing outcome values
         filters: List of filters to apply
+        outcome_shifts: Optional per-outcome constants (e.g. approximate means) subtracted
+            in SQL before summing, to keep the sums of squares numerically stable
 
     Returns:
         dict keyed by outcome column name, each value a dict with keys:
         icc, avg_cluster_size, cv
     """
-    data = get_cluster_outcome_data(session, sa_table, cluster_column, outcome_columns, filters)
-    df = pd.DataFrame(data)
+    rows = get_cluster_sufficient_stats(session, sa_table, cluster_column, outcome_columns, filters, outcome_shifts)
 
     # Cluster sizes and CV are computed over every row with a cluster key, including rows
     # whose outcome values are null: metrics are outcomes that may be filled in as the
     # experiment runs, so the analysis-time cluster size is the full-population size.
     # Do not narrow this to each outcome's non-null rows.
-    sizes = df.groupby(cluster_column).size()
+    sizes = np.array([row["rows__count"] for row in rows], dtype=np.float64)
     avg_cluster_size = float(sizes.mean())
-    # ddof=0 is the population stddev, matching the SQL stddev_pop this replaced.
-    cv = float(sizes.std(ddof=0) / sizes.mean())
+    # np.std defaults to the population stddev, matching the SQL stddev_pop this replaced.
+    cv = float(sizes.std() / sizes.mean())
 
     stats_by_outcome: dict[str, dict[str, float]] = {}
     for outcome_column in outcome_columns:
-        # ICC uses only rows with a value for this outcome, mirroring the per-metric
+        # ICC uses only clusters with values for this outcome, mirroring the per-metric
         # "outcome IS NOT NULL" filter used when each metric was queried separately.
-        outcome_df = df[[cluster_column, outcome_column]].dropna(subset=[outcome_column])
-        if outcome_df.empty:
+        counts = np.array([row[f"{outcome_column}__count"] for row in rows], dtype=np.float64)
+        has_values = counts > 0
+        if not has_values.any():
             raise LateValidationError(
                 f"No data found for cluster column '{cluster_column}' and outcome '{outcome_column}'"
             )
         try:
-            icc = calculate_icc_from_dataframe(outcome_df, cluster_column=cluster_column, outcome_column=outcome_column)
+            icc = calculate_icc_from_sufficient_stats(
+                counts=counts[has_values],
+                sums=np.array([row[f"{outcome_column}__sum"] for row in rows], dtype=np.float64)[has_values],
+                sumsqs=np.array([row[f"{outcome_column}__sumsq"] for row in rows], dtype=np.float64)[has_values],
+            )
         except ValueError as verr:
             raise StatsPowerError.from_error(verr, outcome_column) from verr
         stats_by_outcome[outcome_column] = {

--- a/src/xngin/apiserver/routers/test_power_adapters.py
+++ b/src/xngin/apiserver/routers/test_power_adapters.py
@@ -168,6 +168,23 @@ def test_batched_matches_individual_queries(clustered_dwh_session, sa_table):
         assert batched[outcome_column]["cv"] == pytest.approx(individual["cv"])
 
 
+def test_outcome_shifts_do_not_change_results(clustered_dwh_session, sa_table):
+    """Shifting outcomes by a constant in SQL leaves ICC and cluster stats unchanged."""
+    kwargs = {
+        "session": clustered_dwh_session,
+        "sa_table": sa_table,
+        "cluster_column": "cluster_moderate",
+        "outcome_columns": ["income", "converted"],
+        "filters": [],
+    }
+    unshifted = calculate_cluster_stats_from_database(**kwargs)
+    shifted = calculate_cluster_stats_from_database(**kwargs, outcome_shifts={"income": 50000.0, "converted": 0.5})
+
+    for outcome_column, stats in unshifted.items():
+        for key, value in stats.items():
+            assert shifted[outcome_column][key] == pytest.approx(value), f"{outcome_column}.{key}"
+
+
 def test_null_outcomes_dropped_per_metric_but_counted_in_cluster_sizes(clustered_dwh_session, wide_dwh_sa_table):
     """Null outcome values are dropped from ICC but still counted in cluster sizes.
 

--- a/src/xngin/apiserver/routers/test_power_adapters.py
+++ b/src/xngin/apiserver/routers/test_power_adapters.py
@@ -1,5 +1,7 @@
 """Test our shim between DWH queries and cluster ICC/power stats."""
 
+from collections.abc import Mapping, Sequence
+
 import pandas as pd
 import pytest
 from sqlalchemy import MetaData, Table, create_engine
@@ -7,10 +9,24 @@ from sqlalchemy.orm import Session
 
 from xngin.apiserver import flags
 from xngin.apiserver.conftest import get_test_uri_info
+from xngin.apiserver.dwh.queries import get_cluster_sufficient_stats
 from xngin.apiserver.routers.common_api_types import Filter
 from xngin.apiserver.routers.common_enums import Relation
-from xngin.apiserver.routers.power_adapters import calculate_cluster_stats_from_database
+from xngin.apiserver.routers.power_adapters import calculate_cluster_stats
 from xngin.stats.stats_errors import StatsPowerError
+
+
+def calculate_cluster_stats_from_database(
+    session: Session,
+    sa_table: Table,
+    cluster_column: str,
+    outcome_columns: Sequence[str],
+    filters: list[Filter],
+    outcome_shifts: Mapping[str, float] | None = None,
+) -> dict[str, dict[str, float]]:
+    """Compose the query and the pure computation, as power_check does."""
+    rows = get_cluster_sufficient_stats(session, sa_table, cluster_column, outcome_columns, filters, outcome_shifts)
+    return calculate_cluster_stats(rows, cluster_column, outcome_columns)
 
 
 @pytest.fixture(name="clustered_dwh_session", scope="module")

--- a/src/xngin/stats/cluster_icc.py
+++ b/src/xngin/stats/cluster_icc.py
@@ -5,8 +5,13 @@ These functions accept dataframes rather than database sessions, following the p
 established in analysis.py. The API layer is responsible for fetching data from the DWH.
 """
 
+from collections.abc import Sequence
+
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
+
+type _FloatArray = Sequence[float] | npt.NDArray[np.float64]
 
 
 def _icc_one_way_random_intercept(df: pd.DataFrame, *, cluster_column: str, outcome_column: str) -> float:
@@ -50,6 +55,70 @@ def _icc_one_way_random_intercept(df: pd.DataFrame, *, cluster_column: str, outc
 
     # 4. Final calculation of ICC as the ratio of between-cluster variance to total variance.
     # If MSB < MSW, the point estimate for sigma_b is 0 (prevents negative ICC)
+    var_between = max(0.0, (msb - msw) / n0)
+    var_within = msw
+    total_var = var_between + var_within
+    if total_var == 0:
+        return 0.0
+
+    return float(np.clip(var_between / total_var, 0.0, 1.0))
+
+
+def calculate_icc_from_sufficient_stats(
+    *,
+    counts: _FloatArray,
+    sums: _FloatArray,
+    sumsqs: _FloatArray,
+) -> float:
+    """
+    Calculate intraclass correlation (ICC) from per-cluster sufficient statistics.
+
+    Computes the same one-way random-effects ANOVA estimator as
+    calculate_icc_from_dataframe, but from one (count, sum, sum-of-squares) triple per
+    cluster instead of individual observations. The sums may be over values shifted by
+    any per-metric constant (ICC is shift-invariant); all three arrays must describe the
+    same non-null observations and use the same shift.
+
+    Args:
+        counts: Number of non-null observations in each cluster; all must be > 0
+        sums: Sum of the observations in each cluster
+        sumsqs: Sum of the squared observations in each cluster
+
+    Returns:
+        ICC value between 0 and 1
+
+    Raises:
+        ValueError: If there are fewer than 2 clusters or insufficient observations
+    """
+    n = np.asarray(counts, dtype=np.float64)
+    s = np.asarray(sums, dtype=np.float64)
+    q = np.asarray(sumsqs, dtype=np.float64)
+    if not (len(n) == len(s) == len(q)):
+        raise ValueError("counts, sums, and sumsqs must have the same length")
+    if np.any(n <= 0):
+        raise ValueError("counts must all be positive; drop clusters without observations")
+
+    k = len(n)
+    if k < 2:
+        raise ValueError("Need at least 2 clusters to calculate ICC")
+    n_total = float(n.sum())
+    df_b = k - 1
+    df_w = n_total - k
+    if df_w < 1:
+        raise ValueError("Insufficient within-cluster data (need N > clusters)")
+
+    # ANOVA sums of squares via the identity sum((x - mean)^2) = sum(x^2) - sum(x)^2 / n.
+    # Each term is a sum of squares, so clamp tiny negative floating-point results to 0.
+    between_terms = s**2 / n
+    ssw = max(0.0, float(q.sum() - between_terms.sum()))
+    ssb = max(0.0, float(between_terms.sum() - s.sum() ** 2 / n_total))
+    msb = ssb / df_b
+    msw = ssw / df_w
+
+    # n0 is the "effective cluster size" adjustment for unequal cluster sizes.
+    n0 = (n_total - float((n**2).sum()) / n_total) / df_b
+
+    # If MSB < MSW, the point estimate for sigma_b is 0 (prevents negative ICC).
     var_between = max(0.0, (msb - msw) / n0)
     var_within = msw
     total_var = var_between + var_within

--- a/src/xngin/stats/test_cluster_icc.py
+++ b/src/xngin/stats/test_cluster_icc.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from xngin.stats.cluster_icc import calculate_icc_from_dataframe
+from xngin.stats.cluster_icc import calculate_icc_from_dataframe, calculate_icc_from_sufficient_stats
 
 
 class TestICCFromDataFrame:
@@ -102,3 +102,92 @@ class TestICCFromDataFrame:
         icc = calculate_icc_from_dataframe(df, cluster_column="id", outcome_column="_y")
         assert 0.0 <= icc <= 1.0
         assert icc == pytest.approx(0.8571, abs=1e-4)
+
+
+def _sufficient_stats(
+    cluster_ids: np.ndarray, y: np.ndarray, shift: float = 0.0
+) -> tuple[list[float], list[float], list[float]]:
+    """Per-cluster (count, sum, sumsq) triples, as get_cluster_sufficient_stats returns them."""
+    shifted = y - shift
+    counts, sums, sumsqs = [], [], []
+    for cluster_id in np.unique(cluster_ids):
+        values = shifted[cluster_ids == cluster_id]
+        counts.append(float(len(values)))
+        sums.append(float(values.sum()))
+        sumsqs.append(float((values**2).sum()))
+    return counts, sums, sumsqs
+
+
+def test_sufficient_stats_matches_dataframe_icc():
+    """The sufficient-statistics estimator equals the per-observation one, shifted or not."""
+    rng = np.random.default_rng(7)
+    cluster_sizes = rng.integers(2, 30, size=50)
+    cluster_ids = np.repeat(np.arange(len(cluster_sizes)), cluster_sizes)
+    cluster_means = rng.normal(loc=100, scale=10, size=len(cluster_sizes))
+    y = np.repeat(cluster_means, cluster_sizes) + rng.normal(0, 20, size=len(cluster_ids))
+
+    expected = calculate_icc_from_dataframe(
+        pd.DataFrame({"id": cluster_ids, "y": y}), cluster_column="id", outcome_column="y"
+    )
+    for shift in (0.0, float(y.mean())):
+        counts, sums, sumsqs = _sufficient_stats(cluster_ids, y, shift)
+        icc = calculate_icc_from_sufficient_stats(counts=counts, sums=sums, sumsqs=sumsqs)
+        assert icc == pytest.approx(expected, rel=1e-9)
+
+
+def test_sufficient_stats_matches_dataframe_icc_binary():
+    """Equivalence also holds for 0/1 outcomes, where sumsq equals sum."""
+    rng = np.random.default_rng(11)
+    cluster_ids = np.repeat(np.arange(40), 25)
+    p_by_cluster = rng.uniform(0.2, 0.8, size=40)
+    y = (rng.uniform(size=len(cluster_ids)) < np.repeat(p_by_cluster, 25)).astype(np.float64)
+
+    expected = calculate_icc_from_dataframe(
+        pd.DataFrame({"id": cluster_ids, "y": y}), cluster_column="id", outcome_column="y"
+    )
+    counts, sums, sumsqs = _sufficient_stats(cluster_ids, y)
+    assert sumsqs == sums
+    icc = calculate_icc_from_sufficient_stats(counts=counts, sums=sums, sumsqs=sumsqs)
+    assert icc == pytest.approx(expected, rel=1e-9)
+
+
+def test_sufficient_stats_shift_restores_precision_for_large_means():
+    """Raw sums of squares lose precision when the mean dwarfs the variance; shifting fixes it."""
+    rng = np.random.default_rng(3)
+    cluster_ids = np.repeat(np.arange(30), 20)
+    y = 1e9 + np.repeat(rng.normal(0, 1, size=30), 20) + rng.normal(0, 2, size=len(cluster_ids))
+
+    expected = calculate_icc_from_dataframe(
+        pd.DataFrame({"id": cluster_ids, "y": y}), cluster_column="id", outcome_column="y"
+    )
+    counts, sums, sumsqs = _sufficient_stats(cluster_ids, y, shift=1e9)
+    icc = calculate_icc_from_sufficient_stats(counts=counts, sums=sums, sumsqs=sumsqs)
+    assert icc == pytest.approx(expected, rel=1e-6)
+
+
+def test_sufficient_stats_perfect_and_zero_clustering():
+    assert calculate_icc_from_sufficient_stats(
+        counts=[3, 3, 3],
+        sums=[30, 60, 90],  # constant within cluster: 10s, 20s, 30s
+        sumsqs=[300, 1200, 2700],
+    ) == pytest.approx(1.0)
+    assert calculate_icc_from_sufficient_stats(
+        counts=[3, 3, 3],
+        sums=[60, 60, 60],  # identical clusters: 10, 20, 30 in each
+        sumsqs=[1400, 1400, 1400],
+    ) == pytest.approx(0.0, abs=0.01)
+
+
+def test_sufficient_stats_constant_outcome_returns_zero():
+    assert calculate_icc_from_sufficient_stats(counts=[2, 2], sums=[10, 10], sumsqs=[50, 50]) == 0.0
+
+
+def test_sufficient_stats_validation_errors():
+    with pytest.raises(ValueError, match="Need at least 2 clusters"):
+        calculate_icc_from_sufficient_stats(counts=[3], sums=[30], sumsqs=[300])
+    with pytest.raises(ValueError, match="Insufficient within-cluster data"):
+        calculate_icc_from_sufficient_stats(counts=[1, 1], sums=[10, 20], sumsqs=[100, 400])
+    with pytest.raises(ValueError, match="same length"):
+        calculate_icc_from_sufficient_stats(counts=[2, 2], sums=[10], sumsqs=[50, 50])
+    with pytest.raises(ValueError, match="counts must all be positive"):
+        calculate_icc_from_sufficient_stats(counts=[2, 0], sums=[10, 0], sumsqs=[50, 0])


### PR DESCRIPTION
Implements the query/compute separation suggested in the #321 review:
code inside a `DwhSession` block only queries; computation on the results
happens after the block (and the remote connection) is closed.

**Stacked on #334** — the first two commits belong to #321/#334; only the last
commit is under review. The diff collapses to just this change once they merge.

## What changed

- `queries.py` now contains only queries. `get_stats_on_metrics` became
  `get_raw_metric_stats`, returning the raw aggregate row.
- `power_adapters.py` is now entirely session-free: `build_metric_stats` turns
  the raw row into `DesignSpecMetric` objects, and `calculate_cluster_stats`
  computes ICC/CV from the per-cluster sufficient-statistics rows.
- `power_check` fetches inside the `DwhSession` block and computes after it,
  matching the pattern from the review.

No behavior change; all existing tests pass unchanged (test files compose
query + compute through small helpers with the old signatures).