### PR TITLE
Return an MDE curve from power checks for a requested list of sample sizes

### DIFF
--- a/src/xngin/apiserver/limits.py
+++ b/src/xngin/apiserver/limits.py
@@ -40,6 +40,9 @@ MAX_NUMBER_OF_FIELDS = 150
 # Maximum number of filters we allow to define an audience.
 MAX_NUMBER_OF_FILTERS = 20
 
+# Maximum number of desired sample sizes a power check may request MDEs for in one call.
+MAX_NUMBER_OF_POWER_CURVE_POINTS = 100
+
 # Maximum length of GCP service account info JSON.
 MAX_GCP_SERVICE_ACCOUNT_LEN = 8000
 

--- a/src/xngin/apiserver/routers/admin/admin_api.py
+++ b/src/xngin/apiserver/routers/admin/admin_api.py
@@ -2248,7 +2248,13 @@ async def power_check(
     user: Annotated[tables.User, Depends(require_user_from_token)],
     body: PowerRequest,
 ) -> PowerResponse:
-    """Performs a power check for the specified datasource."""
+    """Performs a power check for the specified datasource.
+
+    Metrics carrying baseline stats (e.g. echoed back from a prior power check response) are used
+    as-is rather than re-queried from the data warehouse. When no metric needs the warehouse — every
+    metric has baseline stats, and cluster stats for cluster-randomized designs — the warehouse is
+    not contacted at all, so the design spec is not validated against the participants table.
+    """
     design_spec = body.design_spec
     ds = await get_datasource_or_raise(session, user, datasource_id)
     if isinstance(ds.config, NoDwh):
@@ -2258,62 +2264,77 @@ async def power_check(
         )
     dsconfig = ds.get_config()
 
-    async with DwhSession(dsconfig.dwh) as dwh:
-        sa_table = await dwh.inspect_table(design_spec.table_name)
-        # Validate the fields used in the design spec are present in the table and that filter values are valid.
-        _ = convert_table_to_fields_or_raise(sa_table, design_spec)
+    filters = design_spec.filters
+    cluster_key = None
+    desired_n_clusters = None
+    if isinstance(design_spec, PreassignedFrequentistExperimentSpec):
+        cluster_key = design_spec.cluster_key
+        desired_n_clusters = design_spec.desired_n_clusters
+    # Exclude rows without a valid cluster key.
+    if cluster_key is not None:
+        filters = [*filters, Filter(field_name=cluster_key, relation=Relation.EXCLUDES, value=[None])]
 
-        filters = design_spec.filters
-        cluster_key = None
-        desired_n_clusters = None
-        if isinstance(design_spec, PreassignedFrequentistExperimentSpec):
-            cluster_key = design_spec.cluster_key
-            desired_n_clusters = design_spec.desired_n_clusters
-        # Exclude rows without a valid cluster key.
-        if cluster_key is not None:
-            filters = [*filters, Filter(field_name=cluster_key, relation=Relation.EXCLUDES, value=[None])]
+    metrics_missing_stats = [m for m in design_spec.metrics if not m.has_baseline_stats]
+    needs_cluster_stats = cluster_key is not None and any(m.icc is None for m in design_spec.metrics)
 
-        metric_stats = await asyncio.to_thread(
-            get_stats_on_metrics,
-            dwh.session,
-            sa_table,
-            design_spec.metrics,
-            filters,
-        )
+    if not metrics_missing_stats and not needs_cluster_stats:
+        metric_stats = [m.to_design_spec_metric() for m in design_spec.metrics]
+    else:
+        async with DwhSession(dsconfig.dwh) as dwh:
+            sa_table = await dwh.inspect_table(design_spec.table_name)
+            # Validate the fields used in the design spec are present in the table and that filter values are valid.
+            _ = convert_table_to_fields_or_raise(sa_table, design_spec)
 
-        # Augment with cluster-level stats if this is a cluster-randomized design.
-        if cluster_key is not None:
-            request_metrics_by_name = {m.field_name: m for m in design_spec.metrics}
-            # Derive stats from the dwh only for metrics without user-provided ICC, in one query.
-            db_derived_metrics = [
-                metric_stat.field_name
-                for metric_stat in metric_stats
-                if request_metrics_by_name[metric_stat.field_name].icc is None
-            ]
-            db_cluster_stats = (
+            queried_stats = (
                 await asyncio.to_thread(
-                    calculate_cluster_stats_from_database,
+                    get_stats_on_metrics,
                     dwh.session,
                     sa_table,
-                    cluster_key,
-                    db_derived_metrics,
+                    metrics_missing_stats,
                     filters,
                 )
-                if db_derived_metrics
-                else {}
+                if metrics_missing_stats
+                else []
             )
-            for metric_stat in metric_stats:
-                req_metric = request_metrics_by_name[metric_stat.field_name]
-                # If the user provided ICC, avg_cluster_size, and cv, use them instead of deriving from the dwh.
-                if req_metric.icc is not None:
-                    metric_stat.icc = req_metric.icc
-                    metric_stat.avg_cluster_size = req_metric.avg_cluster_size
-                    metric_stat.cv = req_metric.cv
-                else:
-                    cluster_stats = db_cluster_stats[metric_stat.field_name]
-                    metric_stat.icc = cluster_stats["icc"]
-                    metric_stat.avg_cluster_size = cluster_stats["avg_cluster_size"]
-                    metric_stat.cv = cluster_stats["cv"]
+            queried_stats_by_name = {m.field_name: m for m in queried_stats}
+            metric_stats = [
+                m.to_design_spec_metric() if m.has_baseline_stats else queried_stats_by_name[m.field_name]
+                for m in design_spec.metrics
+            ]
+
+            # Augment with cluster-level stats if this is a cluster-randomized design.
+            if cluster_key is not None:
+                request_metrics_by_name = {m.field_name: m for m in design_spec.metrics}
+                # Derive stats from the dwh only for metrics without user-provided ICC, in one query.
+                db_derived_metrics = [
+                    metric_stat.field_name
+                    for metric_stat in metric_stats
+                    if request_metrics_by_name[metric_stat.field_name].icc is None
+                ]
+                db_cluster_stats = (
+                    await asyncio.to_thread(
+                        calculate_cluster_stats_from_database,
+                        dwh.session,
+                        sa_table,
+                        cluster_key,
+                        db_derived_metrics,
+                        filters,
+                    )
+                    if db_derived_metrics
+                    else {}
+                )
+                for metric_stat in metric_stats:
+                    req_metric = request_metrics_by_name[metric_stat.field_name]
+                    # If the user provided ICC, avg_cluster_size, and cv, use them instead of deriving from the dwh.
+                    if req_metric.icc is not None:
+                        metric_stat.icc = req_metric.icc
+                        metric_stat.avg_cluster_size = req_metric.avg_cluster_size
+                        metric_stat.cv = req_metric.cv
+                    else:
+                        cluster_stats = db_cluster_stats[metric_stat.field_name]
+                        metric_stat.icc = cluster_stats["icc"]
+                        metric_stat.avg_cluster_size = cluster_stats["avg_cluster_size"]
+                        metric_stat.cv = cluster_stats["cv"]
 
     arm_weights = design_spec.get_validated_arm_weights()
 

--- a/src/xngin/apiserver/routers/admin/admin_api.py
+++ b/src/xngin/apiserver/routers/admin/admin_api.py
@@ -2267,9 +2267,11 @@ async def power_check(
     filters = design_spec.filters
     cluster_key = None
     desired_n_clusters = None
+    desired_ns_clusters = None
     if isinstance(design_spec, PreassignedFrequentistExperimentSpec):
         cluster_key = design_spec.cluster_key
         desired_n_clusters = design_spec.desired_n_clusters
+        desired_ns_clusters = design_spec.desired_ns_clusters
     # Exclude rows without a valid cluster key.
     if cluster_key is not None:
         filters = [*filters, Filter(field_name=cluster_key, relation=Relation.EXCLUDES, value=[None])]
@@ -2347,6 +2349,8 @@ async def power_check(
             arm_weights=arm_weights,
             desired_n=design_spec.desired_n,
             desired_n_clusters=desired_n_clusters,
+            desired_ns=design_spec.desired_ns,
+            desired_ns_clusters=desired_ns_clusters,
         )
     )
 

--- a/src/xngin/apiserver/routers/admin/test_admin_api.py
+++ b/src/xngin/apiserver/routers/admin/test_admin_api.py
@@ -4338,6 +4338,97 @@ async def test_power_check_reuses_provided_cluster_stats_without_dwh(testing_dat
     assert reuse_analysis == first_analysis
 
 
+async def test_power_check_mde_curve(testing_datasource, aclient: AdminAPIClient):
+    """desired_ns produces an MDE-vs-sample-size curve, consistent with the single desired_n MDE."""
+    design_spec = PreassignedFrequentistExperimentSpec(
+        experiment_type=ExperimentsType.FREQ_PREASSIGNED,
+        experiment_name="test power curve",
+        description="desired_ns drives the MDE curve in power check.",
+        table_name="dwh",
+        primary_key="id",
+        start_date=datetime(2024, 1, 1, tzinfo=UTC),
+        end_date=datetime.now(UTC) + timedelta(days=1),
+        arms=[
+            Arm(arm_name="control", arm_description="Control group"),
+            Arm(arm_name="treatment", arm_description="Treatment group"),
+        ],
+        metrics=[DesignSpecMetricRequest(field_name="current_income", metric_pct_change=0.1)],
+        strata=[],
+        filters=[],
+        desired_n=500,
+        desired_ns=[2, 250, 500, 750, 1000],
+    )
+    analysis = aclient.power_check(
+        datasource_id=testing_datasource.datasource_id,
+        body=PowerRequest(design_spec=design_spec),
+    ).data.analyses[0]
+
+    assert analysis.mde_curve is not None
+    assert [p.desired_n for p in analysis.mde_curve] == [2, 250, 500, 750, 1000]
+    # n=2 is too small to solve: best-effort null, not a failed request.
+    assert analysis.mde_curve[0].pct_change is None
+    solvable = analysis.mde_curve[1:]
+    # MDE shrinks as the sample grows, and the curve agrees with the single-value MDE at n=500.
+    mdes = [p.pct_change for p in solvable if p.pct_change is not None]
+    assert len(mdes) == len(solvable)  # every remaining point solved
+    assert mdes == sorted(mdes, reverse=True)
+    assert analysis.mde_curve[2].pct_change == analysis.pct_change_with_desired_n
+
+    # The curve also works without the dwh when stats are echoed back (see the stats reuse tests).
+    reuse_spec = design_spec.model_copy(
+        update={
+            "table_name": "no_such_table",
+            "metrics": [echo_metric_request(analysis.metric_spec)],
+        }
+    )
+    reuse_analysis = aclient.power_check(
+        datasource_id=testing_datasource.datasource_id,
+        body=PowerRequest(design_spec=reuse_spec),
+    ).data.analyses[0]
+    assert reuse_analysis.mde_curve == analysis.mde_curve
+
+
+async def test_power_check_mde_curve_clusters(testing_datasource, aclient: AdminAPIClient):
+    """desired_ns_clusters produces a per-metric converted MDE curve for cluster designs."""
+    design_spec = PreassignedFrequentistExperimentSpec(
+        experiment_type=ExperimentsType.FREQ_PREASSIGNED,
+        experiment_name="test cluster power curve",
+        description="desired_ns_clusters drives the MDE curve in cluster power check.",
+        start_date=datetime(2024, 1, 1, tzinfo=UTC),
+        end_date=datetime.now(UTC) + timedelta(days=1),
+        table_name=WIDE_DWH_PARTICIPANT_DEF.table_name,
+        primary_key="id",
+        arms=[Arm(arm_name="control", arm_description="C"), Arm(arm_name="treatment", arm_description="T")],
+        metrics=[
+            DesignSpecMetricRequest(
+                field_name="household_income",
+                metric_pct_change=0.1,
+                icc=0.015,
+                avg_cluster_size=10,
+                cv=0.1,
+            )
+        ],
+        strata=[],
+        filters=[],
+        cluster_key="age",
+        desired_n_clusters=40,
+        desired_ns_clusters=[20, 40, 80],
+    )
+    analysis = aclient.power_check(
+        datasource_id=testing_datasource.datasource_id,
+        body=PowerRequest(design_spec=design_spec),
+    ).data.analyses[0]
+
+    assert analysis.mde_curve is not None
+    assert [p.desired_n_clusters for p in analysis.mde_curve] == [20, 40, 80]
+    assert [p.desired_n for p in analysis.mde_curve] == [200, 400, 800]
+    mdes = [p.pct_change for p in analysis.mde_curve if p.pct_change is not None]
+    assert len(mdes) == len(analysis.mde_curve)  # every point solved
+    assert mdes == sorted(mdes, reverse=True)
+    # The curve point at 40 clusters agrees with the single desired_n_clusters MDE.
+    assert analysis.mde_curve[1].pct_change == analysis.pct_change_with_desired_n
+
+
 async def test_power_check_with_db_derived_icc_and_nulls_in_cluster_key(testing_datasource, aclient: AdminAPIClient):
     """DB-derived ICC excludes rows with a null cluster key, and available_n is consistent.
 

--- a/src/xngin/apiserver/routers/admin/test_admin_api.py
+++ b/src/xngin/apiserver/routers/admin/test_admin_api.py
@@ -62,6 +62,7 @@ from xngin.apiserver.routers.common_api_types import (
     CreateExperimentRequest,
     CreateExperimentResponse,
     DataType,
+    DesignSpecMetric,
     DesignSpecMetricRequest,
     ExperimentConfig,
     ExperimentsType,
@@ -4191,6 +4192,150 @@ async def test_power_check_with_desired_n_clusters(testing_datasource, aclient: 
     )
     both_analysis = both_result.data.analyses[0]
     assert both_analysis.pct_change_with_desired_n == clusters_analysis.pct_change_with_desired_n
+
+
+def echo_metric_request(spec: DesignSpecMetric) -> DesignSpecMetricRequest:
+    """Builds a follow-up power check metric from a prior response's metric_spec, as the frontend would."""
+    return DesignSpecMetricRequest(
+        field_name=spec.field_name,
+        metric_pct_change=spec.metric_pct_change,
+        icc=spec.icc,
+        avg_cluster_size=spec.avg_cluster_size,
+        cv=spec.cv,
+        metric_type=spec.metric_type,
+        metric_baseline=spec.metric_baseline,
+        metric_stddev=spec.metric_stddev,
+        available_nonnull_n=spec.available_nonnull_n,
+        available_n=spec.available_n,
+    )
+
+
+async def test_power_check_reuses_provided_baseline_stats_without_dwh(testing_datasource, aclient: AdminAPIClient):
+    """Metrics carrying baseline stats are analyzed without querying the dwh at all."""
+    design_spec = PreassignedFrequentistExperimentSpec(
+        experiment_type=ExperimentsType.FREQ_PREASSIGNED,
+        experiment_name="test power check stats reuse",
+        description="Baseline stats from a prior response are reused instead of re-queried.",
+        table_name="dwh",
+        primary_key="id",
+        start_date=datetime(2024, 1, 1, tzinfo=UTC),
+        end_date=datetime.now(UTC) + timedelta(days=1),
+        arms=[
+            Arm(arm_name="control", arm_description="Control group"),
+            Arm(arm_name="treatment", arm_description="Treatment group"),
+        ],
+        metrics=[DesignSpecMetricRequest(field_name="current_income", metric_pct_change=0.1)],
+        strata=[],
+        filters=[],
+        desired_n=500,
+    )
+    first_analysis = aclient.power_check(
+        datasource_id=testing_datasource.datasource_id,
+        body=PowerRequest(design_spec=design_spec),
+    ).data.analyses[0]
+    assert first_analysis.metric_spec.metric_baseline is not None
+
+    # Echo the returned stats back. The bogus table name proves the dwh is not contacted:
+    # inspecting it would fail.
+    reuse_spec = design_spec.model_copy(
+        update={
+            "table_name": "no_such_table",
+            "metrics": [echo_metric_request(first_analysis.metric_spec)],
+        }
+    )
+    reuse_analysis = aclient.power_check(
+        datasource_id=testing_datasource.datasource_id,
+        body=PowerRequest(design_spec=reuse_spec),
+    ).data.analyses[0]
+    assert reuse_analysis == first_analysis
+
+
+async def test_power_check_queries_only_metrics_missing_baseline_stats(testing_datasource, aclient: AdminAPIClient):
+    """Metrics with and without provided baseline stats can be mixed in one power check."""
+
+    def make_design_spec(metrics: list[DesignSpecMetricRequest]) -> PreassignedFrequentistExperimentSpec:
+        return PreassignedFrequentistExperimentSpec(
+            experiment_type=ExperimentsType.FREQ_PREASSIGNED,
+            experiment_name="test power check partial stats reuse",
+            description="Only metrics without provided baseline stats are queried from the dwh.",
+            table_name="dwh",
+            primary_key="id",
+            start_date=datetime(2024, 1, 1, tzinfo=UTC),
+            end_date=datetime.now(UTC) + timedelta(days=1),
+            arms=[
+                Arm(arm_name="control", arm_description="Control group"),
+                Arm(arm_name="treatment", arm_description="Treatment group"),
+            ],
+            metrics=metrics,
+            strata=[],
+            filters=[],
+        )
+
+    both_queried = aclient.power_check(
+        datasource_id=testing_datasource.datasource_id,
+        body=PowerRequest(
+            design_spec=make_design_spec([
+                DesignSpecMetricRequest(field_name="current_income", metric_pct_change=0.1),
+                DesignSpecMetricRequest(field_name="is_engaged", metric_pct_change=0.1),
+            ])
+        ),
+    ).data.analyses
+
+    # Re-issue with stats provided for one metric only; results must match the fully queried run.
+    mixed = aclient.power_check(
+        datasource_id=testing_datasource.datasource_id,
+        body=PowerRequest(
+            design_spec=make_design_spec([
+                echo_metric_request(both_queried[0].metric_spec),
+                DesignSpecMetricRequest(field_name="is_engaged", metric_pct_change=0.1),
+            ])
+        ),
+    ).data.analyses
+    assert mixed == both_queried
+
+
+async def test_power_check_reuses_provided_cluster_stats_without_dwh(testing_datasource, aclient: AdminAPIClient):
+    """A cluster design with baseline stats and ICC provided for every metric skips the dwh."""
+    design_spec = PreassignedFrequentistExperimentSpec(
+        experiment_type=ExperimentsType.FREQ_PREASSIGNED,
+        experiment_name="test cluster power stats reuse",
+        description="Cluster power check with fully provided stats skips the dwh.",
+        start_date=datetime(2024, 1, 1, tzinfo=UTC),
+        end_date=datetime.now(UTC) + timedelta(days=1),
+        table_name=WIDE_DWH_PARTICIPANT_DEF.table_name,
+        primary_key="id",
+        arms=[Arm(arm_name="control", arm_description="C"), Arm(arm_name="treatment", arm_description="T")],
+        metrics=[
+            DesignSpecMetricRequest(
+                field_name="household_income",
+                metric_pct_change=0.1,
+                icc=0.015,
+                avg_cluster_size=10,
+                cv=0.1,
+            )
+        ],
+        strata=[],
+        filters=[],
+        cluster_key="age",
+        desired_n_clusters=40,
+    )
+    first_analysis = aclient.power_check(
+        datasource_id=testing_datasource.datasource_id,
+        body=PowerRequest(design_spec=design_spec),
+    ).data.analyses[0]
+    assert first_analysis.pct_change_with_desired_n is not None
+
+    reuse_spec = design_spec.model_copy(
+        update={
+            "table_name": "no_such_table",
+            "metrics": [echo_metric_request(first_analysis.metric_spec)],
+        }
+    )
+    reuse_analysis = aclient.power_check(
+        datasource_id=testing_datasource.datasource_id,
+        body=PowerRequest(design_spec=reuse_spec),
+    ).data.analyses[0]
+    assert reuse_analysis == first_analysis
 
 
 async def test_power_check_with_db_derived_icc_and_nulls_in_cluster_key(testing_datasource, aclient: AdminAPIClient):

--- a/src/xngin/apiserver/routers/common_api_types.py
+++ b/src/xngin/apiserver/routers/common_api_types.py
@@ -147,10 +147,12 @@ class DesignSpecMetric(DesignSpecMetricBase):
 
 
 class DesignSpecMetricRequest(DesignSpecMetricBase):
-    """Defines a request to look up baseline stats for a metric to measure in an experiment."""
+    """Defines a request to look up baseline stats for a metric to measure in an experiment.
 
-    # TODO: consider supporting {metric_baseline, metric_stddev, available_n} as inputs when the metric may not exist or
-    # be usable yet in the dwh, so that it it can be used as a general power/sizing calculator.
+    Baseline stats may optionally be supplied (e.g. echoed back from a prior power check's
+    `MetricPowerAnalysis.metric_spec`), in which case the server reuses them instead of
+    re-querying the data warehouse.
+    """
 
     # Override the descriptions from above:
     metric_pct_change: Annotated[
@@ -168,6 +170,33 @@ class DesignSpecMetricRequest(DesignSpecMetricBase):
         ),
     ] = None
 
+    # Optional baseline stats, mirroring the fields of DesignSpecMetric. When all are provided
+    # (metric_stddev only for NUMERIC metrics), the server skips the dwh stats query for this metric.
+    metric_type: Annotated[
+        MetricType | None,
+        Field(description="Type of the metric. Set together with the other baseline stats to reuse them."),
+    ] = None
+    metric_baseline: Annotated[
+        float | None,
+        Field(description="Mean of the tracked metric, e.g. from a prior power check response."),
+    ] = None
+    metric_stddev: Annotated[
+        float | None,
+        Field(description="Standard deviation of the tracked metric. Only valid for MetricType.NUMERIC metrics."),
+    ] = None
+    available_nonnull_n: Annotated[
+        int | None,
+        Field(
+            description=(
+                "The number of participants who meet the filtering criteria and have a non-null value for this metric."
+            )
+        ),
+    ] = None
+    available_n: Annotated[
+        int | None,
+        Field(description="The number of participants who meet the filtering criteria."),
+    ] = None
+
     @model_validator(mode="after")
     def check_has_only_one_of_pct_change_or_target(self) -> Self:
         if self.metric_pct_change is not None and self.metric_target is not None:
@@ -175,6 +204,41 @@ class DesignSpecMetricRequest(DesignSpecMetricBase):
         if self.metric_pct_change is None and self.metric_target is None:
             raise ValueError("Must set one of metric_pct_change or metric_target")
         return self
+
+    @model_validator(mode="after")
+    def check_baseline_stats(self) -> Self:
+        """Enforce that baseline stats are either all set or all unset, so that a power calculation
+        never mixes supplied stats with dwh-derived ones for the same metric."""
+        stats_fields = (self.metric_type, self.metric_baseline, self.available_nonnull_n, self.available_n)
+        if any(f is not None for f in stats_fields) and any(f is None for f in stats_fields):
+            raise ValueError(
+                "metric_type, metric_baseline, available_nonnull_n, and available_n must all be set "
+                "together or all be None"
+            )
+        if self.metric_stddev is not None and self.metric_type is not MetricType.NUMERIC:
+            raise ValueError("metric_stddev may only be set for NUMERIC metrics")
+        return self
+
+    @property
+    def has_baseline_stats(self) -> bool:
+        """True when this request carries the baseline stats needed to skip the dwh stats query."""
+        return self.metric_baseline is not None
+
+    def to_design_spec_metric(self) -> DesignSpecMetric:
+        """Converts a request carrying baseline stats into the equivalent dwh-derived metric."""
+        return DesignSpecMetric(
+            field_name=self.field_name,
+            metric_pct_change=self.metric_pct_change,
+            metric_target=self.metric_target,
+            icc=self.icc,
+            avg_cluster_size=self.avg_cluster_size,
+            cv=self.cv,
+            metric_type=self.metric_type,
+            metric_baseline=self.metric_baseline,
+            metric_stddev=self.metric_stddev,
+            available_nonnull_n=self.available_nonnull_n,
+            available_n=self.available_n,
+        )
 
 
 class ParticipantProperty(ApiBaseModel):

--- a/src/xngin/apiserver/routers/common_api_types.py
+++ b/src/xngin/apiserver/routers/common_api_types.py
@@ -94,18 +94,8 @@ class DesignSpecMetricBase(ApiBaseModel):
         Field(description="Coefficient of variation in cluster sizes (0 = equal sizes)."),
     ] = None
 
-    @model_validator(mode="after")
-    def cluster_fields_check(self) -> Self:
-        """Enforce that cluster fields are either all set or all unset."""
-        cluster_fields = (self.icc, self.avg_cluster_size, self.cv)
-        if any(f is not None for f in cluster_fields) and any(f is None for f in cluster_fields):
-            raise ValueError("icc, avg_cluster_size, and cv must all be set together or all be None")
-        return self
-
-
-class DesignSpecMetric(DesignSpecMetricBase):
-    """Defines a metric to measure in an experiment with its baseline stats."""
-
+    # Baseline stats. On responses (DesignSpecMetric) the server fills these in from the dwh; on
+    # requests (DesignSpecMetricRequest) they may be supplied to reuse stats from a prior response.
     metric_type: Annotated[MetricType | None, Field(description="Inferred from the data warehouse column type.")] = None
     metric_baseline: Annotated[float | None, Field(description="Mean of the tracked metric.")] = None
     metric_stddev: Annotated[
@@ -138,6 +128,18 @@ class DesignSpecMetric(DesignSpecMetricBase):
     ] = None
 
     @model_validator(mode="after")
+    def cluster_fields_check(self) -> Self:
+        """Enforce that cluster fields are either all set or all unset."""
+        cluster_fields = (self.icc, self.avg_cluster_size, self.cv)
+        if any(f is not None for f in cluster_fields) and any(f is None for f in cluster_fields):
+            raise ValueError("icc, avg_cluster_size, and cv must all be set together or all be None")
+        return self
+
+
+class DesignSpecMetric(DesignSpecMetricBase):
+    """Defines a metric to measure in an experiment with its baseline stats."""
+
+    @model_validator(mode="after")
     def stddev_check(self):
         """Enforce that metric_stddev is empty for non-NUMERICs. The frontend handles numerics without a
         stddev (the all-null case)."""
@@ -168,33 +170,6 @@ class DesignSpecMetricRequest(DesignSpecMetricBase):
             description="The absolute value you want to be able to detect. Cannot be set together with "
             "metric_pct_change."
         ),
-    ] = None
-
-    # Optional baseline stats, mirroring the fields of DesignSpecMetric. When all are provided
-    # (metric_stddev only for NUMERIC metrics), the server skips the dwh stats query for this metric.
-    metric_type: Annotated[
-        MetricType | None,
-        Field(description="Type of the metric. Set together with the other baseline stats to reuse them."),
-    ] = None
-    metric_baseline: Annotated[
-        float | None,
-        Field(description="Mean of the tracked metric, e.g. from a prior power check response."),
-    ] = None
-    metric_stddev: Annotated[
-        float | None,
-        Field(description="Standard deviation of the tracked metric. Only valid for MetricType.NUMERIC metrics."),
-    ] = None
-    available_nonnull_n: Annotated[
-        int | None,
-        Field(
-            description=(
-                "The number of participants who meet the filtering criteria and have a non-null value for this metric."
-            )
-        ),
-    ] = None
-    available_n: Annotated[
-        int | None,
-        Field(description="The number of participants who meet the filtering criteria."),
     ] = None
 
     @model_validator(mode="after")

--- a/src/xngin/apiserver/routers/common_api_types.py
+++ b/src/xngin/apiserver/routers/common_api_types.py
@@ -32,6 +32,7 @@ from xngin.apiserver.limits import (
     MAX_NUMBER_OF_CONTEXTS,
     MAX_NUMBER_OF_FIELDS,
     MAX_NUMBER_OF_FILTERS,
+    MAX_NUMBER_OF_POWER_CURVE_POINTS,
 )
 from xngin.apiserver.routers.common_enums import (
     ContextType,
@@ -639,6 +640,33 @@ class MetricPowerAnalysisMessage(ApiBaseModel):
     high_cluster_variation: bool = False
 
 
+class MdeCurvePoint(ApiBaseModel):
+    """One point of an MDE-vs-sample-size power curve."""
+
+    desired_n: Annotated[
+        int,
+        Field(
+            description=(
+                "Sample size in individual participants used for this point. For cluster-randomized "
+                "designs this is desired_n_clusters times the metric's avg_cluster_size."
+            )
+        ),
+    ]
+    desired_n_clusters: Annotated[
+        int | None,
+        Field(description="The requested number of clusters for this point. None for individual-randomized requests."),
+    ] = None
+    pct_change: Annotated[
+        float | None,
+        Field(
+            description=(
+                "The minimum detectable effect (MDE) at this sample size, as a percent change relative to "
+                "metric_baseline. None when the power calculation fails at this size (e.g. too small to solve)."
+            )
+        ),
+    ] = None
+
+
 class MetricPowerAnalysis(ApiBaseModel):
     """Describes analysis results of a single metric."""
 
@@ -686,6 +714,18 @@ class MetricPowerAnalysis(ApiBaseModel):
                 "confidence and power. Present only when design_spec.desired_n or design_spec.desired_n_clusters "
                 "is set (frequentist design specs). When desired_n_clusters is set, the desired sample size is "
                 "desired_n_clusters times this metric's avg_cluster_size."
+            )
+        ),
+    ] = None
+
+    mde_curve: Annotated[
+        list[MdeCurvePoint] | None,
+        Field(
+            description=(
+                "The MDE for each requested sample size, in the same order as design_spec.desired_ns "
+                "(or desired_ns_clusters, which takes precedence). Present only when one of those is set. "
+                "Each point is computed best-effort: a size where the calculation fails yields a null "
+                "pct_change instead of failing the request."
             )
         ),
     ] = None
@@ -955,6 +995,18 @@ class BaseFrequentistDesignSpec(BaseDesignSpec):
         ),
     ] = None
 
+    desired_ns: Annotated[
+        list[Annotated[int, Field(ge=1)]] | None,
+        Field(
+            default=None,
+            max_length=MAX_NUMBER_OF_POWER_CURVE_POINTS,
+            description="Optional list of desired individual participant sample sizes. The power check returns "
+            "the minimum detectable effect for each size (MetricPowerAnalysis.mde_curve), letting clients plot "
+            "an MDE-vs-sample-size power curve from a single request. Superseded by desired_ns_clusters when "
+            "both are set. Ignored when creating an experiment.",
+        ),
+    ] = None
+
     # stat parameters
     power: Annotated[
         float,
@@ -1163,6 +1215,19 @@ class PreassignedFrequentistExperimentSpec(BaseFrequentistDesignSpec):
             ),
         ),
     ] = None
+    desired_ns_clusters: Annotated[
+        list[Annotated[int, Field(ge=1)]] | None,
+        Field(
+            default=None,
+            max_length=MAX_NUMBER_OF_POWER_CURVE_POINTS,
+            description=(
+                "Optional list of desired cluster counts. Only valid when cluster_key is set. The power check "
+                "returns the minimum detectable effect for each count (MetricPowerAnalysis.mde_curve), converted "
+                "to a per-metric sample size using each metric's avg_cluster_size; takes precedence over "
+                "desired_ns. Ignored when creating an experiment."
+            ),
+        ),
+    ] = None
 
     @model_validator(mode="after")
     def validate_cluster_randomization(self) -> Self:
@@ -1170,6 +1235,8 @@ class PreassignedFrequentistExperimentSpec(BaseFrequentistDesignSpec):
             raise ValueError("Cluster-randomized frequentist designs cannot also set strata.")
         if self.cluster_key is None and self.desired_n_clusters is not None:
             raise ValueError("desired_n_clusters can only be set when cluster_key is set.")
+        if self.cluster_key is None and self.desired_ns_clusters is not None:
+            raise ValueError("desired_ns_clusters can only be set when cluster_key is set.")
         return self
 
 

--- a/src/xngin/apiserver/routers/test_common_api_types.py
+++ b/src/xngin/apiserver/routers/test_common_api_types.py
@@ -403,3 +403,26 @@ def test_design_spec_metric_request_to_design_spec_metric():
         available_nonnull_n=900,
         available_n=1000,
     )
+
+
+def test_desired_ns_clusters_requires_cluster_key():
+    invalid_spec = {
+        "experiment_type": "freq_preassigned",
+        "experiment_name": "test",
+        "description": "test",
+        "table_name": "dwh",
+        "primary_key": "id",
+        "start_date": "2024-01-01T00:00:00+00:00",
+        "end_date": "2024-12-31T00:00:00+00:00",
+        "arms": [
+            {"arm_name": "C", "arm_description": "C"},
+            {"arm_name": "T", "arm_description": "T"},
+        ],
+        "strata": [],
+        "metrics": [{"field_name": "metric1", "metric_pct_change": 0.1}],
+        "filters": [],
+        "desired_ns_clusters": [10, 20],
+    }
+
+    with pytest.raises(ValidationError, match="desired_ns_clusters can only be set when cluster_key is set"):
+        PreassignedFrequentistExperimentSpec.model_validate(invalid_spec)

--- a/src/xngin/apiserver/routers/test_common_api_types.py
+++ b/src/xngin/apiserver/routers/test_common_api_types.py
@@ -3,13 +3,15 @@ from pydantic import ValidationError
 
 from xngin.apiserver.routers.common_api_types import (
     CreateExperimentRequest,
+    DesignSpecMetric,
+    DesignSpecMetricRequest,
     Filter,
     MABDwhExperimentSpec,
     PreassignedFrequentistExperimentSpec,
     SampleCall,
     SampleCalls,
 )
-from xngin.apiserver.routers.common_enums import Relation
+from xngin.apiserver.routers.common_enums import MetricType, Relation
 
 VALID_COLUMN_NAMES = [
     "column_name",
@@ -334,3 +336,70 @@ def test_sample_calls_labels_must_be_unique():
     # Duplicate labels are rejected (the FE keys its rendered list on them).
     with pytest.raises(ValidationError, match="calls must have unique labels"):
         SampleCalls(calls=[call("Get assignment"), call("Get assignment")])
+
+
+def test_design_spec_metric_request_baseline_stats_all_or_none():
+    # No baseline stats is valid.
+    no_stats = DesignSpecMetricRequest(field_name="metric1", metric_pct_change=0.1)
+    assert no_stats.has_baseline_stats is False
+
+    # All baseline stats together is valid.
+    full_stats = DesignSpecMetricRequest(
+        field_name="metric1",
+        metric_pct_change=0.1,
+        metric_type=MetricType.NUMERIC,
+        metric_baseline=100.0,
+        metric_stddev=15.0,
+        available_nonnull_n=900,
+        available_n=1000,
+    )
+    assert full_stats.has_baseline_stats is True
+
+    # A partial set of baseline stats is rejected.
+    with pytest.raises(ValidationError, match="must all be set together"):
+        DesignSpecMetricRequest(
+            field_name="metric1",
+            metric_pct_change=0.1,
+            metric_baseline=100.0,
+        )
+
+
+def test_design_spec_metric_request_stddev_requires_numeric():
+    with pytest.raises(ValidationError, match="metric_stddev may only be set for NUMERIC metrics"):
+        DesignSpecMetricRequest(
+            field_name="metric1",
+            metric_pct_change=0.1,
+            metric_type=MetricType.BINARY,
+            metric_baseline=0.4,
+            metric_stddev=0.2,
+            available_nonnull_n=900,
+            available_n=1000,
+        )
+
+
+def test_design_spec_metric_request_to_design_spec_metric():
+    request = DesignSpecMetricRequest(
+        field_name="metric1",
+        metric_pct_change=0.1,
+        icc=0.05,
+        avg_cluster_size=20.0,
+        cv=0.3,
+        metric_type=MetricType.NUMERIC,
+        metric_baseline=100.0,
+        metric_stddev=15.0,
+        available_nonnull_n=900,
+        available_n=1000,
+    )
+    metric = request.to_design_spec_metric()
+    assert metric == DesignSpecMetric(
+        field_name="metric1",
+        metric_pct_change=0.1,
+        icc=0.05,
+        avg_cluster_size=20.0,
+        cv=0.3,
+        metric_type=MetricType.NUMERIC,
+        metric_baseline=100.0,
+        metric_stddev=15.0,
+        available_nonnull_n=900,
+        available_n=1000,
+    )

--- a/src/xngin/stats/power.py
+++ b/src/xngin/stats/power.py
@@ -1,5 +1,6 @@
 from xngin.apiserver.routers.common_api_types import (
     DesignSpecMetric,
+    MdeCurvePoint,
     MetricPowerAnalysis,
 )
 from xngin.apiserver.routers.common_enums import MetricPowerAnalysisMessageType, MetricType
@@ -100,6 +101,54 @@ def analyze_metric_power(
     )
 
 
+def _mde_curve_for_metric(
+    metric: DesignSpecMetric,
+    *,
+    n_arms: int,
+    arm_weights: list[float] | None,
+    desired_ns: list[int] | None,
+    desired_ns_clusters: list[int] | None,
+    power: float,
+    alpha: float,
+) -> list[MdeCurvePoint] | None:
+    """Computes the MDE for each requested sample size, best-effort per point.
+
+    desired_ns_clusters takes precedence over desired_ns and requires the metric to have
+    avg_cluster_size. A size where the calculation fails yields a null pct_change so that a
+    single bad point (typically one too small to solve) does not fail the whole curve.
+    """
+    if desired_ns_clusters is not None:
+        if metric.avg_cluster_size is None:
+            raise StatsPowerError(
+                f"desired_ns_clusters requires cluster statistics, but metric {metric.field_name} "
+                "has no avg_cluster_size."
+            )
+        sizes: list[tuple[int | None, int]] = [
+            (clusters, round(clusters * metric.avg_cluster_size)) for clusters in desired_ns_clusters
+        ]
+    elif desired_ns is not None:
+        sizes = [(None, n) for n in desired_ns]
+    else:
+        return None
+
+    curve = []
+    for clusters, n in sizes:
+        try:
+            point_analysis = analyze_metric_power(
+                metric=metric,
+                n_arms=n_arms,
+                arm_weights=arm_weights,
+                desired_n=n,
+                power=power,
+                alpha=alpha,
+            )
+            pct_change = point_analysis.pct_change_possible
+        except StatsPowerError, ZeroDivisionError, ValueError:
+            pct_change = None
+        curve.append(MdeCurvePoint(desired_n=n, desired_n_clusters=clusters, pct_change=pct_change))
+    return curve
+
+
 def check_power(
     metrics: list[DesignSpecMetric],
     *,
@@ -107,6 +156,8 @@ def check_power(
     arm_weights: list[float] | None = None,
     desired_n: int | None = None,
     desired_n_clusters: int | None = None,
+    desired_ns: list[int] | None = None,
+    desired_ns_clusters: list[int] | None = None,
     power: float = 0.8,
     alpha: float = 0.05,
 ) -> list[MetricPowerAnalysis]:
@@ -127,6 +178,11 @@ def check_power(
         desired_n_clusters: Optional desired number of clusters for cluster-randomized designs.
             Converted to a per-metric desired sample size using each metric's avg_cluster_size.
             Takes precedence over desired_n. Every metric must have avg_cluster_size set.
+        desired_ns: Optional list of desired sample sizes. The MDE for each is returned in each
+            analysis's mde_curve, best-effort per point (a size that fails to solve yields a null
+            pct_change).
+        desired_ns_clusters: Optional list of desired cluster counts, converted per metric like
+            desired_n_clusters. Takes precedence over desired_ns.
 
     Returns:
         List of `MetricPowerAnalysis` results, one item per metric in the same order as the input `metrics`.
@@ -170,6 +226,16 @@ def check_power(
                 # power_analysis_error().
                 if mde_analysis.pct_change_possible is not None:
                     analysis.pct_change_with_desired_n = mde_analysis.pct_change_possible
+
+            analysis.mde_curve = _mde_curve_for_metric(
+                metric,
+                n_arms=n_arms,
+                arm_weights=arm_weights,
+                desired_ns=desired_ns,
+                desired_ns_clusters=desired_ns_clusters,
+                power=power,
+                alpha=alpha,
+            )
 
             analyses.append(analysis)
 

--- a/src/xngin/stats/test_power.py
+++ b/src/xngin/stats/test_power.py
@@ -662,3 +662,72 @@ def test_analyze_metric_power_desired_n_with_unbalanced_arms():
     assert metric.metric_baseline is not None
     assert result.target_possible is not None
     assert result.target_possible < metric.metric_baseline
+
+
+def make_curve_metric(**overrides):
+    defaults = dict(
+        field_name="curve_metric",
+        metric_type=MetricType.NUMERIC,
+        metric_baseline=100,
+        metric_pct_change=0.1,
+        metric_stddev=20,
+        available_nonnull_n=1000,
+        available_n=1000,
+    )
+    return DesignSpecMetric(**{**defaults, **overrides})
+
+
+def test_check_power_mde_curve_individual():
+    sizes = [100, 200, 500, 1000]
+    analyses = check_power([make_curve_metric()], n_arms=2, desired_ns=sizes)
+
+    curve = analyses[0].mde_curve
+    assert curve is not None
+    assert [p.desired_n for p in curve] == sizes
+    assert all(p.desired_n_clusters is None for p in curve)
+    mdes = [p.pct_change for p in curve if p.pct_change is not None]
+    assert len(mdes) == len(curve)  # every point solved
+    assert all(m > 0 for m in mdes)
+    # MDE shrinks as the sample grows.
+    assert mdes == sorted(mdes, reverse=True)
+
+    # A curve point at the single desired_n matches pct_change_with_desired_n.
+    single = check_power([make_curve_metric()], n_arms=2, desired_n=500)
+    point_500 = next(p for p in curve if p.desired_n == 500)
+    assert single[0].pct_change_with_desired_n == point_500.pct_change
+
+
+def test_check_power_mde_curve_cluster():
+    metric = make_curve_metric(icc=0.02, avg_cluster_size=10, cv=0.1)
+    analyses = check_power([metric], n_arms=2, desired_ns_clusters=[20, 50, 100])
+
+    curve = analyses[0].mde_curve
+    assert curve is not None
+    assert [p.desired_n_clusters for p in curve] == [20, 50, 100]
+    # Cluster counts convert to individuals via avg_cluster_size.
+    assert [p.desired_n for p in curve] == [200, 500, 1000]
+    mdes = [p.pct_change for p in curve if p.pct_change is not None]
+    assert len(mdes) == len(curve)  # every point solved
+    assert all(m > 0 for m in mdes)
+    assert mdes == sorted(mdes, reverse=True)
+
+
+def test_check_power_mde_curve_cluster_counts_require_cluster_stats():
+    with pytest.raises(StatsPowerError, match="has no avg_cluster_size"):
+        check_power([make_curve_metric()], n_arms=2, desired_ns_clusters=[20, 50])
+
+
+def test_check_power_mde_curve_point_failure_yields_null_not_error():
+    # n=2 is too small for the solver; the point should be null while the others succeed.
+    analyses = check_power([make_curve_metric()], n_arms=2, desired_ns=[2, 500])
+
+    curve = analyses[0].mde_curve
+    assert curve is not None
+    assert [p.desired_n for p in curve] == [2, 500]
+    assert curve[0].pct_change is None
+    assert curve[1].pct_change is not None
+
+
+def test_check_power_no_curve_without_desired_ns():
+    analyses = check_power([make_curve_metric()], n_arms=2, desired_n=500)
+    assert analyses[0].mde_curve is None


### PR DESCRIPTION
Power checks can now return a full MDE-vs-sample-size curve in a single request. The design
spec accepts an optional list of desired sample sizes (or cluster counts), and the response
includes the minimum detectable effect for each one, so the frontend can plot how detectable
effect improves as the sample grows — without issuing one request per point or re-querying
the data warehouse.

**Stacked on #327** — the first two commits belong to that PR; only the last commit is under
review here. The diff collapses once #327 merges.

## API change

- `desired_ns` (frequentist design specs) and `desired_ns_clusters` (preassigned specs, takes
  precedence, requires `cluster_key`): optional lists of desired sample sizes / cluster counts,
  each entry ≥ 1, at most 100 entries.
- `MetricPowerAnalysis.mde_curve`: one `MdeCurvePoint {desired_n, desired_n_clusters,
  pct_change}` per requested size, in request order. Cluster counts convert per metric via
  `avg_cluster_size`, exactly like the single `desired_n_clusters` (#322).

## Behavior

- Each point is computed best-effort: a size the solver can't handle (e.g. too small) yields a
  null `pct_change`; the request never fails on a single point.
- The point list is caller-defined, so point count and spacing are entirely FE choices — no API
  change needed to tune the chart later.
- Combined with #327's stats reuse, a follow-up curve request with echoed stats computes all
  points with **zero** dwh queries (covered by a test that proves it with a nonexistent table
  name).

## Tests

Stats-level (ordering, per-metric cluster conversion, null-on-failure, consistency with the
single-value `pct_change_with_desired_n`), model validation (`desired_ns_clusters` requires
`cluster_key`), and endpoint-level for both individual and cluster designs.

## Follow-up (FE)

Chart in the experiment wizard: 10 points spaced uniformly in MDE (√-spacing) from the minimum
sample size across `available_n`, threshold lines at min and available n.